### PR TITLE
(chore) migrate to JReleaser for Maven Central publishing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,120 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in PCRE4J
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the information below to help us diagnose the issue.
+
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Backend
+      description: Which PCRE4J backend are you using?
+      options:
+        - JNA (org.pcre4j.jna)
+        - FFM (org.pcre4j.ffm)
+        - Both
+        - Unknown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: api-level
+    attributes:
+      label: API Level
+      description: Which API are you using?
+      options:
+        - regex (java.util.regex-compatible)
+        - lib (Pcre2Code, Pcre2MatchData)
+        - api (IPcre2 direct)
+    validations:
+      required: true
+
+  - type: input
+    id: java-version
+    attributes:
+      label: Java Version
+      description: Output of `java -version`
+      placeholder: "e.g., OpenJDK 21.0.1"
+    validations:
+      required: true
+
+  - type: input
+    id: pcre2-version
+    attributes:
+      label: PCRE2 Library Version
+      description: Version of the native PCRE2 library installed on your system
+      placeholder: "e.g., 10.42"
+    validations:
+      required: false
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: Your OS and version
+      placeholder: "e.g., Ubuntu 24.04, macOS 14.2, Windows 11"
+    validations:
+      required: true
+
+  - type: input
+    id: pcre4j-version
+    attributes:
+      label: PCRE4J Version
+      description: Version of PCRE4J you are using
+      placeholder: "e.g., 0.4.3"
+    validations:
+      required: true
+
+  - type: textarea
+    id: pattern
+    attributes:
+      label: Regex Pattern
+      description: The regular expression pattern
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: input
+    attributes:
+      label: Input String
+      description: The input string being matched (if applicable)
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: code
+    attributes:
+      label: Code to Reproduce
+      description: Minimal code example that reproduces the issue
+      render: java
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened (include stack traces if applicable)
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other information that might help diagnose the issue
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: PCRE2 Documentation
+    url: https://www.pcre.org/current/doc/html/
+    about: Official PCRE2 library documentation
+  - name: JavaDoc
+    url: https://javadoc.io/doc/org.pcre4j
+    about: PCRE4J API documentation

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for PCRE4J
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe your idea below.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Use Case
+      description: What problem are you trying to solve? What's your use case?
+      placeholder: "I'm trying to... but currently..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe your proposed solution or feature
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What alternative solutions or workarounds have you considered?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Affected Area
+      description: Which part of PCRE4J does this affect?
+      options:
+        - api (IPcre2 interface)
+        - lib (Pcre2Code, contexts, utilities)
+        - jna (JNA backend)
+        - ffm (FFM backend)
+        - regex (java.util.regex compatibility)
+        - documentation
+        - build/tooling
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, code examples, or references that would help
+    validations:
+      required: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,15 +130,11 @@ jobs:
         with:
           path: build/gh-pages
 
-      - name: Publish artifacts
+      - name: Publish snapshots to GitHub Packages
         if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
-        run: ./gradlew publish -Ppcre4j.version=${{ github.ref_name }}-SNAPSHOT
+        run: ./gradlew publishAllPublicationsToGitHubPackagesRepository -Ppcre4j.version=${{ github.ref_name }}-SNAPSHOT
 
   publish-github-pages:
     if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,11 +41,15 @@ jobs:
       - name: Build artifacts
         run: ./gradlew build jacocoAggregatedTestReport -Dpcre2.library.path=/usr/lib/x86_64-linux-gnu
 
-      - name: Publish artifacts
+      - name: Stage artifacts
+        run: ./gradlew publishAllPublicationsToStagingDeployRepository -Ppcre4j.version=${{ github.ref_name }}
+
+      - name: Release to Maven Central
         env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
-        run: ./gradlew publish -Ppcre4j.version=${{ github.ref_name }}
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
+        run: ./gradlew jreleaserDeploy -Ppcre4j.version=${{ github.ref_name }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,108 @@
+# PCRE4J Project Guidelines
+
+## Project Overview
+
+PCRE4J is a Java binding for the PCRE2 (Perl Compatible Regular Expressions 2) library, providing three API layers:
+- **High-level**: `java.util.regex`-compatible API (`regex` module)
+- **Mid-level**: PCRE4J wrapper API (`lib` module)
+- **Low-level**: Direct PCRE2 API access (`api` module)
+
+**License**: LGPL-3.0
+**Java Version**: 21 (LTS)
+
+## Module Architecture
+
+```
+pcre4j/
+├── api/    → IPcre2 interface (backend contract, ~180 PCRE2 constants)
+├── lib/    → Core wrapper (Pcre2Code, contexts, enums, utilities)
+├── jna/    → JNA backend (Java Native Access implementation)
+├── ffm/    → FFM backend (Foreign Functions & Memory API, Java 21+)
+├── regex/  → java.util.regex compatibility layer (Pattern, Matcher)
+└── test/   → Shared test infrastructure (abstract base tests)
+```
+
+**Dependencies**: `api` ← `lib` ← (`jna` | `ffm`) ← `regex`
+
+## Build Commands
+
+```bash
+# Full build with tests
+./gradlew build -Dpcre2.library.path=/usr/lib/x86_64-linux-gnu
+
+# Run tests only
+./gradlew test -Dpcre2.library.path=/usr/lib/x86_64-linux-gnu
+
+# Module-specific tests
+./gradlew jna:test ffm:test -Dpcre2.library.path=/usr/lib/x86_64-linux-gnu
+
+# Code style check
+./gradlew checkstyleMain checkstyleTest
+
+# Coverage report
+./gradlew build jacocoAggregatedTestReport -Dpcre2.library.path=/usr/lib/x86_64-linux-gnu
+```
+
+**macOS library path**: `-Dpcre2.library.path=/opt/homebrew/lib` (Apple Silicon) or `/usr/local/lib` (Intel)
+
+## Native Library Requirements
+
+PCRE2 must be installed on the system:
+- **Ubuntu/Debian**: `sudo apt install libpcre2-8-0`
+- **macOS**: `brew install pcre2`
+- **Windows**: Download PCRE2 DLL and add to PATH
+
+Library discovery priority:
+1. `pcre2.library.path` system property
+2. `jna.library.path` (JNA) / `java.library.path` (FFM)
+3. System library path
+
+## Code Conventions
+
+- **Line length**: 120 characters (Checkstyle enforced)
+- **Indentation**: 4 spaces
+- **Charset**: UTF-8 with LF line endings
+- **Copyright header**: Required on all files (LGPL-3.0 notice)
+- **JavaDoc**: Required on all public APIs
+- **Naming**:
+  - Classes: `Pcre2Code`, `Pcre2CompileOption`
+  - Enum values: `CASE_INSENSITIVE`, `DOTALL`
+  - Methods: `compile()`, `match()`, `getErrorMessage()`
+
+## Testing Patterns
+
+- **Framework**: JUnit 5 (Jupiter) with parameterized tests
+- **Backend testing**: Shared base class `org.pcre4j.test.Pcre2Tests` extended by backend-specific tests
+- **Parameterization**: Tests run against both JNA and FFM backends via `@MethodSource`
+
+## FFM Backend Notes
+
+The FFM module requires preview features (handled automatically by Gradle):
+- Compiler: `--enable-preview`
+- JVM: `--enable-preview`
+
+## Key Classes
+
+| Class | Module | Purpose |
+|-------|--------|---------|
+| `IPcre2` | api | Backend interface contract |
+| `Pcre2Code` | lib | Compiled pattern wrapper |
+| `Pcre2MatchData` | lib | Match result container |
+| `Pcre4j` | lib | Bootstrap singleton for backend selection |
+| `Pcre4jUtils` | lib | Static utility methods |
+| `Pattern` | regex | java.util.regex-compatible pattern |
+| `Matcher` | regex | java.util.regex-compatible matcher |
+
+## Commit Message Format
+
+Preferred format: `(type) brief description`
+- Types: `chore`, `docs`, `feat`, `fix`
+- Examples: `(chore) gradle 8.12`, `(feat) JIT stack`, `(fix) regex: handle edge case`
+- Reverts use Git default: `Revert "(type) original message"`
+
+## Task Tracking
+
+GitHub Issues: https://github.com/alexey-pelykh/pcre4j/issues
+
+**Closing Issues**: Use PR descriptions (not commit messages) since the project uses rebase-merge.
+Include `Fixes #<number>` or `Closes #<number>` in the PR description to auto-close issues on merge.

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -16,7 +16,6 @@ plugins {
     `java-library`
     checkstyle
     `maven-publish`
-    signing
     jacoco
 }
 
@@ -121,25 +120,8 @@ publishing {
         }
 
         maven {
-            name = "OSSRH"
-            url = uri(
-                if (project.version.toString().endsWith("-SNAPSHOT"))
-                    "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-                else
-                    "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-            )
-            credentials {
-                username = System.getenv("OSSRH_USERNAME")
-                password = System.getenv("OSSRH_TOKEN")
-            }
+            name = "StagingDeploy"
+            url = uri(layout.buildDirectory.dir("staging-deploy"))
         }
     }
-}
-
-signing {
-    useInMemoryPgpKeys(
-        System.getenv("GPG_PRIVATE_KEY"),
-        System.getenv("GPG_PASSPHRASE")
-    )
-    sign(publishing.publications["mavenJava"])
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,10 @@
 plugins {
+    base
     `jacoco-report-aggregation`
+    id("org.jreleaser") version "1.22.0"
 }
+
+version = findProperty("pcre4j.version") as String? ?: "0.0.0-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/ffm/build.gradle.kts
+++ b/ffm/build.gradle.kts
@@ -16,7 +16,6 @@ plugins {
     `java-library`
     checkstyle
     `maven-publish`
-    signing
     jacoco
 }
 
@@ -154,25 +153,8 @@ publishing {
         }
 
         maven {
-            name = "OSSRH"
-            url = uri(
-                if (project.version.toString().endsWith("-SNAPSHOT"))
-                    "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-                else
-                    "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-            )
-            credentials {
-                username = System.getenv("OSSRH_USERNAME")
-                password = System.getenv("OSSRH_TOKEN")
-            }
+            name = "StagingDeploy"
+            url = uri(layout.buildDirectory.dir("staging-deploy"))
         }
     }
-}
-
-signing {
-    useInMemoryPgpKeys(
-        System.getenv("GPG_PRIVATE_KEY"),
-        System.getenv("GPG_PASSPHRASE")
-    )
-    sign(publishing.publications["mavenJava"])
 }

--- a/jna/build.gradle.kts
+++ b/jna/build.gradle.kts
@@ -16,7 +16,6 @@ plugins {
     `java-library`
     checkstyle
     `maven-publish`
-    signing
     jacoco
 }
 
@@ -143,25 +142,8 @@ publishing {
         }
 
         maven {
-            name = "OSSRH"
-            url = uri(
-                if (project.version.toString().endsWith("-SNAPSHOT"))
-                    "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-                else
-                    "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-            )
-            credentials {
-                username = System.getenv("OSSRH_USERNAME")
-                password = System.getenv("OSSRH_TOKEN")
-            }
+            name = "StagingDeploy"
+            url = uri(layout.buildDirectory.dir("staging-deploy"))
         }
     }
-}
-
-signing {
-    useInMemoryPgpKeys(
-        System.getenv("GPG_PRIVATE_KEY"),
-        System.getenv("GPG_PASSPHRASE")
-    )
-    sign(publishing.publications["mavenJava"])
 }

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2024 Oleksii PELYKH
+#
+# This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+# <https://www.gnu.org/licenses/>.
+#
+
+project:
+  name: pcre4j
+  description: PCRE4J - PCRE2 bindings for Java
+  links:
+    homepage: https://pcre4j.org
+  authors:
+    - Alexey Pelykh
+  license: LGPL-3.0
+  inceptionYear: "2024"
+
+release:
+  github:
+    skipRelease: true
+
+signing:
+  active: ALWAYS
+  armored: true
+
+deploy:
+  maven:
+    mavenCentral:
+      sonatype:
+        active: RELEASE
+        url: https://central.sonatype.com/api/v1/publisher
+        stagingRepositories:
+          - api/build/staging-deploy
+          - lib/build/staging-deploy
+          - jna/build/staging-deploy
+          - ffm/build/staging-deploy
+          - regex/build/staging-deploy

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -16,7 +16,6 @@ plugins {
     `java-library`
     checkstyle
     `maven-publish`
-    signing
     jacoco
 }
 
@@ -154,25 +153,8 @@ publishing {
         }
 
         maven {
-            name = "OSSRH"
-            url = uri(
-                if (project.version.toString().endsWith("-SNAPSHOT"))
-                    "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-                else
-                    "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-            )
-            credentials {
-                username = System.getenv("OSSRH_USERNAME")
-                password = System.getenv("OSSRH_TOKEN")
-            }
+            name = "StagingDeploy"
+            url = uri(layout.buildDirectory.dir("staging-deploy"))
         }
     }
-}
-
-signing {
-    useInMemoryPgpKeys(
-        System.getenv("GPG_PRIVATE_KEY"),
-        System.getenv("GPG_PASSPHRASE")
-    )
-    sign(publishing.publications["mavenJava"])
 }

--- a/regex/build.gradle.kts
+++ b/regex/build.gradle.kts
@@ -16,7 +16,6 @@ plugins {
     `java-library`
     checkstyle
     `maven-publish`
-    signing
     jacoco
 }
 
@@ -155,25 +154,8 @@ publishing {
         }
 
         maven {
-            name = "OSSRH"
-            url = uri(
-                if (project.version.toString().endsWith("-SNAPSHOT"))
-                    "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-                else
-                    "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-            )
-            credentials {
-                username = System.getenv("OSSRH_USERNAME")
-                password = System.getenv("OSSRH_TOKEN")
-            }
+            name = "StagingDeploy"
+            url = uri(layout.buildDirectory.dir("staging-deploy"))
         }
     }
-}
-
-signing {
-    useInMemoryPgpKeys(
-        System.getenv("GPG_PRIVATE_KEY"),
-        System.getenv("GPG_PASSPHRASE")
-    )
-    sign(publishing.publications["mavenJava"])
 }


### PR DESCRIPTION
## Summary
- Migrate from deprecated Sonatype OSSRH to Central Portal using JReleaser
- Snapshots now publish only to GitHub Packages (not Maven Central)
- Releases use JReleaser for Maven Central deployment with GPG signing

## Changes
- **jreleaser.yml**: New JReleaser configuration for Central Portal deployment
- **build.gradle.kts**: Added JReleaser plugin and version property
- **Module build files**: Removed OSSRH repository and Gradle signing, added staging repository
- **release.yaml**: Updated to stage artifacts locally then deploy via JReleaser
- **ci.yaml**: Simplified to publish snapshots only to GitHub Packages

## Required GitHub Secrets
- `MAVEN_CENTRAL_USERNAME` - Central Portal token username
- `MAVEN_CENTRAL_PASSWORD` - Central Portal token password  
- `GPG_PASSPHRASE` - GPG key passphrase
- `GPG_PUBLIC_KEY` - GPG public key (armored)
- `GPG_SECRET_KEY` - GPG secret key (armored)

## Test plan
- [ ] Verify `./gradlew jreleaserConfig -Ppcre4j.version=0.5.0` works locally
- [ ] CI passes on the PR
- [ ] Test release workflow by creating a test tag (after merge)

Fixes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)