### PR TITLE
(fix) matchLimit() uses correct INFO_MATCHLIMIT constant

### DIFF
--- a/lib/src/main/java/org/pcre4j/Pcre2Code.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2Code.java
@@ -374,7 +374,7 @@ public class Pcre2Code {
      * @return the match limit
      */
     public int matchLimit() {
-        final var matchLimit = getPatternIntInfo(IPcre2.INFO_DEPTHLIMIT);
+        final var matchLimit = getPatternIntInfo(IPcre2.INFO_MATCHLIMIT);
         if (matchLimit == IPcre2.ERROR_UNSET) {
             throw new IllegalStateException("Match limit is not set");
         }

--- a/lib/src/test/java/org/pcre4j/Pcre2CodeTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodeTests.java
@@ -106,4 +106,18 @@ public class Pcre2CodeTests {
         });
     }
 
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchLimitThrowsWhenUnset(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertThrows(IllegalStateException.class, code::matchLimit);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void depthLimitThrowsWhenUnset(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertThrows(IllegalStateException.class, code::depthLimit);
+    }
+
 }


### PR DESCRIPTION
## Summary
- Fix copy-paste error where `matchLimit()` was reading `INFO_DEPTHLIMIT` instead of `INFO_MATCHLIMIT`

## Work Item
Fixes #66

## Changes
- Changed `getPatternIntInfo(IPcre2.INFO_DEPTHLIMIT)` to `getPatternIntInfo(IPcre2.INFO_MATCHLIMIT)` in `Pcre2Code.matchLimit()` method

## Test Plan
- [x] Build succeeds
- [x] All existing tests pass
- [x] Principle re-scan confirmed no other similar copy-paste errors exist

---
Generated via /do command