### PR TITLE
(feat) enable Maven Central snapshot publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,11 +130,25 @@ jobs:
         with:
           path: build/gh-pages
 
-      - name: Publish snapshots to GitHub Packages
-        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+      - name: Stage snapshot artifacts
+        if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'main') }}
+        run: >
+          ./gradlew publishAllPublicationsToStagingDeployRepository
+          -Ppcre4j.version=${{ github.event_name == 'pull_request' && format('PR-{0}', github.event.pull_request.number) || github.ref_name }}-SNAPSHOT
+
+      - name: Publish snapshots to Maven Central
+        if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'main') }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew publishAllPublicationsToGitHubPackagesRepository -Ppcre4j.version=${{ github.ref_name }}-SNAPSHOT
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JRELEASER_NEXUS2_SNAPSHOTS_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          JRELEASER_NEXUS2_SNAPSHOTS_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: >
+          ./gradlew jreleaserDeploy
+          ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
+          -Ppcre4j.version=${{ github.event_name == 'pull_request' && format('PR-{0}', github.event.pull_request.number) || github.ref_name }}-SNAPSHOT
 
   publish-github-pages:
     if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,5 +51,5 @@ jobs:
           JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
-          JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         run: ./gradlew jreleaserDeploy -Ppcre4j.version=${{ github.ref_name }}

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -43,3 +43,15 @@ deploy:
           - jna/build/staging-deploy
           - ffm/build/staging-deploy
           - regex/build/staging-deploy
+    nexus2:
+      snapshots:
+        active: SNAPSHOT
+        url: https://central.sonatype.com/repository/maven-snapshots/
+        snapshotUrl: https://central.sonatype.com/repository/maven-snapshots/
+        snapshotSupported: true
+        stagingRepositories:
+          - api/build/staging-deploy
+          - lib/build/staging-deploy
+          - jna/build/staging-deploy
+          - ffm/build/staging-deploy
+          - regex/build/staging-deploy


### PR DESCRIPTION
## Summary
- Add nexus2 deployer in jreleaser.yml for snapshots to Maven Central
- Update CI workflow to publish snapshots via JReleaser instead of GitHub Packages
- Add dry-run validation for PRs to catch config issues early
- Fix release workflow to use correct GPG secret names (`GPG_PRIVATE_KEY`, `GPG_PUBLIC_KEY`)

## Prerequisites
Before merging, enable snapshots for the `org.pcre4j` namespace on Maven Central:
1. Go to https://central.sonatype.com/publishing/namespaces
2. Find `org.pcre4j` namespace
3. Click dropdown → "Enable SNAPSHOTs"

## Test plan
- [ ] CI passes with dry-run validation on this PR
- [ ] After merge, verify CI publishes `main-SNAPSHOT` to Maven Central
- [ ] Verify artifacts appear at https://central.sonatype.com/repository/maven-snapshots/org/pcre4j/

🤖 Generated with [Claude Code](https://claude.com/claude-code)