### PR TITLE
(chore) disable GitHub Packages snapshot publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,6 @@ jobs:
 
     permissions:
       contents: read
-      packages: write
 
     needs:
       - compatibility
@@ -134,7 +133,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'main') }}
         run: >
           ./gradlew publishAllPublicationsToStagingDeployRepository
-          -Ppcre4j.version=${{ github.event_name == 'pull_request' && format('PR-{0}', github.event.pull_request.number) || github.ref_name }}-SNAPSHOT
+          -Ppcre4j.version=${{ github.event_name == 'pull_request' && format('PR-{0}-SNAPSHOT', github.event.pull_request.number) || 'main-SNAPSHOT' }}
 
       - name: Publish snapshots to Maven Central
         if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'main') }}
@@ -148,7 +147,7 @@ jobs:
         run: >
           ./gradlew jreleaserDeploy
           ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
-          -Ppcre4j.version=${{ github.event_name == 'pull_request' && format('PR-{0}', github.event.pull_request.number) || github.ref_name }}-SNAPSHOT
+          -Ppcre4j.version=${{ github.event_name == 'pull_request' && format('PR-{0}-SNAPSHOT', github.event.pull_request.number) || 'main-SNAPSHOT' }}
 
   publish-github-pages:
     if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,18 @@ gh release create <version> --title <version> --generate-notes
 
 **Note**: `skipRelease: true` in jreleaser.yml exists because the GitHub Release is already created by `gh release create` before JReleaser runs.
 
+## Snapshot Publishing
+
+Snapshots are published to Maven Central Snapshots repository (not GitHub Packages).
+
+**Version formats**:
+- Main branch: `main-SNAPSHOT`
+- Pull requests: `PR-{number}-SNAPSHOT` (dry-run only)
+
+**Why not GitHub Packages**: GitHub Packages has a known limitation where SNAPSHOT versions don't update when republished - it always returns the first uploaded artifact. This makes it unsuitable for snapshot publishing. See [GitHub Community Discussion #24658](https://github.com/orgs/community/discussions/24658).
+
+**JReleaser configuration**: Uses `versionPattern: CUSTOM` to allow non-semver snapshot version formats.
+
 **Release Notes Style**:
 - Format: `## What's Changed` header with bullet list of PRs
 - Content: Include only `(fix)` and `(feat)` changes; omit `(chore)` and `(docs)`

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -111,15 +111,6 @@ publishing {
 
     repositories {
         maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/" + System.getenv("GITHUB_REPOSITORY"))
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
-
-        maven {
             name = "StagingDeploy"
             url = uri(layout.buildDirectory.dir("staging-deploy"))
         }

--- a/ffm/build.gradle.kts
+++ b/ffm/build.gradle.kts
@@ -144,15 +144,6 @@ publishing {
 
     repositories {
         maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/" + System.getenv("GITHUB_REPOSITORY"))
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
-
-        maven {
             name = "StagingDeploy"
             url = uri(layout.buildDirectory.dir("staging-deploy"))
         }

--- a/jna/build.gradle.kts
+++ b/jna/build.gradle.kts
@@ -133,15 +133,6 @@ publishing {
 
     repositories {
         maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/" + System.getenv("GITHUB_REPOSITORY"))
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
-
-        maven {
             name = "StagingDeploy"
             url = uri(layout.buildDirectory.dir("staging-deploy"))
         }

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -16,6 +16,7 @@
 project:
   name: pcre4j
   description: PCRE4J - PCRE2 bindings for Java
+  versionPattern: CUSTOM
   links:
     homepage: https://pcre4j.org
   authors:

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -144,15 +144,6 @@ publishing {
 
     repositories {
         maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/" + System.getenv("GITHUB_REPOSITORY"))
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
-
-        maven {
             name = "StagingDeploy"
             url = uri(layout.buildDirectory.dir("staging-deploy"))
         }

--- a/regex/build.gradle.kts
+++ b/regex/build.gradle.kts
@@ -145,15 +145,6 @@ publishing {
 
     repositories {
         maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/" + System.getenv("GITHUB_REPOSITORY"))
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
-
-        maven {
             name = "StagingDeploy"
             url = uri(layout.buildDirectory.dir("staging-deploy"))
         }


### PR DESCRIPTION
## Summary

- Remove GitHubPackages repository configuration from all module build.gradle.kts files
- Remove `packages:write` permission from CI workflow (no longer needed)
- Add `versionPattern: CUSTOM` to jreleaser.yml to allow non-semver snapshot versions (`main-SNAPSHOT`, `PR-{number}-SNAPSHOT`)
- Document the GitHub Packages SNAPSHOT limitation and new publishing setup in CLAUDE.md

## Background

GitHub Packages has a known limitation where SNAPSHOT versions don't update when republished - it always returns the first uploaded artifact. See [GitHub Community Discussion #24658](https://github.com/orgs/community/discussions/24658).

Snapshots are now published exclusively to Maven Central Snapshots repository.

## Manual action required

Delete existing SNAPSHOT versions from GitHub Packages:
- https://github.com/alexey-pelykh/pcre4j/packages → Select each package → Delete `main-SNAPSHOT` version

🤖 Generated with [Claude Code](https://claude.ai/code)