### PR TITLE
(fix) remove dead code in limit getters

### DIFF
--- a/lib/src/main/java/org/pcre4j/Pcre2Code.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2Code.java
@@ -277,11 +277,7 @@ public class Pcre2Code {
      * @return the backtracking depth limit
      */
     public int depthLimit() {
-        final var depthLimit = getPatternIntInfo(IPcre2.INFO_DEPTHLIMIT);
-        if (depthLimit == IPcre2.ERROR_UNSET) {
-            throw new IllegalStateException("Depth limit is not set");
-        }
-        return depthLimit;
+        return getPatternIntInfo(IPcre2.INFO_DEPTHLIMIT);
     }
 
     /**
@@ -327,11 +323,7 @@ public class Pcre2Code {
      * @return the heap limit
      */
     public int heapLimit() {
-        final var heapLimit = getPatternIntInfo(IPcre2.INFO_HEAPLIMIT);
-        if (heapLimit == IPcre2.ERROR_UNSET) {
-            throw new IllegalStateException("Heap limit is not set");
-        }
-        return heapLimit;
+        return getPatternIntInfo(IPcre2.INFO_HEAPLIMIT);
     }
 
     /**
@@ -374,11 +366,7 @@ public class Pcre2Code {
      * @return the match limit
      */
     public int matchLimit() {
-        final var matchLimit = getPatternIntInfo(IPcre2.INFO_MATCHLIMIT);
-        if (matchLimit == IPcre2.ERROR_UNSET) {
-            throw new IllegalStateException("Match limit is not set");
-        }
-        return matchLimit;
+        return getPatternIntInfo(IPcre2.INFO_MATCHLIMIT);
     }
 
     /**

--- a/lib/src/test/java/org/pcre4j/Pcre2CodeTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodeTests.java
@@ -120,4 +120,11 @@ public class Pcre2CodeTests {
         assertThrows(IllegalStateException.class, code::depthLimit);
     }
 
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void heapLimitThrowsWhenUnset(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertThrows(IllegalStateException.class, code::heapLimit);
+    }
+
 }


### PR DESCRIPTION
## Summary
- Remove unreachable code in `matchLimit()`, `depthLimit()`, and `heapLimit()` methods
- Add missing `heapLimitThrowsWhenUnset` test

## Context
The `matchLimit()`, `depthLimit()`, and `heapLimit()` methods in `Pcre2Code` had unreachable code that checked for `ERROR_UNSET` after calling `getPatternIntInfo()`. This check was dead code because `getPatternIntInfo()` already throws `IllegalStateException` when PCRE2 returns `ERROR_UNSET` as an error code.

This was discovered while investigating the missing coverage line from PR #70.

## Changes
- Simplified `matchLimit()`, `depthLimit()`, `heapLimit()` to directly return the result from `getPatternIntInfo()`
- Added missing `heapLimitThrowsWhenUnset` test to `Pcre2CodeTests`

The exception behavior is preserved - calling these methods on patterns without embedded limits still throws `IllegalStateException`, just from `getPatternIntInfo()` rather than the (now removed) redundant check.

## Test Plan
- [x] All existing tests pass
- [x] New `heapLimitThrowsWhenUnset` test added
- [x] Coverage improved (no more dead code)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)