### PR TITLE
(feat) implement pcre2_substring_nametable_scan API binding

### DIFF
--- a/PCRE2_API.md
+++ b/PCRE2_API.md
@@ -74,5 +74,5 @@ Here's the list of the PCRE2 API functions exposed via `org.pcre4j.api.IPcre2` a
 | ✅ | [pcre2_substring_length_bynumber](https://www.pcre.org/current/doc/html/pcre2_substring_length_bynumber.html)             | Find length of numbered substring                                                 |
 | ✅ | [pcre2_substring_list_free](https://www.pcre.org/current/doc/html/pcre2_substring_list_free.html)                         | Free list of extracted substrings                                                 |
 | ✅ | [pcre2_substring_list_get](https://www.pcre.org/current/doc/html/pcre2_substring_list_get.html)                           | Extract all substrings into new memory                                            |
-|   | [pcre2_substring_nametable_scan](https://www.pcre.org/current/doc/html/pcre2_substring_nametable_scan.html)               | Find table entries for given string name                                          |
+| ✅ | [pcre2_substring_nametable_scan](https://www.pcre.org/current/doc/html/pcre2_substring_nametable_scan.html)               | Find table entries for given string name                                          |
 | ✅ | [pcre2_substring_number_from_name](https://www.pcre.org/current/doc/html/pcre2_substring_number_from_name.html)           | Convert captured string name to number                                            |

--- a/api/src/main/java/org/pcre4j/api/IPcre2.java
+++ b/api/src/main/java/org/pcre4j/api/IPcre2.java
@@ -1221,6 +1221,30 @@ public interface IPcre2 {
     public int substringNumberFromName(long code, String name);
 
     /**
+     * Find the first and last name table entries for a given capture group name.
+     * <p>
+     * This function locates entries in the name-to-number mapping table for named capture groups.
+     * When duplicate names are allowed (via DUPNAMES option), a name may map to multiple group numbers.
+     * This function returns pointers to the first and last table entries for the given name.
+     * <p>
+     * Each entry in the name table consists of a fixed-size record containing the group number followed by
+     * the null-terminated name. The entry size can be obtained via {@link #patternInfo} with
+     * {@link #INFO_NAMEENTRYSIZE}.
+     *
+     * @param code  the compiled pattern handle
+     * @param name  the name of the capturing group to look up
+     * @param first an array of length 1 to receive the pointer to the first matching entry,
+     *              or null to just get a group number (returns any matching group number)
+     * @param last  an array of length 1 to receive the pointer to the last matching entry,
+     *              or null if not needed
+     * @return On success: the length of each entry in code units (when first is not null),
+     *         or a group number (when first is null and the name is found).
+     *         On failure: {@link #ERROR_NOSUBSTRING} if the name is not found
+     * @see <a href="https://www.pcre.org/current/doc/html/pcre2_substring_nametable_scan.html">pcre2_substring_nametable_scan</a>
+     */
+    public int substringNametableScan(long code, String name, long[] first, long[] last);
+
+    /**
      * Read bytes from a native memory pointer.
      * <p>
      * This is a utility method used internally to read string data from native memory.

--- a/test/src/main/java/org/pcre4j/test/Pcre2Tests.java
+++ b/test/src/main/java/org/pcre4j/test/Pcre2Tests.java
@@ -1439,6 +1439,85 @@ public abstract class Pcre2Tests {
     }
 
     @Test
+    public void scanNametableSingle() {
+        final var code = new Pcre2Code(
+                api,
+                "(?<word>\\w+)",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+
+        final var groupNumbers = code.scanNametable("word");
+        assertArrayEquals(new int[]{1}, groupNumbers);
+    }
+
+    @Test
+    public void scanNametableMultipleGroups() {
+        final var code = new Pcre2Code(
+                api,
+                "(?<first>\\w+) (?<second>\\w+) (?<third>\\w+)",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+
+        assertArrayEquals(new int[]{1}, code.scanNametable("first"));
+        assertArrayEquals(new int[]{2}, code.scanNametable("second"));
+        assertArrayEquals(new int[]{3}, code.scanNametable("third"));
+    }
+
+    @Test
+    public void scanNametableDuplicateNames() {
+        // DUPNAMES option allows duplicate named groups
+        final var code = new Pcre2Code(
+                api,
+                "(?<num>\\d+)|(?<num>\\w+)",
+                EnumSet.of(Pcre2CompileOption.DUPNAMES),
+                null
+        );
+
+        final var groupNumbers = code.scanNametable("num");
+        assertArrayEquals(new int[]{1, 2}, groupNumbers);
+    }
+
+    @Test
+    public void scanNametableMultipleDuplicateNames() {
+        // Multiple duplicate named groups
+        final var code = new Pcre2Code(
+                api,
+                "(?<a>a)|(?<b>b)|(?<a>aa)|(?<b>bb)|(?<a>aaa)",
+                EnumSet.of(Pcre2CompileOption.DUPNAMES),
+                null
+        );
+
+        assertArrayEquals(new int[]{1, 3, 5}, code.scanNametable("a"));
+        assertArrayEquals(new int[]{2, 4}, code.scanNametable("b"));
+    }
+
+    @Test
+    public void scanNametableNonexistent() {
+        final var code = new Pcre2Code(
+                api,
+                "(?<word>\\w+)",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+
+        assertThrows(Pcre2NoSubstringError.class, () -> code.scanNametable("nonexistent"));
+    }
+
+    @Test
+    public void scanNametableNull() {
+        final var code = new Pcre2Code(
+                api,
+                "(?<word>\\w+)",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> code.scanNametable(null));
+    }
+
+    @Test
     public void setMatchLimitNegativeThrows() {
         final var matchContext = new Pcre2MatchContext(api, null);
         assertThrows(IllegalArgumentException.class, () -> matchContext.setMatchLimit(-1));


### PR DESCRIPTION
## Summary
- Add `substringNametableScan` method to `IPcre2` interface for scanning name table entries
- Implement JNA and FFM backends for the native PCRE2 function
- Add `scanNametable` high-level wrapper method in `Pcre2Code` for easy named group enumeration
- Add comprehensive tests covering single groups, multiple groups, and duplicate names (DUPNAMES option)

## Test plan
- [x] Unit tests for single named group lookup
- [x] Unit tests for multiple distinct named groups
- [x] Unit tests for duplicate named groups with DUPNAMES option
- [x] Unit tests for multiple duplicate named groups
- [x] Unit tests for nonexistent group name (throws Pcre2NoSubstringError)
- [x] Unit tests for null name (throws IllegalArgumentException)
- [x] All tests pass on both JNA and FFM backends

Fixes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)