### PR TITLE
(feat) implement pcre2_dfa_match API binding

### DIFF
--- a/api/src/main/java/org/pcre4j/api/IPcre2.java
+++ b/api/src/main/java/org/pcre4j/api/IPcre2.java
@@ -959,6 +959,55 @@ public interface IPcre2 {
     public int match(long code, String subject, int startoffset, int options, long matchData, long mcontext);
 
     /**
+     * Match a compiled pattern against a subject string using the alternative DFA matching algorithm.
+     * <p>
+     * DFA (Deterministic Finite Automaton) matching finds all possible matches at a given point in the subject string.
+     * This is useful for lexers and tokenizers. Note that DFA matching is not Perl-compatible.
+     * <p>
+     * Unlike the standard {@link #match} function, DFA matching requires a workspace array for internal use.
+     * The workspace must be an array of integers, and its size should be at least 20 elements for simple patterns,
+     * though more complex patterns may require larger workspaces.
+     * <p>
+     * Important differences from standard matching:
+     * <ul>
+     *   <li>The output vector contains matched strings in reverse order (longest first)</li>
+     *   <li>Capturing parentheses are not supported (only the overall match is returned)</li>
+     *   <li>The {@link #DFA_RESTART} option can be used to continue after a partial match</li>
+     *   <li>The {@link #DFA_SHORTEST} option can be used to return only the shortest match</li>
+     * </ul>
+     *
+     * @param code        the compiled pattern handle
+     * @param subject     the subject string
+     * @param startoffset the starting offset in the subject string
+     * @param options     option bits (may include {@link #DFA_RESTART}, {@link #DFA_SHORTEST},
+     *                    {@link #PARTIAL_SOFT}, {@link #PARTIAL_HARD})
+     * @param matchData   the match data handle
+     * @param mcontext    the match context handle (may be 0)
+     * @param workspace   an array of integers used as working space by the matching algorithm
+     * @param wscount     the number of elements in the workspace array
+     * @return the number of matched substrings, zero if the output vector is too small,
+     *         or a negative error code:
+     *         {@link #ERROR_NOMATCH} if no match was found,
+     *         {@link #ERROR_DFA_WSSIZE} if the workspace is too small,
+     *         {@link #ERROR_DFA_RECURSE} if recursion is used in the pattern,
+     *         {@link #ERROR_DFA_UCOND} if an unsupported condition is used,
+     *         {@link #ERROR_DFA_UFUNC} if an unsupported function is used,
+     *         {@link #ERROR_DFA_UITEM} if an unsupported pattern item is encountered,
+     *         {@link #ERROR_DFA_BADRESTART} if {@link #DFA_RESTART} is used incorrectly
+     * @see <a href="https://www.pcre.org/current/doc/html/pcre2_dfa_match.html">pcre2_dfa_match</a>
+     */
+    public int dfaMatch(
+            long code,
+            String subject,
+            int startoffset,
+            int options,
+            long matchData,
+            long mcontext,
+            int[] workspace,
+            int wscount
+    );
+
+    /**
      * Get number of the offset pairs in the output vector of the match data
      *
      * @param matchData the match data handle

--- a/jna/src/main/java/org/pcre4j/jna/Pcre2.java
+++ b/jna/src/main/java/org/pcre4j/jna/Pcre2.java
@@ -372,6 +372,51 @@ public class Pcre2 implements IPcre2 {
     }
 
     @Override
+    public int dfaMatch(
+            long code,
+            String subject,
+            int startoffset,
+            int options,
+            long matchData,
+            long mcontext,
+            int[] workspace,
+            int wscount
+    ) {
+        if (subject == null) {
+            throw new IllegalArgumentException("subject must not be null");
+        }
+        if (workspace == null) {
+            throw new IllegalArgumentException("workspace must not be null");
+        }
+        if (wscount < 0) {
+            throw new IllegalArgumentException("wscount must not be negative");
+        }
+        if (wscount > workspace.length) {
+            throw new IllegalArgumentException("wscount must not be greater than workspace.length");
+        }
+
+        final var pCode = new Pointer(code);
+        final var pszSubject = subject.getBytes(StandardCharsets.UTF_8);
+        final var subjectLength = new Pointer(pszSubject.length);
+        final var startOffset = new Pointer(startoffset);
+        final var pMatchData = new Pointer(matchData);
+        final var pMContext = new Pointer(mcontext);
+        final var wsCount = new Pointer(wscount);
+
+        return library.pcre2_dfa_match(
+                pCode,
+                pszSubject,
+                subjectLength,
+                startOffset,
+                options,
+                pMatchData,
+                pMContext,
+                workspace,
+                wsCount
+        );
+    }
+
+    @Override
     public int getOvectorCount(long matchData) {
         final var pMatchData = new Pointer(matchData);
         return library.pcre2_get_ovector_count(pMatchData);
@@ -794,6 +839,18 @@ public class Pcre2 implements IPcre2 {
                 int options,
                 Pointer matchData,
                 Pointer mcontext
+        );
+
+        int pcre2_dfa_match(
+                Pointer code,
+                byte[] subject,
+                Pointer length,
+                Pointer startoffset,
+                int options,
+                Pointer matchData,
+                Pointer mcontext,
+                int[] workspace,
+                Pointer wscount
         );
 
         int pcre2_get_ovector_count(Pointer matchData);


### PR DESCRIPTION
## Summary
- Add `dfaMatch` method to `IPcre2` interface with workspace array parameters for DFA matching
- Implement `dfaMatch` in JNA backend using `Pointer` and native library interface
- Implement `dfaMatch` in FFM backend using `MethodHandle` and `MemorySegment`
- Add comprehensive unit tests covering all scenarios

## Test plan
- [x] Basic DFA matching
- [x] No match scenario
- [x] Matching with start offset
- [x] Multiple alternatives matching
- [x] Workspace too small error (ERROR_DFA_WSSIZE)
- [x] Null subject validation
- [x] Null workspace validation
- [x] Negative wscount validation
- [x] wscount > workspace.length validation
- [x] Unicode (UTF-8) pattern matching
- [x] DFA_SHORTEST option with alternatives

Part of PCRE2 API Phase 4 (#78)
Fixes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)