### PR TITLE
(chore) configure codecov to exclude test package from patch coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 70%
+        paths:
+          - "!test/**"


### PR DESCRIPTION
## Summary

- Add `codecov.yml` to exclude `test/**` from patch coverage calculations
- The test module contains shared test infrastructure in `test/src/main/java/` which creates partial branch coverage from assertions

## Problem

Every `assertTrue(x != 0)` creates 2 branches in JaCoCo, but only the "true" branch gets covered. More test assertions = lower patch coverage %.

Fixes #164

## Test plan

- [ ] CI passes
- [ ] Future PRs with test changes won't be blocked by assertion branch coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)