### PR TITLE
(feat) add PCRE2 version matrix to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,7 @@ jobs:
           - oracle
 #          - dragonwell
         java-version: [ 21 ]
+        pcre2-version: [ '10.42', '10.43', '10.45' ]
 
     runs-on: ${{ matrix.os }}
 
@@ -54,14 +55,14 @@ jobs:
         id: cache-pcre2
         with:
           path: /opt/pcre2
-          key: pcre2-10.45-${{ matrix.os }}
+          key: pcre2-${{ matrix.pcre2-version }}-${{ matrix.os }}
 
       - name: Build PCRE2 from source
         if: ${{ matrix.os == 'ubuntu-24.04' && steps.cache-pcre2.outputs.cache-hit != 'true' }}
         run: |
           sudo apt-get install -y build-essential
-          curl -L https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.45/pcre2-10.45.tar.gz | tar xz
-          cd pcre2-10.45
+          curl -L https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${{ matrix.pcre2-version }}/pcre2-${{ matrix.pcre2-version }}.tar.gz | tar xz
+          cd pcre2-${{ matrix.pcre2-version }}
           ./configure --prefix=/opt/pcre2 --enable-jit
           make -j$(nproc)
           sudo make install


### PR DESCRIPTION
## Summary

- Add `pcre2-version` matrix dimension to CI compatibility job
- Test against PCRE2 10.42, 10.43, and 10.45 to ensure backward compatibility
- Updates cache keys and build steps to use matrix version

## Version Selection

| Version | Purpose |
|---------|---------|
| 10.42 | Pre-feature baseline (ASCII_BSD/BSS/BSW unavailable) |
| 10.43 | Feature boundary (first version with extra compile options) |
| 10.45 | Current stable |

## Motivation

- PCRE2 10.43 introduced new extra compile options (ASCII_BSD, ASCII_BSS, ASCII_BSW)
- Tests use `assumeTrue(Pcre4jUtils.isVersionAtLeast(api, 10, 43))` to skip on older versions
- Testing 10.42 validates skip behavior, testing 10.43 validates feature enablement

## Impact

Compatibility matrix expands from 9 to 27 jobs (9 Java distributions × 3 PCRE2 versions).

## Test plan

- [ ] CI runs successfully with PCRE2 10.42, 10.43, and 10.45
- [ ] Version-conditional tests skip on 10.42
- [ ] Version-conditional tests run on 10.43+

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)