### PR TITLE
(fix) skip snapshot publishing for fork PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,13 +159,13 @@ jobs:
           path: build/gh-pages
 
       - name: Stage snapshot artifacts
-        if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'main') }}
+        if: ${{ (github.event_name == 'push' && github.ref_name == 'main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
         run: >
           ./gradlew publishAllPublicationsToStagingDeployRepository
           -Ppcre4j.version=${{ github.event_name == 'pull_request' && format('PR-{0}-SNAPSHOT', github.event.pull_request.number) || 'main-SNAPSHOT' }}
 
       - name: Publish snapshots to Maven Central
-        if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'main') }}
+        if: ${{ (github.event_name == 'push' && github.ref_name == 'main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_NEXUS2_SNAPSHOTS_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}


### PR DESCRIPTION
## Summary

Fork PRs don't have access to repository secrets (GPG keys, Maven Central credentials), causing JReleaser to fail at configuration validation even in dry-run mode.

## Changes

Restricts snapshot staging and publishing steps to:
- **Push to main branch**: Actual publish to Maven Central
- **PRs from the same repository**: Dry-run validation only

Fork PRs will now skip these steps entirely, allowing CI to pass.

## Context

Discovered while reviewing PR #127 - the `package` job was failing for all fork PRs due to missing secrets, even though the code changes were correct.

---
🤖 Generated with [Claude Code](https://claude.ai/code)