### PR TITLE
(feat) regex: implement Matcher.results()

### DIFF
--- a/regex/src/main/java/org/pcre4j/regex/Matcher.java
+++ b/regex/src/main/java/org/pcre4j/regex/Matcher.java
@@ -21,7 +21,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * Performs match operations on a character sequence by interpreting a {@link Pattern} using the PCRE library yet aims
@@ -764,7 +766,30 @@ public class Matcher implements java.util.regex.MatchResult {
         return reset();
     }
 
-    // TODO: results()
+    /**
+     * Returns a stream of match results for each subsequence of the input sequence that matches the pattern.
+     * <p>
+     * The match results occur in the same order as the matching subsequences in the input sequence.
+     * <p>
+     * Each match result is produced as if by {@link #toMatchResult()}.
+     * <p>
+     * This method does not reset this matcher. Matching starts on initiation of the terminal stream operation
+     * either at the beginning of this matcher's region, or, if the matcher has not since been reset, at the
+     * first character not matched by a previous match.
+     * <p>
+     * If the match results are used after the matcher has been modified (via {@link #find()}, {@link #reset()},
+     * etc.), the behavior is undefined.
+     *
+     * @return a sequential stream of match results
+     * @since 9
+     */
+    public Stream<java.util.regex.MatchResult> results() {
+        return Stream.iterate(
+                find() ? toMatchResult() : null,
+                Objects::nonNull,
+                mr -> find() ? toMatchResult() : null
+        );
+    }
 
     /**
      * Returns the start index of the most recent match

--- a/regex/src/test/java/org/pcre4j/regex/MatcherTests.java
+++ b/regex/src/test/java/org/pcre4j/regex/MatcherTests.java
@@ -1307,4 +1307,217 @@ public class MatcherTests {
         assertEquals(javaSb.toString(), pcre4jSb.toString());
     }
 
+    // ========================================================================
+    // results() method tests
+    // ========================================================================
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void resultsBasic(IPcre2 api) {
+        var regex = "\\d+";
+        var input = "a1b22c333d";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        var javaResults = javaMatcher.results().toList();
+        var pcre4jResults = pcre4jMatcher.results().toList();
+
+        assertEquals(javaResults.size(), pcre4jResults.size());
+        for (int i = 0; i < javaResults.size(); i++) {
+            assertEquals(javaResults.get(i).group(), pcre4jResults.get(i).group());
+            assertEquals(javaResults.get(i).start(), pcre4jResults.get(i).start());
+            assertEquals(javaResults.get(i).end(), pcre4jResults.get(i).end());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void resultsNoMatches(IPcre2 api) {
+        var regex = "xyz";
+        var input = "hello world";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        var javaResults = javaMatcher.results().toList();
+        var pcre4jResults = pcre4jMatcher.results().toList();
+
+        assertEquals(javaResults.size(), pcre4jResults.size());
+        assertTrue(pcre4jResults.isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void resultsSingleMatch(IPcre2 api) {
+        var regex = "world";
+        var input = "hello world!";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        var javaResults = javaMatcher.results().toList();
+        var pcre4jResults = pcre4jMatcher.results().toList();
+
+        assertEquals(javaResults.size(), pcre4jResults.size());
+        assertEquals(1, pcre4jResults.size());
+        assertEquals(javaResults.get(0).group(), pcre4jResults.get(0).group());
+        assertEquals(javaResults.get(0).start(), pcre4jResults.get(0).start());
+        assertEquals(javaResults.get(0).end(), pcre4jResults.get(0).end());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void resultsWithGroups(IPcre2 api) {
+        var regex = "(\\w)(\\d)";
+        var input = "a1 b2 c3";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        var javaResults = javaMatcher.results().toList();
+        var pcre4jResults = pcre4jMatcher.results().toList();
+
+        assertEquals(javaResults.size(), pcre4jResults.size());
+        for (int i = 0; i < javaResults.size(); i++) {
+            assertEquals(javaResults.get(i).groupCount(), pcre4jResults.get(i).groupCount());
+            assertEquals(javaResults.get(i).group(), pcre4jResults.get(i).group());
+            assertEquals(javaResults.get(i).group(1), pcre4jResults.get(i).group(1));
+            assertEquals(javaResults.get(i).group(2), pcre4jResults.get(i).group(2));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void resultsImmutableSnapshots(IPcre2 api) {
+        var regex = "\\w+";
+        var input = "one two three";
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        // Collect all results first
+        var results = pcre4jMatcher.results().toList();
+
+        // Results should be independent snapshots
+        assertEquals(3, results.size());
+        assertEquals("one", results.get(0).group());
+        assertEquals("two", results.get(1).group());
+        assertEquals("three", results.get(2).group());
+
+        // Each should have correct positions
+        assertEquals(0, results.get(0).start());
+        assertEquals(3, results.get(0).end());
+        assertEquals(4, results.get(1).start());
+        assertEquals(7, results.get(1).end());
+        assertEquals(8, results.get(2).start());
+        assertEquals(13, results.get(2).end());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void resultsDoesNotReset(IPcre2 api) {
+        var regex = "\\w+";
+        var input = "one two three";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        // Call find() first to advance the matcher
+        assertTrue(javaMatcher.find());
+        assertTrue(pcre4jMatcher.find());
+        assertEquals("one", javaMatcher.group());
+        assertEquals("one", pcre4jMatcher.group());
+
+        // results() should NOT reset and should continue from current position
+        var javaResults = javaMatcher.results().toList();
+        var pcre4jResults = pcre4jMatcher.results().toList();
+
+        assertEquals(javaResults.size(), pcre4jResults.size());
+        assertEquals(2, pcre4jResults.size());  // "two" and "three" only
+        assertEquals("two", pcre4jResults.get(0).group());
+        assertEquals("three", pcre4jResults.get(1).group());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void resultsZeroWidthMatches(IPcre2 api) {
+        var regex = "(?=\\d)";  // Zero-width positive lookahead for digit
+        var input = "a1b2c3";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        var javaResults = javaMatcher.results().toList();
+        var pcre4jResults = pcre4jMatcher.results().toList();
+
+        assertEquals(javaResults.size(), pcre4jResults.size());
+        for (int i = 0; i < javaResults.size(); i++) {
+            assertEquals(javaResults.get(i).start(), pcre4jResults.get(i).start());
+            assertEquals(javaResults.get(i).end(), pcre4jResults.get(i).end());
+            // Zero-width matches have start == end
+            assertEquals(pcre4jResults.get(i).start(), pcre4jResults.get(i).end());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void resultsEmptyString(IPcre2 api) {
+        var regex = ".*";
+        var input = "";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        var javaResults = javaMatcher.results().toList();
+        var pcre4jResults = pcre4jMatcher.results().toList();
+
+        assertEquals(javaResults.size(), pcre4jResults.size());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void resultsUnicode(IPcre2 api) {
+        var regex = "\\p{L}+";
+        var input = "hello мир 世界";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        var javaResults = javaMatcher.results().toList();
+        var pcre4jResults = pcre4jMatcher.results().toList();
+
+        assertEquals(javaResults.size(), pcre4jResults.size());
+        for (int i = 0; i < javaResults.size(); i++) {
+            assertEquals(javaResults.get(i).group(), pcre4jResults.get(i).group());
+            assertEquals(javaResults.get(i).start(), pcre4jResults.get(i).start());
+            assertEquals(javaResults.get(i).end(), pcre4jResults.get(i).end());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void resultsStreamOperations(IPcre2 api) {
+        var regex = "\\d+";
+        var input = "a1b22c333d4444";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        // Test that stream operations work correctly
+        var javaSum = javaMatcher.results()
+                .mapToInt(mr -> Integer.parseInt(mr.group()))
+                .sum();
+        var pcre4jSum = pcre4jMatcher.results()
+                .mapToInt(mr -> Integer.parseInt(mr.group()))
+                .sum();
+
+        assertEquals(javaSum, pcre4jSum);
+        assertEquals(1 + 22 + 333 + 4444, pcre4jSum);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void resultsCount(IPcre2 api) {
+        var regex = "a";
+        var input = "abracadabra";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        assertEquals(javaMatcher.results().count(), pcre4jMatcher.results().count());
+        // Need to create new matchers since results() consumes the matcher state
+        javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+        assertEquals(5, pcre4jMatcher.results().count());
+    }
+
 }


### PR DESCRIPTION
## Summary

- Implement `Matcher.results()` method for API compatibility with `java.util.regex.Matcher`
- Returns `Stream<MatchResult>` for each subsequence that matches the pattern (Java 9+ API)
- Uses `Stream.iterate()` with immutable snapshots via `toMatchResult()`

## Test plan

- [x] Basic functionality test (`resultsBasic`)
- [x] No matches case (`resultsNoMatches`)
- [x] Single match case (`resultsSingleMatch`)
- [x] Capturing groups (`resultsWithGroups`)
- [x] Immutable snapshots verification (`resultsImmutableSnapshots`)
- [x] Does not reset matcher state (`resultsDoesNotReset`)
- [x] Zero-width matches (`resultsZeroWidthMatches`)
- [x] Empty string (`resultsEmptyString`)
- [x] Unicode support (`resultsUnicode`)
- [x] Stream operations (`resultsStreamOperations`, `resultsCount`)
- [x] All tests verify behavior matches JDK `java.util.regex.Matcher`

Fixes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)