### PR TITLE
(feat) regex: implement anchoring bounds support

### DIFF
--- a/regex/src/test/java/org/pcre4j/regex/MatcherTests.java
+++ b/regex/src/test/java/org/pcre4j/regex/MatcherTests.java
@@ -1520,4 +1520,291 @@ public class MatcherTests {
         assertEquals(5, pcre4jMatcher.results().count());
     }
 
+    // ========================================================================
+    // Anchoring bounds tests
+    // ========================================================================
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void hasAnchoringBoundsDefault(IPcre2 api) {
+        var regex = "test";
+        var input = "test";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        // Default should be true (anchoring enabled)
+        assertEquals(javaMatcher.hasAnchoringBounds(), pcre4jMatcher.hasAnchoringBounds());
+        assertTrue(pcre4jMatcher.hasAnchoringBounds());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void useAnchoringBoundsReturnsThis(IPcre2 api) {
+        var regex = "test";
+        var input = "test";
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        // Should return this for method chaining
+        var result = pcre4jMatcher.useAnchoringBounds(false);
+        assertEquals(pcre4jMatcher, result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void useAnchoringBoundsFalse(IPcre2 api) {
+        var regex = "test";
+        var input = "test";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        javaMatcher.useAnchoringBounds(false);
+        pcre4jMatcher.useAnchoringBounds(false);
+
+        assertEquals(javaMatcher.hasAnchoringBounds(), pcre4jMatcher.hasAnchoringBounds());
+        assertFalse(pcre4jMatcher.hasAnchoringBounds());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void useAnchoringBoundsTrue(IPcre2 api) {
+        var regex = "test";
+        var input = "test";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        // Set to false first, then back to true
+        javaMatcher.useAnchoringBounds(false).useAnchoringBounds(true);
+        pcre4jMatcher.useAnchoringBounds(false).useAnchoringBounds(true);
+
+        assertEquals(javaMatcher.hasAnchoringBounds(), pcre4jMatcher.hasAnchoringBounds());
+        assertTrue(pcre4jMatcher.hasAnchoringBounds());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void anchoringBoundsCaretWithRegion(IPcre2 api) {
+        // Test that ^ matches at region start with anchoring bounds enabled (default)
+        var regex = "^test";
+        var input = "XXXtestYYY";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        javaMatcher.region(3, 7);
+        pcre4jMatcher.region(3, 7);
+
+        // With anchoring bounds (default), ^ should match at region start
+        var javaResult = javaMatcher.find();
+        var pcre4jResult = pcre4jMatcher.find();
+        assertEquals(javaResult, pcre4jResult);
+        assertTrue(javaResult);  // Java behavior: ^ matches at region start with anchoring bounds
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void anchoringBoundsCaretWithRegionDisabled(IPcre2 api) {
+        // Test that ^ does NOT match at region start with anchoring bounds disabled
+        var regex = "^test";
+        var input = "XXXtestYYY";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        javaMatcher.region(3, 7).useAnchoringBounds(false);
+        pcre4jMatcher.region(3, 7).useAnchoringBounds(false);
+
+        // With non-anchoring bounds, ^ should NOT match at region start (only at true input start)
+        assertEquals(javaMatcher.find(), pcre4jMatcher.find());
+        assertFalse(pcre4jMatcher.hasAnchoringBounds());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void anchoringBoundsDollarWithRegion(IPcre2 api) {
+        // Test that $ matches at region end with anchoring bounds enabled (default)
+        var regex = "test$";
+        var input = "XXXtestYYY";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        javaMatcher.region(3, 7);
+        pcre4jMatcher.region(3, 7);
+
+        // With anchoring bounds (default), $ should match at region end
+        assertEquals(javaMatcher.find(), pcre4jMatcher.find());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void anchoringBoundsDollarWithRegionDisabled(IPcre2 api) {
+        // Test that $ does NOT match at region end with anchoring bounds disabled
+        var regex = "test$";
+        var input = "XXXtestYYY";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        javaMatcher.region(3, 7).useAnchoringBounds(false);
+        pcre4jMatcher.region(3, 7).useAnchoringBounds(false);
+
+        // With non-anchoring bounds, $ should NOT match at region end (only at true input end)
+        assertEquals(javaMatcher.find(), pcre4jMatcher.find());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void anchoringBoundsLookingAtWithRegion(IPcre2 api) {
+        // Test lookingAt() with ^ pattern in a region
+        var regex = "^test";
+        var input = "XXXtestYYY";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        javaMatcher.region(3, 7);
+        pcre4jMatcher.region(3, 7);
+
+        // With anchoring bounds (default), ^ should match at region start in lookingAt
+        assertEquals(javaMatcher.lookingAt(), pcre4jMatcher.lookingAt());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void anchoringBoundsLookingAtWithRegionDisabled(IPcre2 api) {
+        // Test lookingAt() with ^ pattern in a region with anchoring bounds disabled
+        var regex = "^test";
+        var input = "XXXtestYYY";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        javaMatcher.region(3, 7).useAnchoringBounds(false);
+        pcre4jMatcher.region(3, 7).useAnchoringBounds(false);
+
+        // With non-anchoring bounds, ^ should NOT match at region start in lookingAt
+        assertEquals(javaMatcher.lookingAt(), pcre4jMatcher.lookingAt());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void anchoringBoundsMatchesWithRegion(IPcre2 api) {
+        // Test matches() with ^ and $ pattern in a region
+        var regex = "^test$";
+        var input = "XXXtestYYY";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        javaMatcher.region(3, 7);
+        pcre4jMatcher.region(3, 7);
+
+        // With anchoring bounds (default), ^test$ should match the region content
+        assertEquals(javaMatcher.matches(), pcre4jMatcher.matches());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void anchoringBoundsMatchesWithRegionDisabled(IPcre2 api) {
+        // Test matches() with ^ and $ pattern in a region with anchoring bounds disabled
+        var regex = "^test$";
+        var input = "XXXtestYYY";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        javaMatcher.region(3, 7).useAnchoringBounds(false);
+        pcre4jMatcher.region(3, 7).useAnchoringBounds(false);
+
+        // With non-anchoring bounds, ^test$ should NOT match (anchors won't match at region boundaries)
+        assertEquals(javaMatcher.matches(), pcre4jMatcher.matches());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void anchoringBoundsPreservedAfterReset(IPcre2 api) {
+        var regex = "test";
+        var input = "test";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        javaMatcher.useAnchoringBounds(false);
+        pcre4jMatcher.useAnchoringBounds(false);
+
+        javaMatcher.reset();
+        pcre4jMatcher.reset();
+
+        // Anchoring bounds setting should be preserved after reset
+        assertEquals(javaMatcher.hasAnchoringBounds(), pcre4jMatcher.hasAnchoringBounds());
+        assertFalse(pcre4jMatcher.hasAnchoringBounds());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void anchoringBoundsPreservedAfterResetWithInput(IPcre2 api) {
+        var regex = "test";
+        var input = "test";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        javaMatcher.useAnchoringBounds(false);
+        pcre4jMatcher.useAnchoringBounds(false);
+
+        javaMatcher.reset("newtest");
+        pcre4jMatcher.reset("newtest");
+
+        // Anchoring bounds setting should be preserved after reset with new input
+        assertEquals(javaMatcher.hasAnchoringBounds(), pcre4jMatcher.hasAnchoringBounds());
+        assertFalse(pcre4jMatcher.hasAnchoringBounds());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void anchoringBoundsWithFullInput(IPcre2 api) {
+        // When region covers full input, anchoring bounds should have no effect
+        var regex = "^test$";
+        var input = "test";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        // Test with anchoring bounds enabled (default)
+        assertEquals(javaMatcher.matches(), pcre4jMatcher.matches());
+        assertTrue(pcre4jMatcher.matches());
+
+        // Test with anchoring bounds disabled - should still match since region = full input
+        javaMatcher.reset().useAnchoringBounds(false);
+        pcre4jMatcher.reset().useAnchoringBounds(false);
+        assertEquals(javaMatcher.matches(), pcre4jMatcher.matches());
+        assertTrue(pcre4jMatcher.matches());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void anchoringBoundsWordBoundaryWithRegion(IPcre2 api) {
+        // Test that \b (word boundary) behavior with regions
+        var regex = "\\bword\\b";
+        var input = "XXXword YYY";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        javaMatcher.region(3, 8);
+        pcre4jMatcher.region(3, 8);
+
+        // With anchoring bounds, \b should match at region boundaries
+        assertEquals(javaMatcher.find(), pcre4jMatcher.find());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void anchoringBoundsWordBoundaryWithRegionDisabled(IPcre2 api) {
+        // Test that \b (word boundary) behavior with regions and non-anchoring bounds.
+        // Note: In Java, useAnchoringBounds(false) only affects ^ and $.
+        // Word boundaries (\b) are controlled by useTransparentBounds() which is NOT yet implemented.
+        // With transparent bounds disabled (the default), \b treats region boundaries as word boundaries
+        // regardless of the anchoringBounds setting.
+        var regex = "\\bword\\b";
+        var input = "XXXword YYY";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        javaMatcher.region(3, 8).useAnchoringBounds(false);
+        pcre4jMatcher.region(3, 8).useAnchoringBounds(false);
+
+        // With transparent bounds disabled (default), \b sees region boundaries as word boundaries,
+        // so \bword\b matches at region start even though "XXX" is adjacent in full input.
+        assertEquals(javaMatcher.find(), pcre4jMatcher.find());
+    }
+
 }


### PR DESCRIPTION
## Summary

- Implement `useAnchoringBounds(boolean)` and `hasAnchoringBounds()` methods for `Matcher` class
- Provides control over whether region boundaries are treated as line anchors (`^` and `$`)
- When anchoring bounds is true (default), region boundaries act as subject start/end for anchor matching

## Changes

- Added `anchoringBounds` field with default value `true` (matching `java.util.regex` behavior)
- Implemented `useAnchoringBounds(boolean)` to set anchoring bounds mode
- Implemented `hasAnchoringBounds()` to query current anchoring bounds setting
- Integrated anchoring bounds with region handling using PCRE2's `NOTBOL`/`NOTEOL` match options
- Refactored region handling logic into `RegionSubject` record and helper methods to reduce code duplication

## Test Plan

- [x] Added 16 comprehensive tests for anchoring bounds functionality
- [x] Tests verify behavior matches `java.util.regex.Matcher` across various scenarios
- [x] All 172 regex module tests pass
- [x] Checkstyle passes

Fixes #115

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)