### PR TITLE
(feat) ffm: update to Java 22 finalized FFM API

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
           - semeru
           - oracle
 #          - dragonwell
-        java-version: [ 21 ]
+        java-version: [ 22 ]
         pcre2-version: [ '10.42', '10.43', '10.47' ]
 
     runs-on: ${{ matrix.os }}
@@ -84,11 +84,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up temurin-jdk-21
+      - name: Set up temurin-jdk-22
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 22
 
       - name: Set up Git Hub Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,11 +17,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up temurin-jdk-21
+      - name: Set up temurin-jdk-22
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 22
 
       - name: Cache Gradle packages
         uses: actions/cache@v4

--- a/README.md
+++ b/README.md
@@ -193,12 +193,11 @@ shared library. For this backend to work, the `pcre2` shared library must be ins
 ### `ffm`
 
 The `ffm` backend uses
-the [Foreign Functions and Memory API](https://docs.oracle.com/en/java/javase/21/core/foreign-function-and-memory-api.html)
+the [Foreign Functions and Memory API](https://docs.oracle.com/en/java/javase/22/core/foreign-function-and-memory-api.html)
 to invoke the `pcre2` shared library. For this backend to work, the `pcre2` shared library must be installed on the
 system and be visible via `java.library.path`.
 
-Note that `--enable-preview` must be passed to the Java compiler to enable the preview features for this backend to be
-used.
+Note that Java 22 or later is required for the FFM backend as the Foreign Function & Memory API was finalized in Java 22.
 
 ## Javadoc
 

--- a/ffm/build.gradle.kts
+++ b/ffm/build.gradle.kts
@@ -46,24 +46,19 @@ sourceSets {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_22
+    targetCompatibility = JavaVersion.VERSION_22
 
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(22)
     }
 
     withSourcesJar()
     withJavadocJar()
 }
 
-tasks.withType<JavaCompile> {
-    options.compilerArgs.add("--enable-preview")
-}
-
 tasks.test {
     useJUnitPlatform()
-    jvmArgs("--enable-preview")
 
     systemProperty(
         "java.library.path", listOf(
@@ -101,8 +96,7 @@ tasks.named<Jar>("sourcesJar") {
 tasks.withType<Javadoc> {
     val javadocOptions = options as CoreJavadocOptions
 
-    javadocOptions.addStringOption("source", "21")
-    javadocOptions.addBooleanOption("-enable-preview", true)
+    javadocOptions.addStringOption("source", "22")
 }
 
 publishing {

--- a/ffm/src/main/java/org/pcre4j/ffm/Pcre2.java
+++ b/ffm/src/main/java/org/pcre4j/ffm/Pcre2.java
@@ -807,7 +807,7 @@ public class Pcre2 implements IPcre2 {
         }
 
         try (var arena = Arena.ofConfined()) {
-            final var pWhere = arena.allocateArray(ValueLayout.JAVA_INT, 1);
+            final var pWhere = arena.allocate(ValueLayout.JAVA_INT);
 
             final var result = (int) pcre2_config.invokeExact(
                     what,
@@ -979,8 +979,8 @@ public class Pcre2 implements IPcre2 {
         try (var arena = Arena.ofConfined()) {
             final var pszPattern = allocateString(arena, pattern);
             final var patternSize = MemorySegment.ofAddress(getStringLength(pszPattern));
-            final var pErrorCode = arena.allocateArray(ValueLayout.JAVA_INT, 1);
-            final var pErrorOffset = arena.allocateArray(ValueLayout.JAVA_LONG, 1);
+            final var pErrorCode = arena.allocate(ValueLayout.JAVA_INT);
+            final var pErrorOffset = arena.allocate(ValueLayout.JAVA_LONG);
             final var pContext = MemorySegment.ofAddress(ccontext);
 
             final var pCode = (MemorySegment) pcre2_compile.invokeExact(
@@ -1111,7 +1111,7 @@ public class Pcre2 implements IPcre2 {
 
         try (var arena = Arena.ofConfined()) {
             final var pCode = MemorySegment.ofAddress(code);
-            final var pWhere = arena.allocateArray(ValueLayout.JAVA_INT, 1);
+            final var pWhere = arena.allocate(ValueLayout.JAVA_INT);
 
             final var result = (int) pcre2_pattern_info.invokeExact(
                     pCode,
@@ -1138,7 +1138,7 @@ public class Pcre2 implements IPcre2 {
 
         try (var arena = Arena.ofConfined()) {
             final var pCode = MemorySegment.ofAddress(code);
-            final var pWhere = arena.allocateArray(ValueLayout.JAVA_LONG, 1);
+            final var pWhere = arena.allocate(ValueLayout.JAVA_LONG);
 
             final var result = (int) pcre2_pattern_info.invokeExact(
                     pCode,
@@ -1162,7 +1162,7 @@ public class Pcre2 implements IPcre2 {
 
         try (var arena = Arena.ofConfined()) {
             final var pCode = MemorySegment.ofAddress(code);
-            final var pWhere = arena.allocateArray(ValueLayout.ADDRESS, 1);
+            final var pWhere = arena.allocate(ValueLayout.ADDRESS);
 
             final var result = (int) pcre2_pattern_info.invokeExact(
                     pCode,
@@ -1554,7 +1554,7 @@ public class Pcre2 implements IPcre2 {
             final var startOffset = MemorySegment.ofAddress(startoffset);
             final var pMatchData = MemorySegment.ofAddress(matchData);
             final var pMatchContext = MemorySegment.ofAddress(mcontext);
-            final var pWorkspace = arena.allocateArray(ValueLayout.JAVA_INT, workspace);
+            final var pWorkspace = arena.allocateFrom(ValueLayout.JAVA_INT, workspace);
             final var wsCount = MemorySegment.ofAddress(wscount);
 
             return (int) pcre2_dfa_match.invokeExact(
@@ -1865,7 +1865,7 @@ public class Pcre2 implements IPcre2 {
             final var pszReplacement = allocateString(arena, replacement);
             final var replacementLength = MemorySegment.ofAddress(getStringLength(pszReplacement));
             final var pOutputBuffer = MemorySegment.ofBuffer(outputbuffer);
-            final var pOutputLength = arena.allocateArray(ValueLayout.JAVA_LONG, 1);
+            final var pOutputLength = arena.allocate(ValueLayout.JAVA_LONG);
             pOutputLength.set(ValueLayout.JAVA_LONG, 0, outputlength[0]);
 
             final var result = (int) pcre2_substitute.invokeExact(
@@ -1901,8 +1901,8 @@ public class Pcre2 implements IPcre2 {
 
         try (var arena = Arena.ofConfined()) {
             final var pMatchData = MemorySegment.ofAddress(matchData);
-            final var pBufferPtr = arena.allocateArray(ValueLayout.ADDRESS, 1);
-            final var pBuffLen = arena.allocateArray(ValueLayout.JAVA_LONG, 1);
+            final var pBufferPtr = arena.allocate(ValueLayout.ADDRESS);
+            final var pBuffLen = arena.allocate(ValueLayout.JAVA_LONG);
 
             final var result = (int) pcre2_substring_get_bynumber.invokeExact(
                     pMatchData,
@@ -1935,7 +1935,7 @@ public class Pcre2 implements IPcre2 {
         try (var arena = Arena.ofConfined()) {
             final var pMatchData = MemorySegment.ofAddress(matchData);
             final var pBuffer = MemorySegment.ofBuffer(buffer);
-            final var pBuffLen = arena.allocateArray(ValueLayout.JAVA_LONG, 1);
+            final var pBuffLen = arena.allocate(ValueLayout.JAVA_LONG);
             pBuffLen.set(ValueLayout.JAVA_LONG, 0, bufflen[0]);
 
             final var result = (int) pcre2_substring_copy_bynumber.invokeExact(
@@ -1968,8 +1968,8 @@ public class Pcre2 implements IPcre2 {
         try (var arena = Arena.ofConfined()) {
             final var pMatchData = MemorySegment.ofAddress(matchData);
             final var pszName = allocateString(arena, name);
-            final var pBufferPtr = arena.allocateArray(ValueLayout.ADDRESS, 1);
-            final var pBuffLen = arena.allocateArray(ValueLayout.JAVA_LONG, 1);
+            final var pBufferPtr = arena.allocate(ValueLayout.ADDRESS);
+            final var pBuffLen = arena.allocate(ValueLayout.JAVA_LONG);
 
             final var result = (int) pcre2_substring_get_byname.invokeExact(
                     pMatchData,
@@ -2006,7 +2006,7 @@ public class Pcre2 implements IPcre2 {
             final var pMatchData = MemorySegment.ofAddress(matchData);
             final var pszName = allocateString(arena, name);
             final var pBuffer = MemorySegment.ofBuffer(buffer);
-            final var pBuffLen = arena.allocateArray(ValueLayout.JAVA_LONG, 1);
+            final var pBuffLen = arena.allocate(ValueLayout.JAVA_LONG);
             pBuffLen.set(ValueLayout.JAVA_LONG, 0, bufflen[0]);
 
             final var result = (int) pcre2_substring_copy_byname.invokeExact(
@@ -2046,7 +2046,7 @@ public class Pcre2 implements IPcre2 {
                 throw new IllegalArgumentException("length must be an array of length 1");
             }
 
-            final var pLength = arena.allocateArray(ValueLayout.JAVA_LONG, 1);
+            final var pLength = arena.allocate(ValueLayout.JAVA_LONG);
 
             final var result = (int) pcre2_substring_length_byname.invokeExact(
                     pMatchData,
@@ -2082,7 +2082,7 @@ public class Pcre2 implements IPcre2 {
         }
 
         try (var arena = Arena.ofConfined()) {
-            final var pLength = arena.allocateArray(ValueLayout.JAVA_LONG, 1);
+            final var pLength = arena.allocate(ValueLayout.JAVA_LONG);
 
             final var result = (int) pcre2_substring_length_bynumber.invokeExact(
                     pMatchData,
@@ -2124,9 +2124,9 @@ public class Pcre2 implements IPcre2 {
 
         try (var arena = Arena.ofConfined()) {
             final var pMatchData = MemorySegment.ofAddress(matchData);
-            final var pListPtr = arena.allocateArray(ValueLayout.ADDRESS, 1);
+            final var pListPtr = arena.allocate(ValueLayout.ADDRESS);
             final var pLengthsPtr = lengthsptr != null
-                    ? arena.allocateArray(ValueLayout.ADDRESS, 1)
+                    ? arena.allocate(ValueLayout.ADDRESS)
                     : MemorySegment.NULL;
 
             final var result = (int) pcre2_substring_list_get.invokeExact(
@@ -2251,7 +2251,7 @@ public class Pcre2 implements IPcre2 {
 
         try (var arena = Arena.ofConfined()) {
             // Create an array of pointers for the codes
-            final var pCodes = arena.allocateArray(ValueLayout.ADDRESS, numberOfCodes);
+            final var pCodes = arena.allocate(ValueLayout.ADDRESS, numberOfCodes);
             for (int i = 0; i < numberOfCodes; i++) {
                 pCodes.setAtIndex(ValueLayout.ADDRESS, i, MemorySegment.ofAddress(codes[i]));
             }
@@ -2296,10 +2296,10 @@ public class Pcre2 implements IPcre2 {
 
         try (var arena = Arena.ofConfined()) {
             // Allocate memory for the output array of pointers
-            final var pCodes = arena.allocateArray(ValueLayout.ADDRESS, numberOfCodes);
+            final var pCodes = arena.allocate(ValueLayout.ADDRESS, numberOfCodes);
 
             // Copy the input bytes to native memory
-            final var pBytes = arena.allocateArray(ValueLayout.JAVA_BYTE, bytes.length);
+            final var pBytes = arena.allocate(ValueLayout.JAVA_BYTE, bytes.length);
             pBytes.copyFrom(MemorySegment.ofArray(bytes));
 
             final var pGContext = MemorySegment.ofAddress(gcontext);
@@ -2348,7 +2348,7 @@ public class Pcre2 implements IPcre2 {
         }
 
         try (var arena = Arena.ofConfined()) {
-            final var pBytes = arena.allocateArray(ValueLayout.JAVA_BYTE, bytes.length);
+            final var pBytes = arena.allocate(ValueLayout.JAVA_BYTE, bytes.length);
             pBytes.copyFrom(MemorySegment.ofArray(bytes));
 
             return (int) pcre2_serialize_get_number_of_codes.invokeExact(
@@ -2372,7 +2372,7 @@ public class Pcre2 implements IPcre2 {
     private MemorySegment allocateString(Arena arena, String str) {
         if (codeUnitSize == 1) {
             // For UTF-8, use the built-in method which adds null terminator
-            return arena.allocateUtf8String(str);
+            return arena.allocateFrom(str);
         } else {
             // For UTF-16 and UTF-32, encode manually with null terminator
             final var bytes = str.getBytes(charset);

--- a/ffm/src/test/java/org/pcre4j/ffm/Pcre2Tests.java
+++ b/ffm/src/test/java/org/pcre4j/ffm/Pcre2Tests.java
@@ -200,7 +200,7 @@ public class Pcre2Tests extends org.pcre4j.test.Pcre2Tests {
         // Read the converted pattern from native memory
         MemorySegment pConvertedPattern = MemorySegment.ofAddress(buffer[0])
                 .reinterpret(blength[0] + 1); // +1 for null terminator
-        String convertedPattern = pConvertedPattern.getUtf8String(0);
+        String convertedPattern = pConvertedPattern.getString(0);
 
         // Compile the converted pattern
         int[] errorcode = new int[1];

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -37,6 +37,16 @@ configurations {
     implementation {
         resolutionStrategy.failOnVersionConflict()
     }
+    testCompileClasspath {
+        attributes {
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 22)
+        }
+    }
+    testRuntimeClasspath {
+        attributes {
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 22)
+        }
+    }
 }
 
 sourceSets {
@@ -50,7 +60,7 @@ java {
     targetCompatibility = JavaVersion.VERSION_21
 
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(22)
     }
 
     withSourcesJar()
@@ -59,7 +69,6 @@ java {
 
 tasks.test {
     useJUnitPlatform()
-    jvmArgs("--enable-preview")
 
     systemProperty(
         "jna.library.path", listOf(
@@ -86,10 +95,6 @@ tasks.test {
     }
 
     finalizedBy(tasks.jacocoTestReport)
-}
-
-tasks.named<JavaCompile>("compileTestJava") {
-    options.compilerArgs.add("--enable-preview")
 }
 
 tasks.jacocoTestReport {

--- a/regex/build.gradle.kts
+++ b/regex/build.gradle.kts
@@ -38,6 +38,16 @@ configurations {
     implementation {
         resolutionStrategy.failOnVersionConflict()
     }
+    testCompileClasspath {
+        attributes {
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 22)
+        }
+    }
+    testRuntimeClasspath {
+        attributes {
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 22)
+        }
+    }
 }
 
 sourceSets {
@@ -51,7 +61,7 @@ java {
     targetCompatibility = JavaVersion.VERSION_21
 
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(22)
     }
 
     withSourcesJar()
@@ -60,7 +70,6 @@ java {
 
 tasks.test {
     useJUnitPlatform()
-    jvmArgs("--enable-preview")
 
     systemProperty(
         "jna.library.path", listOf(
@@ -87,10 +96,6 @@ tasks.test {
     }
 
     finalizedBy(tasks.jacocoTestReport)
-}
-
-tasks.named<JavaCompile>("compileTestJava") {
-    options.compilerArgs.add("--enable-preview")
 }
 
 tasks.jacocoTestReport {


### PR DESCRIPTION
Attempts to tackle #193 

## Summary
  - Update FFM module to Java 22 where the Foreign Function & Memory API was finalized (JEP 454)
  - Remove `--enable-preview` flags as FFM is no longer a preview feature
  - Update FFM API calls for Java 22 compatibility (`allocateArray` → `allocate`, `allocateUtf8String` → `allocateFrom`, `getUtf8String` → `getString`)

## Test plan
I compiled and published this to my local Maven repository, and was able to use the ffm backend in a Java 25 project.