### PR TITLE
(fix) docs: use correct variable name in Low-Level Usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ public class Usage {
             );
         }
 
-        api.codeFree(code);
+        pcre2.codeFree(code);
     }
 }
 ```


### PR DESCRIPTION
## Summary

- Fixes undefined variable reference in README.md Low-Level Usage example
- Line 176 used `api.codeFree(code)` but the variable is named `pcre2` (defined on line 165)

Fixes #67

## Test plan

- [x] Verified the code example now uses consistent variable naming (`pcre2` throughout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)