### PR TITLE
(feat) regex: implement UNICODE_CASE flag support

### DIFF
--- a/regex/src/main/java/org/pcre4j/regex/Matcher.java
+++ b/regex/src/main/java/org/pcre4j/regex/Matcher.java
@@ -1369,6 +1369,8 @@ public class Matcher implements java.util.regex.MatchResult {
             if ((flags & Pattern.UNICODE_CHARACTER_CLASS) != 0) {
                 compileOptions.add(Pcre2CompileOption.UCP);
             }
+            // Note: UNICODE_CASE flag is recognized for API compatibility but has no additional effect
+            // since PCRE2 with UTF mode (always enabled) already performs Unicode-aware case folding.
             if ((flags & Pattern.COMMENTS) != 0) {
                 compileOptions.add(Pcre2CompileOption.EXTENDED);
             }

--- a/regex/src/main/java/org/pcre4j/regex/Pattern.java
+++ b/regex/src/main/java/org/pcre4j/regex/Pattern.java
@@ -78,8 +78,25 @@ public class Pattern {
      */
     public static final int COMMENTS = java.util.regex.Pattern.COMMENTS;
 
+    /**
+     * A {@link java.util.regex.Pattern#UNICODE_CASE}-compatible flag that enables Unicode-aware case folding.
+     * <p>
+     * When this flag is specified, case-insensitive matching (when enabled by the {@link #CASE_INSENSITIVE} flag)
+     * is done in a manner consistent with the Unicode Standard. By default in {@link java.util.regex.Pattern},
+     * case-insensitive matching assumes that only characters in the US-ASCII charset are being matched.
+     * </p>
+     * <p>
+     * <strong>Implementation Note:</strong> PCRE2 with UTF mode (which PCRE4J always enables) already performs
+     * Unicode-aware case folding when {@link #CASE_INSENSITIVE} is used. This flag is provided for API
+     * compatibility with {@link java.util.regex.Pattern} and has no additional effect on PCRE2's behavior
+     * since Unicode case folding is already enabled by default.
+     * </p>
+     *
+     * @see #CASE_INSENSITIVE
+     */
+    public static final int UNICODE_CASE = java.util.regex.Pattern.UNICODE_CASE;
+
     // TODO: public static final int CANON_EQ = java.util.regex.Pattern.CANON_EQ;
-    // TODO: public static final int UNICODE_CASE = java.util.regex.Pattern.UNICODE_CASE;
     /* package-private */ final Pcre2Code code;
     /* package-private */ final Pcre2Code matchingCode;
     /* package-private */ final Pcre2Code lookingAtCode;
@@ -126,6 +143,8 @@ public class Pattern {
         if ((flags & COMMENTS) != 0) {
             compileOptions.add(Pcre2CompileOption.EXTENDED);
         }
+        // Note: UNICODE_CASE flag is recognized for API compatibility but has no additional effect
+        // since PCRE2 with UTF mode (always enabled) already performs Unicode-aware case folding.
 
         final var compileContext = new Pcre2CompileContext(api, null);
         if ((flags & UNIX_LINES) != 0) {


### PR DESCRIPTION
## Summary

Implements `Pattern.UNICODE_CASE` flag for `java.util.regex.Pattern` API compatibility.

**Key implementation insight**: PCRE2 with UTF mode (which PCRE4J always enables) already performs Unicode-aware case folding when `CASE_INSENSITIVE` is used. This flag is provided for API compatibility and has no additional effect on PCRE2's behavior.

## Changes

- Add `Pattern.UNICODE_CASE` flag constant (value `0x40`)
- Add comprehensive JavaDoc explaining the behavioral difference from java.util.regex
- Add documentation comments in `Pattern.java` and `Matcher.java`
- Add unit tests for:
  - Flag value verification
  - Kelvin sign (U+212A) Unicode case folding
  - Long S (U+017F) Unicode case folding
  - Basic case-insensitive matching
  - `flags()` method returning UNICODE_CASE
  - Negative test: UNICODE_CASE alone doesn't enable case-insensitive matching

## Behavioral Note

| Behavior | java.util.regex | PCRE4J |
|----------|-----------------|--------|
| `CASE_INSENSITIVE` alone | ASCII-only case folding | Unicode case folding (due to UTF mode) |
| `CASE_INSENSITIVE \| UNICODE_CASE` | Unicode case folding | Unicode case folding |

This is a documented behavioral difference - PCRE4J provides Unicode case folding by default.

Fixes #119

## Test Plan

- [x] All existing tests pass
- [x] New tests added for UNICODE_CASE functionality
- [x] Tests run on both JNA and FFM backends
- [x] Checkstyle passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)