### PR TITLE
(chore) gradle: upgrade to 9.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
 reporting {
     reports {
         register<JacocoCoverageReport>("jacocoAggregatedTestReport") {
-            testType = TestSuiteType.UNIT_TEST
+            testSuiteName = "test"
         }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

- Upgrade Gradle from 8.12 to 9.3.0
- Update JaCoCo report configuration for Gradle 9.x compatibility (`testType` → `testSuiteName`)

## Changes

- `gradle/wrapper/gradle-wrapper.properties`: Update distribution URL to 9.3.0
- `build.gradle.kts`: Replace deprecated `testType = TestSuiteType.UNIT_TEST` with `testSuiteName = "test"` (API removed in Gradle 8.13)

## Test plan

- [x] Full build passes: `./gradlew build`
- [x] JaCoCo aggregated report generates: `./gradlew jacocoAggregatedTestReport`
- [x] No deprecation warnings from Gradle

Fixes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)