### PR TITLE
(docs) add community health files

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: alexey-pelykh

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Description
+
+<!-- Describe your changes. What does this PR do and why? -->
+
+Fixes #
+
+## Checklist
+
+- [ ] Tests pass (`./gradlew build`)
+- [ ] Checkstyle passes (`./gradlew checkstyleMain checkstyleTest`)
+- [ ] Commits are signed off (DCO: `git commit -s`)
+- [ ] `PCRE2_API.md` updated (if new PCRE2 API bindings are added)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at https://github.com/alexey-pelykh/pcre4j/issues. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing to PCRE4J
+
+Thank you for your interest in contributing to PCRE4J! This document provides guidelines and instructions for contributing.
+
+## Reporting Bugs
+
+Please use the [bug report template](https://github.com/alexey-pelykh/pcre4j/issues/new?template=bug_report.yml) to report bugs. Include as much detail as possible, including your Java version, operating system, and PCRE2 library version.
+
+## Requesting Features
+
+Use the [feature request template](https://github.com/alexey-pelykh/pcre4j/issues/new?template=feature_request.yml) to suggest new features or enhancements.
+
+## Submitting Pull Requests
+
+1. Fork the repository and create a branch from `main`
+2. Make your changes
+3. Ensure the build passes (see [Build Instructions](#build-instructions) below)
+4. Submit a pull request against `main`
+
+## Developer Certificate of Origin (DCO)
+
+All commits must be signed off to certify that you have the right to submit the contribution under the project's license. Add a `Signed-off-by` line to every commit message:
+
+```
+(feat) add new feature
+
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+Use `git commit -s` to automatically add this line. If you forget, you can amend the last commit with `git commit --amend -s`.
+
+## Code Conventions
+
+- **Line length**: 120 characters (enforced by Checkstyle)
+- **Indentation**: 4 spaces (no tabs)
+- **Charset**: UTF-8 with LF line endings
+- **Copyright header**: Required on all source files (LGPL-3.0 notice)
+- **JavaDoc**: Required on all public APIs
+
+## Commit Message Format
+
+Use the format `(type) brief description`:
+
+- `(feat)` — new feature
+- `(fix)` — bug fix
+- `(chore)` — maintenance (build, dependencies, CI)
+- `(docs)` — documentation changes
+
+Examples:
+- `(feat) regex: implement CANON_EQ flag support`
+- `(fix) matcher: handle empty region anchor semantics`
+- `(chore) gradle: upgrade to 9.3.0`
+
+## Build Instructions
+
+### Prerequisites
+
+PCRE2 must be installed on your system:
+
+- **Ubuntu/Debian**: `sudo apt install libpcre2-8-0`
+- **macOS**: `brew install pcre2`
+- **Windows**: Download PCRE2 DLL and add to PATH
+
+### Building and Testing
+
+```bash
+# Full build with tests
+./gradlew build -Dpcre2.library.path=/usr/lib/x86_64-linux-gnu
+
+# macOS (Apple Silicon)
+./gradlew build -Dpcre2.library.path=/opt/homebrew/lib
+
+# macOS (Intel)
+./gradlew build -Dpcre2.library.path=/usr/local/lib
+
+# Code style check
+./gradlew checkstyleMain checkstyleTest
+```
+
+### Before Submitting
+
+Ensure the following pass:
+
+- `./gradlew build` — compilation and tests
+- `./gradlew checkstyleMain checkstyleTest` — code style
+
+If your changes add new PCRE2 API bindings, update `PCRE2_API.md` to mark the API as implemented.
+
+## License
+
+By contributing to PCRE4J, you agree that your contributions will be licensed under the [GNU Lesser General Public License v3.0](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in PCRE4J, please report it through [GitHub Security Advisories](https://github.com/alexey-pelykh/pcre4j/security/advisories/new). This ensures the issue is handled confidentially.
+
+**Please do not open a public issue for security vulnerabilities.**
+
+## Scope
+
+This security policy covers the **PCRE4J binding layer** — the Java code in this repository that interfaces with the PCRE2 native library.
+
+Security issues in the **PCRE2 native library itself** should be reported to the [PCRE2 upstream project](https://github.com/PCRE2Project/pcre2).
+
+## Response
+
+We aim to acknowledge security reports within 72 hours and provide a timeline for a fix. Critical vulnerabilities will be prioritized for patching.


### PR DESCRIPTION
## Summary
- Add `.github/FUNDING.yml` with GitHub Sponsors configuration
- Add `CONTRIBUTING.md` with bug reporting, PR workflow, DCO requirement, code conventions, build instructions, and commit message format
- Add `CODE_OF_CONDUCT.md` using Contributor Covenant v2.1
- Add `SECURITY.md` with vulnerability reporting via GitHub Security Advisories and PCRE4J vs PCRE2 upstream scope
- Add `.github/PULL_REQUEST_TEMPLATE.md` with description, issue linking, and checklist

## Test plan
- [ ] Verify FUNDING.yml renders sponsor button on GitHub repo page
- [ ] Verify PR template appears when creating new PRs
- [ ] Verify CONTRIBUTING.md, CODE_OF_CONDUCT.md, and SECURITY.md are linked from GitHub's Community Standards page

🤖 Generated with [Claude Code](https://claude.com/claude-code)