### PR TITLE
(feat) regex: implement Pattern.splitAsStream

### DIFF
--- a/regex/src/main/java/org/pcre4j/regex/Pattern.java
+++ b/regex/src/main/java/org/pcre4j/regex/Pattern.java
@@ -19,11 +19,13 @@ import org.pcre4j.api.IPcre2;
 
 import java.text.Normalizer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Stream;
 
 /**
  * A compiled representation of a regular expression that uses the PCRE library yet aims to have a
@@ -470,8 +472,6 @@ public class Pattern {
         return result.subList(0, resultSize).toArray(new String[resultSize]);
     }
 
-    // TODO: splitAsStream(CharSequence input)
-
     /**
      * Returns a map of named groups in this pattern.
      *
@@ -484,5 +484,15 @@ public class Pattern {
     @Override
     public String toString() {
         return regex;
+    }
+
+    /**
+     * Creates a stream from the given input sequence around matches of this pattern.
+     *
+     * @param input the character sequence to be split
+     * @return a stream of strings computed by splitting the input around matches of this pattern
+     */
+    public Stream<String> splitAsStream(CharSequence input) {
+        return Arrays.stream(split(input, 0));
     }
 }

--- a/regex/src/test/java/org/pcre4j/regex/PatternTests.java
+++ b/regex/src/test/java/org/pcre4j/regex/PatternTests.java
@@ -937,4 +937,31 @@ public class PatternTests {
         assertTrue(pcre4jMatcher.matches());
     }
 
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void splitAsStream(IPcre2 api) {
+        // Test splitAsStream against Java Pattern for multiple inputs and edge cases
+        Object[][] cases = new Object[][]{
+                {",", "a,b,c"},
+                {",", "a,b,c,"},
+                {",", ""},
+                {",", "abc"},
+                {"\\d", "a1b2c"}
+        };
+
+        for (Object[] c : cases) {
+            String regex = (String) c[0];
+            String input = (String) c[1];
+
+            var javaPattern = java.util.regex.Pattern.compile(regex);
+            var pcre4jPattern = Pattern.compile(api, regex);
+
+            assertArrayEquals(
+                    javaPattern.splitAsStream(input).toArray(),
+                    pcre4jPattern.splitAsStream(input).toArray(),
+                    "Mismatch for regex=" + regex + ", input=" + input
+            );
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary

Implement `Pattern.splitAsStream(CharSequence)` method for API compatibility with `java.util.regex.Pattern`.

- Add `splitAsStream` method wrapping existing `split(input, 0)` via `Arrays.stream()`
- Add parameterized tests covering: basic split, trailing empty strings, empty input, no-match, regex patterns
- Add JavaDoc
- Remove TODO comment

Based on the work from #166 by @Subekxya.

Closes #114

Co-Authored-By: Subekxya <subekxyasapkota35@gmail.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>