### PR TITLE
(fix) docs: fix broken links in README and javadoc index

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,4 +291,4 @@ The `ffm` module is packaged as a Multi-Release JAR supporting both:
 
 ## Javadoc
 
-Please see [the Javadoc Index](./javadoc/index.md) for the detailed API documentation.
+Please see [the Javadoc Index](./gh-pages/javadoc/index.md) for the detailed API documentation.

--- a/gh-pages/javadoc/index.md
+++ b/gh-pages/javadoc/index.md
@@ -4,4 +4,4 @@
 - [`org.pcre4j.lib`](./lib)
 - [`org.pcre4j.jna`](./jna)
 - [`org.pcre4j.ffm`](./ffm)
-- [`org.pcre4j.regex`](./ffm)
+- [`org.pcre4j.regex`](./regex)


### PR DESCRIPTION
## Summary
- Fix README.md javadoc link: `./javadoc/index.md` → `./gh-pages/javadoc/index.md`
- Fix gh-pages/javadoc/index.md: `org.pcre4j.regex` link pointed to `./ffm` instead of `./regex`

Fixes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)