### PR TITLE
(chore) ci: pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,25 +40,25 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Always need JDK 21 for building base MRJAR classes
       - name: Set up temurin-jdk-21 (for MRJAR base)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 21
 
       # Always need JDK 22 for building MRJAR overlay classes
       - name: Set up temurin-jdk-22 (for MRJAR overlay)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 22
 
       # Set up the test runtime Java version (available via toolchain, not JAVA_HOME)
       - name: Set up ${{ matrix.java-distribution }}-jdk-${{ matrix.java-version }} (test runtime)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: ${{ matrix.java-distribution }}
           java-version: ${{ matrix.java-version }}
@@ -68,7 +68,7 @@ jobs:
         run: echo "JAVA_HOME=$JAVA_HOME_21_X64" >> $GITHUB_ENV
 
       - name: Cache Gradle packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.gradle/caches
@@ -78,7 +78,7 @@ jobs:
 
       - name: Cache PCRE2
         if: ${{ matrix.os == 'ubuntu-24.04' }}
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: cache-pcre2
         with:
           path: /opt/pcre2
@@ -113,26 +113,26 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Need both JDKs for MRJAR build
       - name: Set up temurin-jdk-21 (for MRJAR base)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 21
 
       - name: Set up temurin-jdk-22 (for MRJAR overlay)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 22
 
       - name: Set up Git Hub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Cache Gradle packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.gradle/caches
@@ -144,7 +144,7 @@ jobs:
         run: ./gradlew checkstyleMain checkstyleTest
 
       - name: Cache PCRE2
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: cache-pcre2
         with:
           path: /opt/pcre2
@@ -186,13 +186,13 @@ jobs:
           cp -a regex/build/docs/javadoc/. build/gh-pages/javadoc/regex
 
       - name: Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: build/reports/jacoco/jacocoAggregatedTestReport/jacoco.xml
 
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: build/gh-pages
 
@@ -235,8 +235,8 @@ jobs:
 
     steps:
       - name: Set up Git Hub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Publish GitHub Pages
         id: publish-github-pages
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,23 +15,23 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Need both JDKs for MRJAR build
       - name: Set up temurin-jdk-21 (for MRJAR base)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 21
 
       - name: Set up temurin-jdk-22 (for MRJAR overlay)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 22
 
       - name: Cache Gradle packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
## Summary
* Pin all GitHub Actions in CI and Release workflows to commit SHAs instead of mutable version tags
* Adds version comments (e.g. `# v4`) for readability alongside the SHA references

## Test plan
- [ ] CI workflow runs successfully with SHA-pinned actions
- [ ] All existing jobs (compatibility, package, publish-github-pages) execute correctly

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)