### PR TITLE
(chore) ci: add job timeout limits and tighten permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,9 +8,16 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
 
   compatibility:
+    permissions:
+      contents: read
+
+    timeout-minutes: 30
+
     strategy:
       matrix:
         os: [ ubuntu-24.04 ]
@@ -107,6 +114,8 @@ jobs:
 
     permissions:
       contents: read
+
+    timeout-minutes: 30
 
     needs:
       - compatibility
@@ -225,6 +234,8 @@ jobs:
       contents: read
       pages: write
       id-token: write
+
+    timeout-minutes: 10
 
     needs:
       - package

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,13 +5,16 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 
+permissions: {}
+
 jobs:
   package:
     runs-on: ubuntu-24.04
 
     permissions:
       contents: read
-      packages: write
+
+    timeout-minutes: 30
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
* Add `timeout-minutes` to all CI and Release workflow jobs (30 min for build/test jobs, 10 min for pages deployment)
* Add top-level `permissions: {}` to both workflows to deny all permissions by default
* Add explicit `permissions: contents: read` to the `compatibility` job which previously inherited defaults
* Remove unused `packages: write` permission from the Release workflow (publishes to Maven Central, not GitHub Packages)

Fixes #213

## Test plan
- [ ] CI workflow runs successfully with the new timeout limits and permissions
- [ ] All matrix jobs in `compatibility` can still checkout code and run tests
- [ ] `package` job can still build, upload pages artifact, and publish snapshots
- [ ] `publish-github-pages` job can still deploy pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)