### PR TITLE
(feat) ci: add Dependabot for dependency vulnerability scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` to enable automated dependency vulnerability scanning
- Configure weekly checks for both Gradle dependencies and GitHub Actions

Fixes #216

## Test plan

- [ ] Verify Dependabot picks up the configuration after merge
- [ ] Confirm Dependabot creates PRs for outdated/vulnerable dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)