### PR TITLE
(chore) ci: verify PCRE2 source tarball integrity

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,13 @@ jobs:
 #          - dragonwell
         java-version: [ 21, 22, 25 ]
         pcre2-version: [ '10.42', '10.43', '10.47' ]
+        include:
+          - pcre2-version: '10.42'
+            pcre2-sha256: 'c33b418e3b936ee3153de2c61cc638e7e4fe3156022a5c77d0711bcbb9d64f1f'
+          - pcre2-version: '10.43'
+            pcre2-sha256: '889d16be5abb8d05400b33c25e151638b8d4bac0e2d9c76e9d6923118ae8a34e'
+          - pcre2-version: '10.47'
+            pcre2-sha256: 'c08ae2388ef333e8403e670ad70c0a11f1eed021fd88308d7e02f596fcd9dc16'
         exclude:
           # Some distributions may not have all Java versions yet
           - java-distribution: adopt-hotspot
@@ -91,11 +98,17 @@ jobs:
           path: /opt/pcre2
           key: pcre2-${{ matrix.pcre2-version }}-${{ matrix.os }}
 
+      - name: Download and verify PCRE2 source
+        if: ${{ matrix.os == 'ubuntu-24.04' && steps.cache-pcre2.outputs.cache-hit != 'true' }}
+        run: |
+          curl -Lo pcre2.tar.gz "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${{ matrix.pcre2-version }}/pcre2-${{ matrix.pcre2-version }}.tar.gz"
+          echo "${{ matrix.pcre2-sha256 }}  pcre2.tar.gz" | sha256sum -c
+          tar xzf pcre2.tar.gz
+
       - name: Build PCRE2 from source
         if: ${{ matrix.os == 'ubuntu-24.04' && steps.cache-pcre2.outputs.cache-hit != 'true' }}
         run: |
           sudo apt-get install -y build-essential
-          curl -L https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${{ matrix.pcre2-version }}/pcre2-${{ matrix.pcre2-version }}.tar.gz | tar xz
           cd pcre2-${{ matrix.pcre2-version }}
           ./configure --prefix=/opt/pcre2 --enable-jit --enable-pcre2-16 --enable-pcre2-32
           make -j$(nproc)
@@ -159,11 +172,17 @@ jobs:
           path: /opt/pcre2
           key: pcre2-10.47-ubuntu-24.04
 
+      - name: Download and verify PCRE2 source
+        if: ${{ steps.cache-pcre2.outputs.cache-hit != 'true' }}
+        run: |
+          curl -Lo pcre2.tar.gz "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.47/pcre2-10.47.tar.gz"
+          echo "c08ae2388ef333e8403e670ad70c0a11f1eed021fd88308d7e02f596fcd9dc16  pcre2.tar.gz" | sha256sum -c
+          tar xzf pcre2.tar.gz
+
       - name: Build PCRE2 from source
         if: ${{ steps.cache-pcre2.outputs.cache-hit != 'true' }}
         run: |
           sudo apt-get install -y build-essential
-          curl -L https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.47/pcre2-10.47.tar.gz | tar xz
           cd pcre2-10.47
           ./configure --prefix=/opt/pcre2 --enable-jit --enable-pcre2-16 --enable-pcre2-32
           make -j$(nproc)


### PR DESCRIPTION
## Summary

- Add SHA256 checksum verification for PCRE2 source tarballs in CI pipeline
- Tarballs are now downloaded to a file and verified before extraction
- Checksums maintained for all three PCRE2 versions in the matrix (10.42, 10.43, 10.47)
- Build fails immediately if checksum doesn't match, preventing tampered tarball extraction

Fixes #218

## Test plan

- [ ] CI passes: compatibility job verifies checksums for all three PCRE2 versions (10.42, 10.43, 10.47)
- [ ] CI passes: package job verifies checksum for PCRE2 10.47
- [ ] Verify that `sha256sum -c` step appears in workflow logs and reports "OK"

🤖 Generated with [Claude Code](https://claude.com/claude-code)