### PR TITLE
(fix) build: fix JNA transitive dependency leak in lib test scope

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -27,8 +27,9 @@ repositories {
 
 dependencies {
     api(project(":api"))
-    testImplementation(project(":jna"))
-    testImplementation(project(":ffm"))
+    // Runtime-only: lib tests discover backends reflectively to avoid compile-time coupling
+    testRuntimeOnly(project(":jna"))
+    testRuntimeOnly(project(":ffm"))
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/lib/src/test/java/org/pcre4j/Pcre2CodeTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodeTests.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.stream.Stream;
 
 import java.util.EnumSet;
@@ -29,13 +30,27 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Pcre2CodeTests {
 
-    private static final IPcre2 JNA_PCRE2 = new org.pcre4j.jna.Pcre2();
-    private static final IPcre2 FFM_PCRE2 = new org.pcre4j.ffm.Pcre2();
+    /**
+     * Reflectively instantiates an {@link IPcre2} backend by class name.
+     *
+     * @param className the fully qualified class name of the backend
+     * @return the backend instance
+     */
+    private static IPcre2 loadBackend(String className) {
+        try {
+            return (IPcre2) Class.forName(className).getDeclaredConstructor().newInstance();
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Backend " + className + " not found on classpath", e);
+        } catch (InvocationTargetException | InstantiationException | IllegalAccessException
+                 | NoSuchMethodException e) {
+            throw new RuntimeException("Failed to instantiate backend " + className, e);
+        }
+    }
 
     private static Stream<Arguments> parameters() {
         return Stream.of(
-                Arguments.of(JNA_PCRE2),
-                Arguments.of(FFM_PCRE2)
+                Arguments.of(loadBackend("org.pcre4j.jna.Pcre2")),
+                Arguments.of(loadBackend("org.pcre4j.ffm.Pcre2"))
         );
     }
 


### PR DESCRIPTION
## Summary

- Change `testImplementation` to `testRuntimeOnly` for `:jna` and `:ffm` dependencies in `lib/build.gradle.kts`, preventing compile-time access to backend implementation classes
- Refactor `Pcre2CodeTests` to instantiate backends reflectively via `Class.forName()` instead of direct class references, enforcing the architectural boundary that `lib` depends only on the `IPcre2` interface

Fixes #219

## Test plan

- [x] `lib:compileTestJava` succeeds — confirms no compile-time references to JNA/FFM classes
- [x] `lib:test` passes — all parameterized tests work with reflective backend loading
- [x] Full `test` suite passes — no regressions in jna, ffm, or regex modules
- [x] `checkstyleMain checkstyleTest` passes — code style compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)