### PR TITLE
(feat) ci: tier CI matrix to reduce PR build time

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    # Weekly full compatibility run (Sundays at 06:00 UTC)
+    - cron: '0 6 * * 0'
 
 permissions: {}
 
@@ -21,19 +24,9 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-24.04 ]
-        java-distribution:
-          - temurin
-          - zulu
-          - adopt-hotspot
-          - adopt-openj9
-          - liberica
-          - microsoft
-          - corretto
-          - semeru
-          - oracle
-#          - dragonwell
-        java-version: [ 21, 22, 25 ]
-        pcre2-version: [ '10.42', '10.43', '10.47' ]
+        java-distribution: ${{ github.event_name == 'pull_request' && fromJson('["temurin"]') || fromJson('["temurin","zulu","adopt-hotspot","adopt-openj9","liberica","microsoft","corretto","semeru","oracle"]') }}
+        java-version: ${{ github.event_name == 'pull_request' && fromJson('[21, 25]') || fromJson('[21, 22, 25]') }}
+        pcre2-version: ${{ github.event_name == 'pull_request' && fromJson('["10.47"]') || fromJson('["10.42","10.43","10.47"]') }}
         include:
           - pcre2-version: '10.42'
             pcre2-sha256: 'c33b418e3b936ee3153de2c61cc638e7e4fe3156022a5c77d0711bcbb9d64f1f'


### PR DESCRIPTION
## Summary

- PR builds now use a minimal compatibility matrix: Temurin only, Java 21 + 25, PCRE2 10.47 (~2 jobs, ~5 min)
- Pushes to main retain the full matrix: 9 JDK distributions x 3 Java versions x 3 PCRE2 versions (~69 jobs)
- Added weekly scheduled run (Sundays 06:00 UTC) for full compatibility regression detection

## Implementation

Uses GitHub Actions `fromJson()` with conditional expressions on `github.event_name` to dynamically select matrix dimensions per trigger type.

## Test plan

- [ ] PR CI runs only ~2 compatibility jobs (Temurin, Java 21+25, PCRE2 10.47)
- [ ] All PR jobs pass
- [ ] Verify full matrix would still run on push to main (inspectable from workflow file)

Fixes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)