### PR TITLE
(feat) build: add Gradle module dependency constraints

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -26,8 +26,8 @@ repositories {
 }
 
 dependencies {
-    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 configurations {
@@ -76,43 +76,12 @@ publishing {
     publications {
         create<MavenPublication>("mavenJava") {
             from(components["java"])
-
-            groupId = "org.pcre4j"
             artifactId = project.name
-            version = project.version.toString()
 
             pom {
                 name = "org.pcre4j:${project.name}"
                 description = "PCRE4J Backend API"
-                url = "https://pcre4j.org"
-
-                licenses {
-                    license {
-                        name = "GNU Lesser General Public License v3.0"
-                        url = "https://www.gnu.org/licenses/lgpl-3.0.txt"
-                    }
-                }
-                developers {
-                    developer {
-                        name = "Alexey Pelykh"
-                        email = "alexey.pelykh@gmail.com"
-                        organization = "The PCRE4J Project"
-                        organizationUrl = "https://pcre4j.org"
-                    }
-                }
-                scm {
-                    connection = "scm:git:git://github.com/alexey-pelykh/pcre4j.git"
-                    developerConnection = "scm:git:ssh://github.com:alexey-pelykh/pcre4j.git"
-                    url = "https://github.com/alexey-pelykh/pcre4j"
-                }
             }
-        }
-    }
-
-    repositories {
-        maven {
-            name = "StagingDeploy"
-            url = uri(layout.buildDirectory.dir("staging-deploy"))
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     base
     `jacoco-report-aggregation`
-    id("org.jreleaser") version "1.22.0"
+    alias(libs.plugins.jreleaser)
 }
 
 version = findProperty("pcre4j.version") as String? ?: "0.0.0-SNAPSHOT"
@@ -26,6 +26,99 @@ reporting {
     reports {
         register<JacocoCoverageReport>("jacocoAggregatedTestReport") {
             testSuiteName = "test"
+        }
+    }
+}
+
+// ==========================================================================
+// Module dependency constraints
+// Enforces: api ← lib ← backends (jna, ffm) ← regex
+// ==========================================================================
+val allowedProjectDependencies = mapOf(
+    ":api" to emptySet(),
+    ":lib" to setOf(":api"),
+    ":jna" to setOf(":api"),
+    ":ffm" to setOf(":api"),
+    ":regex" to setOf(":api", ":lib")
+)
+
+tasks.register("checkModuleDependencies") {
+    description = "Validates module dependency constraints (api ← lib ← backends ← regex)"
+    group = "verification"
+
+    doLast {
+        val violations = mutableListOf<String>()
+        allowedProjectDependencies.forEach { (modulePath, allowed) ->
+            val subproject = project(modulePath)
+            subproject.configurations
+                .filter { it.name in setOf("api", "implementation", "compileOnly", "compileOnlyApi") }
+                .forEach { config ->
+                    config.dependencies.filterIsInstance<ProjectDependency>().forEach { dep ->
+                        val depPath = dep.path
+                        if (depPath !in allowed) {
+                            violations.add(
+                                "$modulePath → $depPath (via '${config.name}') " +
+                                    "violates allowed dependencies: $allowed"
+                            )
+                        }
+                    }
+                }
+        }
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                "Module dependency constraint violations:\n" +
+                    violations.joinToString("\n") { "  - $it" }
+            )
+        }
+        logger.lifecycle("Module dependency constraints verified: all modules comply")
+    }
+}
+
+tasks.named("check") {
+    dependsOn("checkModuleDependencies")
+}
+
+// ==========================================================================
+// Shared POM metadata for all published modules
+// ==========================================================================
+subprojects {
+    pluginManager.withPlugin("maven-publish") {
+        configure<PublishingExtension> {
+            publications.withType<MavenPublication> {
+                groupId = "org.pcre4j"
+                version = project.version.toString()
+
+                pom {
+                    url = "https://pcre4j.org"
+
+                    licenses {
+                        license {
+                            name = "GNU Lesser General Public License v3.0"
+                            url = "https://www.gnu.org/licenses/lgpl-3.0.txt"
+                        }
+                    }
+                    developers {
+                        developer {
+                            name = "Alexey Pelykh"
+                            email = "alexey.pelykh@gmail.com"
+                            organization = "The PCRE4J Project"
+                            organizationUrl = "https://pcre4j.org"
+                        }
+                    }
+                    scm {
+                        connection = "scm:git:git://github.com/alexey-pelykh/pcre4j.git"
+                        developerConnection = "scm:git:ssh://github.com:alexey-pelykh/pcre4j.git"
+                        url = "https://github.com/alexey-pelykh/pcre4j"
+                    }
+                }
+            }
+
+            repositories {
+                maven {
+                    name = "StagingDeploy"
+                    url = uri(layout.buildDirectory.dir("staging-deploy"))
+                }
+            }
         }
     }
 }

--- a/ffm/build.gradle.kts
+++ b/ffm/build.gradle.kts
@@ -27,10 +27,10 @@ repositories {
 
 dependencies {
     api(project(":api"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+    testImplementation(libs.junit.jupiter)
     testImplementation(project(":lib"))
     testImplementation(testFixtures(project(":lib")))
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 configurations {
@@ -164,7 +164,7 @@ dependencies {
     "testJava22ClassesImplementation"(project(":api"))
     "testJava22ClassesImplementation"(project(":lib"))
     "testJava22ClassesImplementation"(testFixtures(project(":lib")))
-    "testJava22ClassesImplementation"("org.junit.jupiter:junit-jupiter:5.10.2")
+    "testJava22ClassesImplementation"(libs.junit.jupiter)
 }
 
 // Compile test sources with Java 22 (no preview needed since FFM is GA)
@@ -271,43 +271,12 @@ publishing {
     publications {
         create<MavenPublication>("mavenJava") {
             from(components["java"])
-
-            groupId = "org.pcre4j"
             artifactId = project.name
-            version = project.version.toString()
 
             pom {
                 name = "org.pcre4j:${project.name}"
                 description = "PCRE4J FFM Backend"
-                url = "https://pcre4j.org"
-
-                licenses {
-                    license {
-                        name = "GNU Lesser General Public License v3.0"
-                        url = "https://www.gnu.org/licenses/lgpl-3.0.txt"
-                    }
-                }
-                developers {
-                    developer {
-                        name = "Alexey Pelykh"
-                        email = "alexey.pelykh@gmail.com"
-                        organization = "The PCRE4J Project"
-                        organizationUrl = "https://pcre4j.org"
-                    }
-                }
-                scm {
-                    connection = "scm:git:git://github.com/alexey-pelykh/pcre4j.git"
-                    developerConnection = "scm:git:ssh://github.com:alexey-pelykh/pcre4j.git"
-                    url = "https://github.com/alexey-pelykh/pcre4j"
-                }
             }
-        }
-    }
-
-    repositories {
-        maven {
-            name = "StagingDeploy"
-            url = uri(layout.buildDirectory.dir("staging-deploy"))
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,13 @@
+[versions]
+jna = "5.14.0"
+junit-jupiter = "5.10.2"
+junit-platform = "1.10.2"
+jreleaser = "1.22.0"
+
+[libraries]
+jna-platform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
+
+[plugins]
+jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }

--- a/jna/build.gradle.kts
+++ b/jna/build.gradle.kts
@@ -27,11 +27,11 @@ repositories {
 
 dependencies {
     api(project(":api"))
-    implementation("net.java.dev.jna:jna-platform:5.14.0")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+    implementation(libs.jna.platform)
+    testImplementation(libs.junit.jupiter)
     testImplementation(project(":lib"))
     testImplementation(testFixtures(project(":lib")))
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 configurations {
@@ -98,43 +98,12 @@ publishing {
     publications {
         create<MavenPublication>("mavenJava") {
             from(components["java"])
-
-            groupId = "org.pcre4j"
             artifactId = project.name
-            version = project.version.toString()
 
             pom {
                 name = "org.pcre4j:${project.name}"
                 description = "PCRE4J JNA Backend"
-                url = "https://pcre4j.org"
-
-                licenses {
-                    license {
-                        name = "GNU Lesser General Public License v3.0"
-                        url = "https://www.gnu.org/licenses/lgpl-3.0.txt"
-                    }
-                }
-                developers {
-                    developer {
-                        name = "Alexey Pelykh"
-                        email = "alexey.pelykh@gmail.com"
-                        organization = "The PCRE4J Project"
-                        organizationUrl = "https://pcre4j.org"
-                    }
-                }
-                scm {
-                    connection = "scm:git:git://github.com/alexey-pelykh/pcre4j.git"
-                    developerConnection = "scm:git:ssh://github.com:alexey-pelykh/pcre4j.git"
-                    url = "https://github.com/alexey-pelykh/pcre4j"
-                }
             }
-        }
-    }
-
-    repositories {
-        maven {
-            name = "StagingDeploy"
-            url = uri(layout.buildDirectory.dir("staging-deploy"))
         }
     }
 }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -28,12 +28,12 @@ repositories {
 
 dependencies {
     api(project(":api"))
-    testFixturesApi("org.junit.jupiter:junit-jupiter:5.10.2")
+    testFixturesApi(libs.junit.jupiter)
     // Runtime-only: lib tests discover backends reflectively to avoid compile-time coupling
     testRuntimeOnly(project(":jna"))
     testRuntimeOnly(project(":ffm"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 configurations {
@@ -112,43 +112,12 @@ publishing {
     publications {
         create<MavenPublication>("mavenJava") {
             from(components["java"])
-
-            groupId = "org.pcre4j"
             artifactId = project.name
-            version = project.version.toString()
 
             pom {
                 name = "org.pcre4j:${project.name}"
                 description = "PCRE4J Library"
-                url = "https://pcre4j.org"
-
-                licenses {
-                    license {
-                        name = "GNU Lesser General Public License v3.0"
-                        url = "https://www.gnu.org/licenses/lgpl-3.0.txt"
-                    }
-                }
-                developers {
-                    developer {
-                        name = "Alexey Pelykh"
-                        email = "alexey.pelykh@gmail.com"
-                        organization = "The PCRE4J Project"
-                        organizationUrl = "https://pcre4j.org"
-                    }
-                }
-                scm {
-                    connection = "scm:git:git://github.com/alexey-pelykh/pcre4j.git"
-                    developerConnection = "scm:git:ssh://github.com:alexey-pelykh/pcre4j.git"
-                    url = "https://github.com/alexey-pelykh/pcre4j"
-                }
             }
-        }
-    }
-
-    repositories {
-        maven {
-            name = "StagingDeploy"
-            url = uri(layout.buildDirectory.dir("staging-deploy"))
         }
     }
 }

--- a/regex/build.gradle.kts
+++ b/regex/build.gradle.kts
@@ -30,8 +30,8 @@ dependencies {
     api(project(":lib"))
     testImplementation(project(":jna"))
     testImplementation(project(":ffm"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 configurations {
@@ -110,43 +110,12 @@ publishing {
     publications {
         create<MavenPublication>("mavenJava") {
             from(components["java"])
-
-            groupId = "org.pcre4j"
             artifactId = project.name
-            version = project.version.toString()
 
             pom {
                 name = "org.pcre4j:${project.name}"
                 description = "PCRE4J java.util.regex-alike API"
-                url = "https://pcre4j.org"
-
-                licenses {
-                    license {
-                        name = "GNU Lesser General Public License v3.0"
-                        url = "https://www.gnu.org/licenses/lgpl-3.0.txt"
-                    }
-                }
-                developers {
-                    developer {
-                        name = "Alexey Pelykh"
-                        email = "alexey.pelykh@gmail.com"
-                        organization = "The PCRE4J Project"
-                        organizationUrl = "https://pcre4j.org"
-                    }
-                }
-                scm {
-                    connection = "scm:git:git://github.com/alexey-pelykh/pcre4j.git"
-                    developerConnection = "scm:git:ssh://github.com:alexey-pelykh/pcre4j.git"
-                    url = "https://github.com/alexey-pelykh/pcre4j"
-                }
             }
-        }
-    }
-
-    repositories {
-        maven {
-            name = "StagingDeploy"
-            url = uri(layout.buildDirectory.dir("staging-deploy"))
         }
     }
 }


### PR DESCRIPTION
## Summary

- Create `gradle/libs.versions.toml` to centralize dependency versions (JNA, JUnit, JReleaser plugin) and migrate all module build scripts to use the version catalog
- Add `checkModuleDependencies` task that validates the architectural dependency direction (`api` ← `lib` ← backends ← `regex`) by inspecting compile-time project dependencies, wired into the `check` lifecycle
- Deduplicate shared POM metadata (groupId, version, url, licenses, developers, scm, staging repository) into a root `subprojects` block, leaving only module-specific `name` and `description` in each module

Fixes #221

## Test plan

- [x] `./gradlew checkModuleDependencies` passes (all modules comply with constraints)
- [x] `./gradlew build` passes with all tests green
- [x] `./gradlew checkstyleMain checkstyleTest` passes
- [x] Generated POMs verified to contain all required metadata (licenses, developers, scm)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)