### PR TITLE
(feat) test: increase lib module test coverage to 70%+

### DIFF
--- a/lib/src/test/java/org/pcre4j/Pcre2CodeErrorHandlingTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodeErrorHandlingTests.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.pcre4j.api.IPcre2;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.EnumSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for error handling paths in {@link Pcre2Code} and related classes.
+ */
+public class Pcre2CodeErrorHandlingTests {
+
+    private static IPcre2 loadBackend(String className) {
+        try {
+            return (IPcre2) Class.forName(className).getDeclaredConstructor().newInstance();
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Backend " + className + " not found on classpath", e);
+        } catch (InvocationTargetException | InstantiationException | IllegalAccessException
+                 | NoSuchMethodException e) {
+            throw new RuntimeException("Failed to instantiate backend " + className, e);
+        }
+    }
+
+    private static Stream<Arguments> parameters() {
+        return Stream.of(
+                Arguments.of(loadBackend("org.pcre4j.jna.Pcre2")),
+                Arguments.of(loadBackend("org.pcre4j.ffm.Pcre2"))
+        );
+    }
+
+    // --- Pcre2Code constructor null checks ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void constructorNullApiThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> new Pcre2Code(null, "test"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void constructorNullPatternThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> new Pcre2Code(api, null));
+    }
+
+    // --- Various invalid patterns ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void unmatchedBracketThrows(IPcre2 api) {
+        var error = assertThrows(Pcre2CompileError.class, () -> new Pcre2Code(api, "[abc"));
+        assertNotNull(error.pattern());
+        assertTrue(error.offset() >= 0);
+        assertNotNull(error.message());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void unmatchedParenthesisThrows(IPcre2 api) {
+        assertThrows(Pcre2CompileError.class, () -> new Pcre2Code(api, "(abc"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void invalidQuantifierThrows(IPcre2 api) {
+        assertThrows(Pcre2CompileError.class, () -> new Pcre2Code(api, "?"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void invalidEscapeThrows(IPcre2 api) {
+        assertThrows(Pcre2CompileError.class, () -> new Pcre2Code(api, "\\"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void invalidRepetitionRangeThrows(IPcre2 api) {
+        assertThrows(Pcre2CompileError.class, () -> new Pcre2Code(api, "a{5,3}"));
+    }
+
+    // --- Pcre2CompileError fields ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void compileErrorContainsPatternInfo(IPcre2 api) {
+        var error = assertThrows(Pcre2CompileError.class, () -> new Pcre2Code(api, "(?P<>)"));
+        assertNotNull(error.getMessage());
+        assertNotNull(error.pattern());
+        assertNotNull(error.message());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void compileErrorLongPatternRegion(IPcre2 api) {
+        // Pattern with error far from the start to exercise getPatternRegion truncation
+        // Use a long valid prefix followed by an invalid construct
+        var longPattern = "abcdefghijklmnopqrstuvwxyz(((";
+        var error = assertThrows(Pcre2CompileError.class, () -> new Pcre2Code(api, longPattern));
+        assertNotNull(error.getMessage());
+        assertTrue(error.getMessage().length() > 0);
+    }
+
+    // --- match() null/invalid parameter checks ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchNullSubjectThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        var matchData = new Pcre2MatchData(code);
+        assertThrows(IllegalArgumentException.class, () ->
+                code.match(null, 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchNegativeStartOffsetThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        var matchData = new Pcre2MatchData(code);
+        assertThrows(IllegalArgumentException.class, () ->
+                code.match("test", -1, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchNullMatchDataThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertThrows(IllegalArgumentException.class, () ->
+                code.match("test", 0, EnumSet.noneOf(Pcre2MatchOption.class), null, null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchNoMatchReturnsNegative(IPcre2 api) {
+        var code = new Pcre2Code(api, "xyz");
+        var matchData = new Pcre2MatchData(code);
+        var result = code.match("abc", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null);
+        assertTrue(result < 0, "Non-matching should return negative (ERROR_NOMATCH)");
+    }
+
+    // --- substitute() null/invalid parameter checks ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void substituteNullSubjectThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertThrows(IllegalArgumentException.class, () ->
+                code.substitute(null, 0, null, null, null, "replacement"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void substituteNegativeStartOffsetThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertThrows(IllegalArgumentException.class, () ->
+                code.substitute("test", -1, null, null, null, "replacement"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void substituteStartOffsetPastEndThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertThrows(IllegalArgumentException.class, () ->
+                code.substitute("abc", 4, null, null, null, "replacement"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void substituteNullReplacementThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertThrows(IllegalArgumentException.class, () ->
+                code.substitute("test", 0, null, null, null, null));
+    }
+
+    // --- Pcre2MatchData constructor null checks ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchDataNullApiThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> new Pcre2MatchData(null, 10));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchDataNullCodeThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> new Pcre2MatchData(null));
+    }
+
+    // --- Context null checks ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void compileContextNullApiThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> new Pcre2CompileContext(null, null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchContextNullApiThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> new Pcre2MatchContext(null, null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void generalContextNullApiThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> new Pcre2GeneralContext(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitStackNullApiThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () ->
+                new Pcre2JitStack(null, 32 * 1024, 512 * 1024, null));
+    }
+
+    // --- JitCode error handling ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitCodeBadPatternThrows(IPcre2 api) {
+        assertThrows(Pcre2CompileError.class, () ->
+                new Pcre2JitCode(api, "?", null, null, null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitCodeMatchNullSubjectThrows(IPcre2 api) {
+        var code = new Pcre2JitCode(api, "test", null, null, null);
+        var matchData = new Pcre2MatchData(code);
+        assertThrows(IllegalArgumentException.class, () ->
+                code.match(null, 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitCodeMatchNegativeOffsetThrows(IPcre2 api) {
+        var code = new Pcre2JitCode(api, "test", null, null, null);
+        var matchData = new Pcre2MatchData(code);
+        assertThrows(IllegalArgumentException.class, () ->
+                code.match("test", -1, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitCodeMatchOffsetPastEndThrows(IPcre2 api) {
+        var code = new Pcre2JitCode(api, "test", null, null, null);
+        var matchData = new Pcre2MatchData(code);
+        assertThrows(IllegalArgumentException.class, () ->
+                code.match("ab", 3, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitCodeMatchNullMatchDataThrows(IPcre2 api) {
+        var code = new Pcre2JitCode(api, "test", null, null, null);
+        assertThrows(IllegalArgumentException.class, () ->
+                code.match("test", 0, EnumSet.noneOf(Pcre2MatchOption.class), null, null));
+    }
+}

--- a/lib/src/test/java/org/pcre4j/Pcre2CodePatternInfoTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodePatternInfoTests.java
@@ -1,0 +1,424 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.pcre4j.api.IPcre2;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.EnumSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link Pcre2Code} pattern information methods.
+ */
+public class Pcre2CodePatternInfoTests {
+
+    private static IPcre2 loadBackend(String className) {
+        try {
+            return (IPcre2) Class.forName(className).getDeclaredConstructor().newInstance();
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Backend " + className + " not found on classpath", e);
+        } catch (InvocationTargetException | InstantiationException | IllegalAccessException
+                 | NoSuchMethodException e) {
+            throw new RuntimeException("Failed to instantiate backend " + className, e);
+        }
+    }
+
+    private static Stream<Arguments> parameters() {
+        return Stream.of(
+                Arguments.of(loadBackend("org.pcre4j.jna.Pcre2")),
+                Arguments.of(loadBackend("org.pcre4j.ffm.Pcre2"))
+        );
+    }
+
+    // --- backRefMax ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void backRefMaxNoBackrefs(IPcre2 api) {
+        var code = new Pcre2Code(api, "hello");
+        assertEquals(0, code.backRefMax());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void backRefMaxWithBackrefs(IPcre2 api) {
+        var code = new Pcre2Code(api, "(a)(b)\\2");
+        assertEquals(2, code.backRefMax());
+    }
+
+    // --- argOptions ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void argOptionsDefault(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        var options = code.argOptions();
+        assertNotNull(options);
+        // Default compile with no options should return empty or just UTF
+        assertFalse(options.contains(Pcre2CompileOption.CASELESS));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void argOptionsWithCaseless(IPcre2 api) {
+        var code = new Pcre2Code(api, "test", EnumSet.of(Pcre2CompileOption.CASELESS));
+        var options = code.argOptions();
+        assertTrue(options.contains(Pcre2CompileOption.CASELESS));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void argOptionsWithMultipleOptions(IPcre2 api) {
+        var code = new Pcre2Code(api, "test",
+                EnumSet.of(Pcre2CompileOption.CASELESS, Pcre2CompileOption.DOTALL));
+        var options = code.argOptions();
+        assertTrue(options.contains(Pcre2CompileOption.CASELESS));
+        assertTrue(options.contains(Pcre2CompileOption.DOTALL));
+    }
+
+    // --- captureCount ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void captureCountNoGroups(IPcre2 api) {
+        var code = new Pcre2Code(api, "hello");
+        assertEquals(0, code.captureCount());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void captureCountWithGroups(IPcre2 api) {
+        var code = new Pcre2Code(api, "(a)(b)(c)");
+        assertEquals(3, code.captureCount());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void captureCountNonCapturing(IPcre2 api) {
+        var code = new Pcre2Code(api, "(?:a)(b)");
+        assertEquals(1, code.captureCount());
+    }
+
+    // --- bsr ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void bsrReturnsValidValue(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        var bsr = code.bsr();
+        assertNotNull(bsr);
+        assertTrue(bsr == Pcre2Bsr.UNICODE || bsr == Pcre2Bsr.ANYCRLF);
+    }
+
+    // --- frameSize ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void frameSizePositive(IPcre2 api) {
+        var code = new Pcre2Code(api, "(a)(b)");
+        assertTrue(code.frameSize() > 0);
+    }
+
+    // --- firstCodeType ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void firstCodeTypeAnchored(IPcre2 api) {
+        // Pattern anchored with ^ and starting with a literal should return 1 (first code unit set)
+        var code = new Pcre2Code(api, "^test");
+        assertEquals(1, code.firstCodeType());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void firstCodeTypeNoFixedStart(IPcre2 api) {
+        // Pattern starting with .* is implicitly anchored, returns 2
+        var code = new Pcre2Code(api, ".*test");
+        assertEquals(2, code.firstCodeType());
+    }
+
+    // --- hasBackslashC ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void hasBackslashCFalse(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertFalse(code.hasBackslashC());
+    }
+
+    // --- hasCrOrLf ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void hasCrOrLfFalse(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertFalse(code.hasCrOrLf());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void hasCrOrLfTrue(IPcre2 api) {
+        var code = new Pcre2Code(api, "test\\r");
+        // The pattern has an explicit CR
+        assertTrue(code.hasCrOrLf());
+    }
+
+    // --- jChanged ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jChangedFalse(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertFalse(code.jChanged());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jChangedTrue(IPcre2 api) {
+        var code = new Pcre2Code(api, "(?J)(?<name>a)(?<name>b)");
+        assertTrue(code.jChanged());
+    }
+
+    // --- jitSize ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitSizeZeroForNonJit(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertEquals(0, code.jitSize());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitSizePositiveForJit(IPcre2 api) {
+        var code = new Pcre2JitCode(api, "test", null, null, null);
+        assertTrue(code.jitSize() > 0);
+    }
+
+    // --- matchEmpty ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchEmptyFalse(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertFalse(code.matchEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchEmptyTrue(IPcre2 api) {
+        var code = new Pcre2Code(api, "a*");
+        assertTrue(code.matchEmpty());
+    }
+
+    // --- maxLookBehind ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void maxLookBehindZero(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertEquals(0, code.maxLookBehind());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void maxLookBehindPositive(IPcre2 api) {
+        var code = new Pcre2Code(api, "(?<=abc)test");
+        assertEquals(3, code.maxLookBehind());
+    }
+
+    // --- minLength ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void minLengthSimple(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertEquals(4, code.minLength());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void minLengthWithOptional(IPcre2 api) {
+        // "te?st" matches "tst" (3 chars) or "test" (4 chars), minimum is 3
+        var code = new Pcre2Code(api, "te?st");
+        assertEquals(3, code.minLength());
+    }
+
+    // --- nameCount ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void nameCountZero(IPcre2 api) {
+        var code = new Pcre2Code(api, "(a)(b)");
+        assertEquals(0, code.nameCount());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void nameCountWithNamedGroups(IPcre2 api) {
+        var code = new Pcre2Code(api, "(?<first>a)(?<second>b)");
+        assertEquals(2, code.nameCount());
+    }
+
+    // --- newline ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void newlineReturnsValidValue(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        var newline = code.newline();
+        assertNotNull(newline);
+    }
+
+    // --- nameEntrySize ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void nameEntrySizeWithNamedGroups(IPcre2 api) {
+        var code = new Pcre2Code(api, "(?<first>a)");
+        assertTrue(code.nameEntrySize() > 0);
+    }
+
+    // --- nameTable ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void nameTableEmpty(IPcre2 api) {
+        var code = new Pcre2Code(api, "(a)(b)");
+        assertEquals(0, code.nameTable().length);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void nameTableWithNamedGroups(IPcre2 api) {
+        var code = new Pcre2Code(api, "(?<first>a)(?<second>b)");
+        var nameTable = code.nameTable();
+        assertEquals(2, nameTable.length);
+
+        // Verify entries are present (order may vary)
+        boolean foundFirst = false;
+        boolean foundSecond = false;
+        for (var entry : nameTable) {
+            if ("first".equals(entry.name()) && entry.group() == 1) foundFirst = true;
+            if ("second".equals(entry.name()) && entry.group() == 2) foundSecond = true;
+        }
+        assertTrue(foundFirst, "Name table should contain 'first' mapped to group 1");
+        assertTrue(foundSecond, "Name table should contain 'second' mapped to group 2");
+    }
+
+    // --- size ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void sizePositive(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertTrue(code.size() > 0);
+    }
+
+    // --- api() and handle() ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void apiReturnsNonNull(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertNotNull(code.api());
+        assertEquals(api, code.api());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void handleReturnsNonZero(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertTrue(code.handle() != 0);
+    }
+
+    // --- groupNumberFromName ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void groupNumberFromNameValid(IPcre2 api) {
+        var code = new Pcre2Code(api, "(?<first>a)(?<second>b)");
+        assertEquals(1, code.groupNumberFromName("first"));
+        assertEquals(2, code.groupNumberFromName("second"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void groupNumberFromNameNullThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "(?<name>a)");
+        assertThrows(IllegalArgumentException.class, () -> code.groupNumberFromName(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void groupNumberFromNameNonexistentThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "(?<name>a)");
+        assertThrows(Pcre2NoSubstringError.class, () -> code.groupNumberFromName("nonexistent"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void groupNumberFromNameDuplicateThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "(?<name>a)|(?<name>b)",
+                EnumSet.of(Pcre2CompileOption.DUPNAMES));
+        assertThrows(Pcre2NoUniqueSubstringError.class, () -> code.groupNumberFromName("name"));
+    }
+
+    // --- scanNametable ---
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void scanNametableValid(IPcre2 api) {
+        var code = new Pcre2Code(api, "(?<first>a)(?<second>b)");
+        var groups = code.scanNametable("first");
+        assertArrayEquals(new int[]{1}, groups);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void scanNametableDuplicateNames(IPcre2 api) {
+        var code = new Pcre2Code(api, "(?<name>a)|(?<name>b)",
+                EnumSet.of(Pcre2CompileOption.DUPNAMES));
+        var groups = code.scanNametable("name");
+        assertEquals(2, groups.length);
+        assertEquals(1, groups[0]);
+        assertEquals(2, groups[1]);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void scanNametableNullThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "(?<name>a)");
+        assertThrows(IllegalArgumentException.class, () -> code.scanNametable(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void scanNametableNonexistentThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "(?<name>a)");
+        assertThrows(Pcre2NoSubstringError.class, () -> code.scanNametable("nonexistent"));
+    }
+}

--- a/lib/src/test/java/org/pcre4j/Pcre2CodeSubstituteTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodeSubstituteTests.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.pcre4j.api.IPcre2;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.EnumSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Tests for {@link Pcre2Code#substitute} method.
+ */
+public class Pcre2CodeSubstituteTests {
+
+    private static IPcre2 loadBackend(String className) {
+        try {
+            return (IPcre2) Class.forName(className).getDeclaredConstructor().newInstance();
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Backend " + className + " not found on classpath", e);
+        } catch (InvocationTargetException | InstantiationException | IllegalAccessException
+                 | NoSuchMethodException e) {
+            throw new RuntimeException("Failed to instantiate backend " + className, e);
+        }
+    }
+
+    private static Stream<Arguments> parameters() {
+        return Stream.of(
+                Arguments.of(loadBackend("org.pcre4j.jna.Pcre2")),
+                Arguments.of(loadBackend("org.pcre4j.ffm.Pcre2"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void substituteSimple(IPcre2 api) {
+        var code = new Pcre2Code(api, "world");
+        var result = code.substitute("hello world", 0, null, null, null, "earth");
+        assertEquals("hello earth", result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void substituteGlobal(IPcre2 api) {
+        var code = new Pcre2Code(api, "o");
+        var result = code.substitute("foo boo", 0,
+                EnumSet.of(Pcre2SubstituteOption.GLOBAL), null, null, "0");
+        assertEquals("f00 b00", result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void substituteWithBackreference(IPcre2 api) {
+        var code = new Pcre2Code(api, "(\\w+) (\\w+)");
+        var result = code.substitute("hello world", 0, null, null, null, "$2 $1");
+        assertEquals("world hello", result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void substituteWithNamedGroup(IPcre2 api) {
+        var code = new Pcre2Code(api, "(?<first>\\w+) (?<second>\\w+)");
+        var result = code.substitute("hello world", 0, null, null, null, "${second} ${first}");
+        assertEquals("world hello", result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void substituteNoMatch(IPcre2 api) {
+        var code = new Pcre2Code(api, "xyz");
+        var result = code.substitute("hello world", 0, null, null, null, "abc");
+        assertEquals("hello world", result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void substituteEmptyReplacement(IPcre2 api) {
+        var code = new Pcre2Code(api, "world");
+        var result = code.substitute("hello world", 0, null, null, null, "");
+        assertEquals("hello ", result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void substituteWithStartOffset(IPcre2 api) {
+        var code = new Pcre2Code(api, "o");
+        var result = code.substitute("foo boo", 2, null, null, null, "0");
+        // Should only substitute the first "o" at or after offset 2
+        assertEquals("fo0 boo", result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void substituteUnicode(IPcre2 api) {
+        var code = new Pcre2Code(api, "caf\u00e9");
+        var result = code.substitute("I love caf\u00e9", 0, null, null, null, "coffee");
+        assertEquals("I love coffee", result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void substituteNullOptionsUsesEmpty(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        var result = code.substitute("test", 0, null, null, null, "replaced");
+        assertNotNull(result);
+        assertEquals("replaced", result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void substituteLargeReplacementTriggersReallocation(IPcre2 api) {
+        // Create a replacement much larger than the subject to exercise buffer reallocation
+        var code = new Pcre2Code(api, "a");
+        var largeReplacement = "X".repeat(1000);
+        var result = code.substitute("a", 0, null, null, null, largeReplacement);
+        assertEquals(largeReplacement, result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void substituteGlobalWithLargeOutput(IPcre2 api) {
+        // Many substitutions that expand the output significantly
+        var code = new Pcre2Code(api, ".");
+        var subject = "abcdef";
+        var result = code.substitute(subject, 0,
+                EnumSet.of(Pcre2SubstituteOption.GLOBAL), null, null, "XX");
+        assertEquals("XXXXXXXXXXXX", result); // Each char replaced with "XX"
+    }
+}

--- a/lib/src/test/java/org/pcre4j/Pcre2ContextTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2ContextTests.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.pcre4j.api.IPcre2;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.EnumSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for context classes: {@link Pcre2GeneralContext}, {@link Pcre2CompileContext},
+ * {@link Pcre2MatchContext}, and {@link Pcre2JitStack}.
+ */
+public class Pcre2ContextTests {
+
+    private static IPcre2 loadBackend(String className) {
+        try {
+            return (IPcre2) Class.forName(className).getDeclaredConstructor().newInstance();
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Backend " + className + " not found on classpath", e);
+        } catch (InvocationTargetException | InstantiationException | IllegalAccessException
+                 | NoSuchMethodException e) {
+            throw new RuntimeException("Failed to instantiate backend " + className, e);
+        }
+    }
+
+    private static Stream<Arguments> parameters() {
+        return Stream.of(
+                Arguments.of(loadBackend("org.pcre4j.jna.Pcre2")),
+                Arguments.of(loadBackend("org.pcre4j.ffm.Pcre2"))
+        );
+    }
+
+    // === Pcre2GeneralContext ===
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void generalContextCreation(IPcre2 api) {
+        var ctx = new Pcre2GeneralContext(api);
+        assertNotNull(ctx);
+        assertNotNull(ctx.api());
+        assertEquals(api, ctx.api());
+        assertTrue(ctx.handle() != 0);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void generalContextUsableForCompileContext(IPcre2 api) {
+        var generalCtx = new Pcre2GeneralContext(api);
+        assertDoesNotThrow(() -> new Pcre2CompileContext(api, generalCtx));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void generalContextUsableForMatchContext(IPcre2 api) {
+        var generalCtx = new Pcre2GeneralContext(api);
+        assertDoesNotThrow(() -> new Pcre2MatchContext(api, generalCtx));
+    }
+
+    // === Pcre2CompileContext ===
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void compileContextCreation(IPcre2 api) {
+        var ctx = new Pcre2CompileContext(api, null);
+        assertNotNull(ctx);
+        assertNotNull(ctx.api());
+        assertEquals(api, ctx.api());
+        assertTrue(ctx.handle() != 0);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void compileContextSetNewline(IPcre2 api) {
+        var ctx = new Pcre2CompileContext(api, null);
+        assertDoesNotThrow(() -> ctx.setNewline(Pcre2Newline.LF));
+        assertDoesNotThrow(() -> ctx.setNewline(Pcre2Newline.CR));
+        assertDoesNotThrow(() -> ctx.setNewline(Pcre2Newline.CRLF));
+        assertDoesNotThrow(() -> ctx.setNewline(Pcre2Newline.ANY));
+        assertDoesNotThrow(() -> ctx.setNewline(Pcre2Newline.ANYCRLF));
+        assertDoesNotThrow(() -> ctx.setNewline(Pcre2Newline.NUL));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void compileContextSetNewlineNullThrows(IPcre2 api) {
+        var ctx = new Pcre2CompileContext(api, null);
+        assertThrows(IllegalArgumentException.class, () -> ctx.setNewline(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void compileContextSetBsr(IPcre2 api) {
+        var ctx = new Pcre2CompileContext(api, null);
+        assertDoesNotThrow(() -> ctx.setBsr(Pcre2Bsr.UNICODE));
+        assertDoesNotThrow(() -> ctx.setBsr(Pcre2Bsr.ANYCRLF));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void compileContextSetBsrNullThrows(IPcre2 api) {
+        var ctx = new Pcre2CompileContext(api, null);
+        assertThrows(IllegalArgumentException.class, () -> ctx.setBsr(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void compileContextSetParensNestLimit(IPcre2 api) {
+        var ctx = new Pcre2CompileContext(api, null);
+        assertDoesNotThrow(() -> ctx.setParensNestLimit(100));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void compileContextSetMaxPatternLength(IPcre2 api) {
+        var ctx = new Pcre2CompileContext(api, null);
+        assertDoesNotThrow(() -> ctx.setMaxPatternLength(1024));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void compileContextSetCompileExtraOptions(IPcre2 api) {
+        var ctx = new Pcre2CompileContext(api, null);
+        assertDoesNotThrow(() -> ctx.setCompileExtraOptions(Pcre2CompileExtraOption.BAD_ESCAPE_IS_LITERAL));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void compileContextSetCompileExtraOptionsNullThrows(IPcre2 api) {
+        var ctx = new Pcre2CompileContext(api, null);
+        assertThrows(IllegalArgumentException.class, () ->
+                ctx.setCompileExtraOptions((Pcre2CompileExtraOption[]) null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void compileContextSetCompileExtraOptionsNullElementThrows(IPcre2 api) {
+        var ctx = new Pcre2CompileContext(api, null);
+        assertThrows(IllegalArgumentException.class, () ->
+                ctx.setCompileExtraOptions(Pcre2CompileExtraOption.BAD_ESCAPE_IS_LITERAL, null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void compileContextUsedInCompilation(IPcre2 api) {
+        var ctx = new Pcre2CompileContext(api, null);
+        ctx.setNewline(Pcre2Newline.CR);
+
+        // Compile a pattern using the context
+        var code = new Pcre2Code(api, "test", null, ctx);
+        assertNotNull(code);
+
+        // Verify the newline setting was applied
+        assertEquals(Pcre2Newline.CR, code.newline());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void compileContextParensLimitEnforced(IPcre2 api) {
+        var ctx = new Pcre2CompileContext(api, null);
+        ctx.setParensNestLimit(2);
+
+        // A pattern with deeply nested parentheses should fail with strict limit
+        assertThrows(Pcre2CompileError.class, () ->
+                new Pcre2Code(api, "((((a))))", null, ctx));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void compileContextMaxPatternLengthEnforced(IPcre2 api) {
+        var ctx = new Pcre2CompileContext(api, null);
+        ctx.setMaxPatternLength(3);
+
+        // A pattern longer than 3 characters should fail
+        assertThrows(Pcre2CompileError.class, () ->
+                new Pcre2Code(api, "test", null, ctx));
+    }
+
+    // === Pcre2MatchContext ===
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchContextCreation(IPcre2 api) {
+        var ctx = new Pcre2MatchContext(api, null);
+        assertNotNull(ctx);
+        assertNotNull(ctx.api());
+        assertEquals(api, ctx.api());
+        assertTrue(ctx.handle() != 0);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchContextSetMatchLimit(IPcre2 api) {
+        var ctx = new Pcre2MatchContext(api, null);
+        assertDoesNotThrow(() -> ctx.setMatchLimit(1000));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchContextSetMatchLimitNegativeThrows(IPcre2 api) {
+        var ctx = new Pcre2MatchContext(api, null);
+        assertThrows(IllegalArgumentException.class, () -> ctx.setMatchLimit(-1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchContextSetDepthLimit(IPcre2 api) {
+        var ctx = new Pcre2MatchContext(api, null);
+        assertDoesNotThrow(() -> ctx.setDepthLimit(500));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchContextSetDepthLimitNegativeThrows(IPcre2 api) {
+        var ctx = new Pcre2MatchContext(api, null);
+        assertThrows(IllegalArgumentException.class, () -> ctx.setDepthLimit(-1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchContextSetHeapLimit(IPcre2 api) {
+        var ctx = new Pcre2MatchContext(api, null);
+        assertDoesNotThrow(() -> ctx.setHeapLimit(1024));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchContextSetHeapLimitNegativeThrows(IPcre2 api) {
+        var ctx = new Pcre2MatchContext(api, null);
+        assertThrows(IllegalArgumentException.class, () -> ctx.setHeapLimit(-1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchContextSetOffsetLimit(IPcre2 api) {
+        var ctx = new Pcre2MatchContext(api, null);
+        assertDoesNotThrow(() -> ctx.setOffsetLimit(100));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchContextSetOffsetLimitNegativeThrows(IPcre2 api) {
+        var ctx = new Pcre2MatchContext(api, null);
+        assertThrows(IllegalArgumentException.class, () -> ctx.setOffsetLimit(-1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchContextAssignJitStack(IPcre2 api) {
+        var matchCtx = new Pcre2MatchContext(api, null);
+        var jitStack = new Pcre2JitStack(api, 32 * 1024, 512 * 1024, null);
+        assertDoesNotThrow(() -> matchCtx.assignJitStack(jitStack));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchContextAssignJitStackNullThrows(IPcre2 api) {
+        var matchCtx = new Pcre2MatchContext(api, null);
+        assertThrows(IllegalArgumentException.class, () -> matchCtx.assignJitStack(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchContextLowMatchLimitCausesError(IPcre2 api) {
+        var ctx = new Pcre2MatchContext(api, null);
+        ctx.setMatchLimit(1); // Extremely low limit
+
+        var code = new Pcre2Code(api, "(a+)+b");
+        var matchData = new Pcre2MatchData(code);
+
+        // With match limit of 1, a complex backtracking pattern should fail
+        var result = code.match("aaaaac", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, ctx);
+        assertTrue(result < 0, "Very low match limit should cause match failure");
+    }
+
+    // === Pcre2JitStack ===
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitStackCreation(IPcre2 api) {
+        var stack = new Pcre2JitStack(api, 32 * 1024, 512 * 1024, null);
+        assertNotNull(stack);
+        assertNotNull(stack.api());
+        assertEquals(api, stack.api());
+        assertTrue(stack.handle() != 0);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitStackWithGeneralContext(IPcre2 api) {
+        var generalCtx = new Pcre2GeneralContext(api);
+        var stack = new Pcre2JitStack(api, 32 * 1024, 512 * 1024, generalCtx);
+        assertNotNull(stack);
+        assertTrue(stack.handle() != 0);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitStackUsedInMatch(IPcre2 api) {
+        var matchCtx = new Pcre2MatchContext(api, null);
+        var jitStack = new Pcre2JitStack(api, 32 * 1024, 512 * 1024, null);
+        matchCtx.assignJitStack(jitStack);
+
+        var code = new Pcre2JitCode(api, "(hello)", null, null, null);
+        var matchData = new Pcre2MatchData(code);
+        var result = code.match("hello", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, matchCtx);
+        assertTrue(result > 0, "JIT match with custom stack should succeed");
+    }
+}

--- a/lib/src/test/java/org/pcre4j/Pcre2EnumTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2EnumTests.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j;
+
+import org.junit.jupiter.api.Test;
+import org.pcre4j.api.IPcre2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for enum classes and error types.
+ */
+public class Pcre2EnumTests {
+
+    // === Pcre2Bsr ===
+
+    @Test
+    void bsrValueOfValid() {
+        assertTrue(Pcre2Bsr.valueOf(IPcre2.BSR_UNICODE).isPresent());
+        assertEquals(Pcre2Bsr.UNICODE, Pcre2Bsr.valueOf(IPcre2.BSR_UNICODE).get());
+
+        assertTrue(Pcre2Bsr.valueOf(IPcre2.BSR_ANYCRLF).isPresent());
+        assertEquals(Pcre2Bsr.ANYCRLF, Pcre2Bsr.valueOf(IPcre2.BSR_ANYCRLF).get());
+    }
+
+    @Test
+    void bsrValueOfInvalid() {
+        assertFalse(Pcre2Bsr.valueOf(-999).isPresent());
+    }
+
+    @Test
+    void bsrValue() {
+        assertEquals(IPcre2.BSR_UNICODE, Pcre2Bsr.UNICODE.value());
+        assertEquals(IPcre2.BSR_ANYCRLF, Pcre2Bsr.ANYCRLF.value());
+    }
+
+    // === Pcre2Newline ===
+
+    @Test
+    void newlineValueOfValid() {
+        assertTrue(Pcre2Newline.valueOf(IPcre2.NEWLINE_CR).isPresent());
+        assertEquals(Pcre2Newline.CR, Pcre2Newline.valueOf(IPcre2.NEWLINE_CR).get());
+
+        assertTrue(Pcre2Newline.valueOf(IPcre2.NEWLINE_LF).isPresent());
+        assertEquals(Pcre2Newline.LF, Pcre2Newline.valueOf(IPcre2.NEWLINE_LF).get());
+
+        assertTrue(Pcre2Newline.valueOf(IPcre2.NEWLINE_CRLF).isPresent());
+        assertEquals(Pcre2Newline.CRLF, Pcre2Newline.valueOf(IPcre2.NEWLINE_CRLF).get());
+
+        assertTrue(Pcre2Newline.valueOf(IPcre2.NEWLINE_ANY).isPresent());
+        assertEquals(Pcre2Newline.ANY, Pcre2Newline.valueOf(IPcre2.NEWLINE_ANY).get());
+
+        assertTrue(Pcre2Newline.valueOf(IPcre2.NEWLINE_ANYCRLF).isPresent());
+        assertEquals(Pcre2Newline.ANYCRLF, Pcre2Newline.valueOf(IPcre2.NEWLINE_ANYCRLF).get());
+
+        assertTrue(Pcre2Newline.valueOf(IPcre2.NEWLINE_NUL).isPresent());
+        assertEquals(Pcre2Newline.NUL, Pcre2Newline.valueOf(IPcre2.NEWLINE_NUL).get());
+    }
+
+    @Test
+    void newlineValueOfInvalid() {
+        assertFalse(Pcre2Newline.valueOf(-999).isPresent());
+    }
+
+    @Test
+    void newlineValues() {
+        assertEquals(IPcre2.NEWLINE_CR, Pcre2Newline.CR.value());
+        assertEquals(IPcre2.NEWLINE_LF, Pcre2Newline.LF.value());
+        assertEquals(IPcre2.NEWLINE_CRLF, Pcre2Newline.CRLF.value());
+        assertEquals(IPcre2.NEWLINE_ANY, Pcre2Newline.ANY.value());
+        assertEquals(IPcre2.NEWLINE_ANYCRLF, Pcre2Newline.ANYCRLF.value());
+        assertEquals(IPcre2.NEWLINE_NUL, Pcre2Newline.NUL.value());
+    }
+
+    // === Pcre2CompileOption ===
+
+    @Test
+    void compileOptionValues() {
+        assertEquals(IPcre2.ANCHORED, Pcre2CompileOption.ANCHORED.value());
+        assertEquals(IPcre2.CASELESS, Pcre2CompileOption.CASELESS.value());
+        assertEquals(IPcre2.DOTALL, Pcre2CompileOption.DOTALL.value());
+        assertEquals(IPcre2.MULTILINE, Pcre2CompileOption.MULTILINE.value());
+    }
+
+    // === Pcre2MatchOption ===
+
+    @Test
+    void matchOptionValues() {
+        assertEquals(IPcre2.NOTBOL, Pcre2MatchOption.NOTBOL.value());
+        assertEquals(IPcre2.NOTEOL, Pcre2MatchOption.NOTEOL.value());
+        assertEquals(IPcre2.NOTEMPTY, Pcre2MatchOption.NOTEMPTY.value());
+        assertEquals(IPcre2.PARTIAL_SOFT, Pcre2MatchOption.PARTIAL_SOFT.value());
+        assertEquals(IPcre2.PARTIAL_HARD, Pcre2MatchOption.PARTIAL_HARD.value());
+        assertEquals(IPcre2.COPY_MATCHED_SUBJECT, Pcre2MatchOption.COPY_MATCHED_SUBJECT.value());
+    }
+
+    // === Pcre2SubstituteOption ===
+
+    @Test
+    void substituteOptionValues() {
+        assertEquals(IPcre2.SUBSTITUTE_GLOBAL, Pcre2SubstituteOption.GLOBAL.value());
+        assertEquals(IPcre2.SUBSTITUTE_EXTENDED, Pcre2SubstituteOption.EXTENDED.value());
+    }
+
+    // === Pcre2JitOption ===
+
+    @Test
+    void jitOptionValues() {
+        assertEquals(IPcre2.JIT_COMPLETE, Pcre2JitOption.COMPLETE.value());
+        assertEquals(IPcre2.JIT_PARTIAL_SOFT, Pcre2JitOption.PARTIAL_SOFT.value());
+        assertEquals(IPcre2.JIT_PARTIAL_HARD, Pcre2JitOption.PARTIAL_HARD.value());
+    }
+
+    // === Pcre2CompileExtraOption ===
+
+    @Test
+    void compileExtraOptionValues() {
+        for (var option : Pcre2CompileExtraOption.values()) {
+            assertTrue(option.value() != 0, "Extra option " + option + " should have non-zero value");
+        }
+    }
+
+    // === Pcre2PatternInfo ===
+
+    @Test
+    void patternInfoValueOfValid() {
+        assertTrue(Pcre2PatternInfo.valueOf(IPcre2.INFO_BACKREFMAX).isPresent());
+        assertTrue(Pcre2PatternInfo.valueOf(IPcre2.INFO_CAPTURECOUNT).isPresent());
+        assertTrue(Pcre2PatternInfo.valueOf(IPcre2.INFO_BSR).isPresent());
+    }
+
+    @Test
+    void patternInfoValueOfInvalid() {
+        assertFalse(Pcre2PatternInfo.valueOf(-999).isPresent());
+    }
+
+    // === Pcre2CompileError ===
+
+    @Test
+    void compileErrorFields() {
+        var error = new Pcre2CompileError("test?", 4, "quantifier does not follow a repeatable item");
+        assertEquals("test?", error.pattern());
+        assertEquals(4, error.offset());
+        assertEquals("quantifier does not follow a repeatable item", error.message());
+        assertNotNull(error.getMessage());
+    }
+
+    @Test
+    void compileErrorWithCause() {
+        var cause = new RuntimeException("underlying");
+        var error = new Pcre2CompileError("test?", 4, "compile error", cause);
+        assertEquals(cause, error.getCause());
+    }
+
+    @Test
+    void compileErrorPatternRegionTruncation() {
+        // Test with error at the beginning (should not have leading ellipsis)
+        var error1 = new Pcre2CompileError("?test", 0, "error");
+        assertNotNull(error1.getMessage());
+        assertFalse(error1.getMessage().contains("\u2026?"));
+
+        // Test with error in the middle of a long pattern (should have ellipsis on both sides)
+        var error2 = new Pcre2CompileError("abcdefghijklmnop", 8, "error");
+        assertNotNull(error2.getMessage());
+
+        // Test with error at the end
+        var error3 = new Pcre2CompileError("test?", 4, "error");
+        assertNotNull(error3.getMessage());
+    }
+
+    // === Pcre2SubstituteError ===
+
+    @Test
+    void substituteErrorMessage() {
+        var error = new Pcre2SubstituteError("substitution error");
+        assertEquals("substitution error", error.getMessage());
+    }
+
+    // === Pcre2NoSubstringError ===
+
+    @Test
+    void noSubstringErrorMessage() {
+        var error = new Pcre2NoSubstringError("no substring");
+        assertEquals("no substring", error.getMessage());
+    }
+
+    // === Pcre2NoUniqueSubstringError ===
+
+    @Test
+    void noUniqueSubstringErrorMessage() {
+        var error = new Pcre2NoUniqueSubstringError("not unique");
+        assertEquals("not unique", error.getMessage());
+    }
+}

--- a/lib/src/test/java/org/pcre4j/Pcre2JitCodeTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2JitCodeTests.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.pcre4j.api.IPcre2;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.EnumSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link Pcre2JitCode}.
+ */
+public class Pcre2JitCodeTests {
+
+    private static IPcre2 loadBackend(String className) {
+        try {
+            return (IPcre2) Class.forName(className).getDeclaredConstructor().newInstance();
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Backend " + className + " not found on classpath", e);
+        } catch (InvocationTargetException | InstantiationException | IllegalAccessException
+                 | NoSuchMethodException e) {
+            throw new RuntimeException("Failed to instantiate backend " + className, e);
+        }
+    }
+
+    private static Stream<Arguments> parameters() {
+        return Stream.of(
+                Arguments.of(loadBackend("org.pcre4j.jna.Pcre2")),
+                Arguments.of(loadBackend("org.pcre4j.ffm.Pcre2"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getSupportedMatchOptions(IPcre2 api) {
+        var options = Pcre2JitCode.getSupportedMatchOptions();
+        assertNotNull(options);
+        assertEquals(6, options.size());
+        assertTrue(options.contains(Pcre2MatchOption.NOTBOL));
+        assertTrue(options.contains(Pcre2MatchOption.NOTEOL));
+        assertTrue(options.contains(Pcre2MatchOption.NOTEMPTY));
+        assertTrue(options.contains(Pcre2MatchOption.NOTEMPTY_ATSTART));
+        assertTrue(options.contains(Pcre2MatchOption.PARTIAL_HARD));
+        assertTrue(options.contains(Pcre2MatchOption.PARTIAL_SOFT));
+        // COPY_MATCHED_SUBJECT should NOT be in supported options
+        assertFalse(options.contains(Pcre2MatchOption.COPY_MATCHED_SUBJECT));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitMatchSuccess(IPcre2 api) {
+        var code = new Pcre2JitCode(api, "(hello) (world)", null, null, null);
+        var matchData = new Pcre2MatchData(code);
+        var result = code.match("hello world", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null);
+        assertTrue(result > 0, "JIT match should succeed");
+        assertEquals(3, matchData.ovectorCount());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitMatchNoMatch(IPcre2 api) {
+        var code = new Pcre2JitCode(api, "xyz", null, null, null);
+        var matchData = new Pcre2MatchData(code);
+        var result = code.match("abc", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null);
+        assertTrue(result < 0, "JIT match should return negative for no match");
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitMatchWithStartOffset(IPcre2 api) {
+        var code = new Pcre2JitCode(api, "o", null, null, null);
+        var matchData = new Pcre2MatchData(code);
+
+        // Match at offset 0 should find "o" at position 1
+        var result = code.match("foo", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null);
+        assertTrue(result > 0);
+
+        // Match starting at offset 2 should find "o" at position 2
+        result = code.match("foo", 2, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null);
+        assertTrue(result > 0);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitMatchWithMatchContext(IPcre2 api) {
+        var matchCtx = new Pcre2MatchContext(api, null);
+        var jitStack = new Pcre2JitStack(api, 32 * 1024, 512 * 1024, null);
+        matchCtx.assignJitStack(jitStack);
+
+        var code = new Pcre2JitCode(api, "(test)", null, null, null);
+        var matchData = new Pcre2MatchData(code);
+        var result = code.match("test", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, matchCtx);
+        assertTrue(result > 0, "JIT match with match context should succeed");
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitCodeWithSpecificJitOptions(IPcre2 api) {
+        // Compile with only COMPLETE (not PARTIAL_SOFT and PARTIAL_HARD)
+        var code = new Pcre2JitCode(api, "test", null,
+                EnumSet.of(Pcre2JitOption.COMPLETE), null);
+        var matchData = new Pcre2MatchData(code);
+        var result = code.match("test", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null);
+        assertTrue(result > 0, "JIT match with specific JIT options should succeed");
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitCodeWithCompileOptions(IPcre2 api) {
+        var code = new Pcre2JitCode(api, "test",
+                EnumSet.of(Pcre2CompileOption.CASELESS), null, null);
+        var matchData = new Pcre2MatchData(code);
+        var result = code.match("TEST", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null);
+        assertTrue(result > 0, "JIT match with CASELESS option should match TEST");
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitCodeWithCompileContext(IPcre2 api) {
+        var compileCtx = new Pcre2CompileContext(api, null);
+        compileCtx.setNewline(Pcre2Newline.LF);
+
+        var code = new Pcre2JitCode(api, "^test$", null, null, compileCtx);
+        var matchData = new Pcre2MatchData(code);
+        var result = code.match("test", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null);
+        assertTrue(result > 0, "JIT match with compile context should succeed");
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitCodeWithMatchOptions(IPcre2 api) {
+        var code = new Pcre2JitCode(api, "^test", null, null, null);
+        var matchData = new Pcre2MatchData(code);
+
+        // NOTBOL should prevent ^ from matching at start
+        var result = code.match("test", 0,
+                EnumSet.of(Pcre2MatchOption.NOTBOL), matchData, null);
+        assertTrue(result < 0, "NOTBOL should prevent ^ from matching");
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void jitCodePartialMatch(IPcre2 api) {
+        var code = new Pcre2JitCode(api, "testing", null, null, null);
+        var matchData = new Pcre2MatchData(code);
+
+        var result = code.match("test", 0,
+                EnumSet.of(Pcre2MatchOption.PARTIAL_SOFT), matchData, null);
+        // Partial match returns ERROR_PARTIAL (negative)
+        assertEquals(IPcre2.ERROR_PARTIAL, result, "Should get partial match");
+    }
+}

--- a/lib/src/test/java/org/pcre4j/Pcre4jUtilsExtendedTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre4jUtilsExtendedTests.java
@@ -1,0 +1,566 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.pcre4j.api.IPcre2;
+import org.pcre4j.api.Pcre2UtfWidth;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.EnumSet;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Extended tests for {@link Pcre4jUtils} covering configuration queries,
+ * error messages, group extraction, and ovector conversion edge cases.
+ */
+public class Pcre4jUtilsExtendedTests {
+
+    private static IPcre2 loadBackend(String className) {
+        try {
+            return (IPcre2) Class.forName(className).getDeclaredConstructor().newInstance();
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Backend " + className + " not found on classpath", e);
+        } catch (InvocationTargetException | InstantiationException | IllegalAccessException
+                 | NoSuchMethodException e) {
+            throw new RuntimeException("Failed to instantiate backend " + className, e);
+        }
+    }
+
+    private static Stream<Arguments> parameters() {
+        return Stream.of(
+                Arguments.of(loadBackend("org.pcre4j.jna.Pcre2")),
+                Arguments.of(loadBackend("org.pcre4j.ffm.Pcre2"))
+        );
+    }
+
+    // === Configuration query methods ===
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getVersion(IPcre2 api) {
+        var version = Pcre4jUtils.getVersion(api);
+        assertNotNull(version);
+        assertFalse(version.isEmpty());
+        assertTrue(version.contains("."), "Version should contain a dot: " + version);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getVersionNullThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getVersion(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void isVersionAtLeast(IPcre2 api) {
+        // PCRE2 10.x should be present
+        assertTrue(Pcre4jUtils.isVersionAtLeast(api, 10, 0));
+        // Version 99.0 should not be reached
+        assertFalse(Pcre4jUtils.isVersionAtLeast(api, 99, 0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void isVersionAtLeastSameMajorHigherMinor(IPcre2 api) {
+        // Should handle same major with higher minor correctly
+        assertTrue(Pcre4jUtils.isVersionAtLeast(api, 10, 0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void isVersionAtLeastNullThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.isVersionAtLeast(null, 10, 0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getUnicodeVersion(IPcre2 api) {
+        var version = Pcre4jUtils.getUnicodeVersion(api);
+        assertNotNull(version);
+        assertFalse(version.isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getUnicodeVersionNullThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getUnicodeVersion(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void isUnicodeSupported(IPcre2 api) {
+        // Standard PCRE2 builds support Unicode
+        assertTrue(Pcre4jUtils.isUnicodeSupported(api));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void isUnicodeSupportedNullThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.isUnicodeSupported(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getDefaultParenthesesNestingLimit(IPcre2 api) {
+        var limit = Pcre4jUtils.getDefaultParenthesesNestingLimit(api);
+        assertTrue(limit > 0, "Default parens nesting limit should be positive");
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getDefaultParenthesesNestingLimitNullThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getDefaultParenthesesNestingLimit(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getDefaultNewline(IPcre2 api) {
+        var newline = Pcre4jUtils.getDefaultNewline(api);
+        assertNotNull(newline);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getDefaultNewlineNullThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getDefaultNewline(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void isBackslashCDisabled(IPcre2 api) {
+        // Just verify it doesn't throw
+        Pcre4jUtils.isBackslashCDisabled(api);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void isBackslashCDisabledNullThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.isBackslashCDisabled(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getDefaultMatchLimit(IPcre2 api) {
+        var limit = Pcre4jUtils.getDefaultMatchLimit(api);
+        assertTrue(limit > 0, "Default match limit should be positive");
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getDefaultMatchLimitNullThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getDefaultMatchLimit(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getInternalLinkSize(IPcre2 api) {
+        var linkSize = Pcre4jUtils.getInternalLinkSize(api);
+        assertTrue(linkSize > 0, "Internal link size should be positive");
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getInternalLinkSizeNullThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getInternalLinkSize(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getJitTarget(IPcre2 api) {
+        var target = Pcre4jUtils.getJitTarget(api);
+        // May return null if JIT not supported, or a non-empty string
+        if (target != null) {
+            assertFalse(target.isEmpty());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getJitTargetNullThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getJitTarget(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void isJitSupported(IPcre2 api) {
+        // Just verify it doesn't throw; JIT support depends on build
+        Pcre4jUtils.isJitSupported(api);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void isJitSupportedNullThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.isJitSupported(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getDefaultHeapLimit(IPcre2 api) {
+        var limit = Pcre4jUtils.getDefaultHeapLimit(api);
+        assertTrue(limit >= 0, "Default heap limit should be non-negative");
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getDefaultHeapLimitNullThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getDefaultHeapLimit(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getDefaultDepthLimit(IPcre2 api) {
+        var limit = Pcre4jUtils.getDefaultDepthLimit(api);
+        assertTrue(limit > 0, "Default depth limit should be positive");
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getDefaultDepthLimitNullThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getDefaultDepthLimit(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getCompiledWidths(IPcre2 api) {
+        var widths = Pcre4jUtils.getCompiledWidths(api);
+        assertNotNull(widths);
+        assertFalse(widths.isEmpty(), "Should have at least one compiled width");
+        assertTrue(widths.contains(Pcre2UtfWidth.UTF8), "Must support UTF-8");
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getCompiledWidthsNullThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getCompiledWidths(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getDefaultBsr(IPcre2 api) {
+        var bsr = Pcre4jUtils.getDefaultBsr(api);
+        assertNotNull(bsr);
+        assertTrue(bsr == Pcre2Bsr.UNICODE || bsr == Pcre2Bsr.ANYCRLF);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getDefaultBsrNullThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getDefaultBsr(null));
+    }
+
+    // === getErrorMessage ===
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getErrorMessageValidCode(IPcre2 api) {
+        // ERROR_NOMATCH is -1
+        var msg = Pcre4jUtils.getErrorMessage(api, IPcre2.ERROR_NOMATCH);
+        assertNotNull(msg);
+        assertFalse(msg.isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getErrorMessageNullApiThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getErrorMessage(null, 0));
+    }
+
+    // === convertCharacterIndexToByteOffset ===
+
+    @Test
+    void convertCharacterIndexToByteOffsetAscii() {
+        assertEquals(0, Pcre4jUtils.convertCharacterIndexToByteOffset("hello", 0));
+        assertEquals(3, Pcre4jUtils.convertCharacterIndexToByteOffset("hello", 3));
+        assertEquals(5, Pcre4jUtils.convertCharacterIndexToByteOffset("hello", 5));
+    }
+
+    @Test
+    void convertCharacterIndexToByteOffsetMultiByte() {
+        // "café" - é is 2 bytes in UTF-8
+        var subject = "caf\u00e9";
+        assertEquals(0, Pcre4jUtils.convertCharacterIndexToByteOffset(subject, 0));
+        assertEquals(3, Pcre4jUtils.convertCharacterIndexToByteOffset(subject, 3));
+        assertEquals(5, Pcre4jUtils.convertCharacterIndexToByteOffset(subject, 4)); // é = 2 bytes
+    }
+
+    @Test
+    void convertCharacterIndexToByteOffsetThreeByte() {
+        // Chinese characters are 3 bytes each in UTF-8
+        var subject = "\u4e16\u754c"; // "世界"
+        assertEquals(0, Pcre4jUtils.convertCharacterIndexToByteOffset(subject, 0));
+        assertEquals(3, Pcre4jUtils.convertCharacterIndexToByteOffset(subject, 1));
+        assertEquals(6, Pcre4jUtils.convertCharacterIndexToByteOffset(subject, 2));
+    }
+
+    @Test
+    void convertCharacterIndexToByteOffsetSurrogate() {
+        // Emoji U+1F600 (😀) uses a surrogate pair in Java, 4 bytes in UTF-8
+        var subject = "\uD83D\uDE00";
+        assertEquals(0, Pcre4jUtils.convertCharacterIndexToByteOffset(subject, 0));
+        assertEquals(2, Pcre4jUtils.convertCharacterIndexToByteOffset(subject, 1));
+        assertEquals(4, Pcre4jUtils.convertCharacterIndexToByteOffset(subject, 2));
+    }
+
+    @Test
+    void convertCharacterIndexToByteOffsetNullThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre4jUtils.convertCharacterIndexToByteOffset(null, 0));
+    }
+
+    @Test
+    void convertCharacterIndexToByteOffsetNegativeThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre4jUtils.convertCharacterIndexToByteOffset("test", -1));
+    }
+
+    // === convertOvectorToStringIndices ===
+
+    @Test
+    void convertOvectorToStringIndicesAscii() {
+        var subject = "hello world";
+        // Full match "hello" at bytes 0-5
+        var ovector = new long[]{0, 5};
+        assertArrayEquals(new int[]{0, 5}, Pcre4jUtils.convertOvectorToStringIndices(subject, ovector));
+    }
+
+    @Test
+    void convertOvectorToStringIndicesWithGroups() {
+        var subject = "hello world";
+        // Full match + 2 groups
+        var ovector = new long[]{0, 11, 0, 5, 6, 11};
+        assertArrayEquals(
+                new int[]{0, 11, 0, 5, 6, 11},
+                Pcre4jUtils.convertOvectorToStringIndices(subject, ovector)
+        );
+    }
+
+    @Test
+    void convertOvectorToStringIndicesUnmatchedGroup() {
+        var subject = "hello";
+        // Full match + group that didn't match
+        var ovector = new long[]{0, 5, -1, -1};
+        assertArrayEquals(
+                new int[]{0, 5, -1, -1},
+                Pcre4jUtils.convertOvectorToStringIndices(subject, ovector)
+        );
+    }
+
+    @Test
+    void convertOvectorToStringIndicesMultiByte() {
+        // "café" - é is 2 bytes in UTF-8
+        var subject = "caf\u00e9";
+        // Match "é" at byte offset 3-5
+        var ovector = new long[]{3, 5};
+        var result = Pcre4jUtils.convertOvectorToStringIndices(subject, ovector);
+        assertEquals(3, result[0]); // char index 3
+        assertEquals(4, result[1]); // char index 4
+    }
+
+    @Test
+    void convertOvectorToStringIndicesAllUnmatched() {
+        var subject = "hello";
+        var ovector = new long[]{-1, -1};
+        assertArrayEquals(new int[]{-1, -1}, Pcre4jUtils.convertOvectorToStringIndices(subject, ovector));
+    }
+
+    @Test
+    void convertOvectorToStringIndicesNullSubjectThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre4jUtils.convertOvectorToStringIndices(null, new long[]{0, 5}));
+    }
+
+    @Test
+    void convertOvectorToStringIndicesNullOvectorThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre4jUtils.convertOvectorToStringIndices("test", (long[]) null));
+    }
+
+    @Test
+    void convertOvectorToStringIndicesTooSmallThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre4jUtils.convertOvectorToStringIndices("test", new long[]{0}));
+    }
+
+    @Test
+    void convertOvectorToStringIndicesOddLengthThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre4jUtils.convertOvectorToStringIndices("test", new long[]{0, 5, 1}));
+    }
+
+    @Test
+    void convertOvectorToStringIndicesWithUtf8ByteArray() {
+        var subject = "hello";
+        var subjectUtf8 = subject.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        var ovector = new long[]{0, 5};
+        assertArrayEquals(
+                new int[]{0, 5},
+                Pcre4jUtils.convertOvectorToStringIndices(subject, subjectUtf8, ovector)
+        );
+    }
+
+    @Test
+    void convertOvectorToStringIndicesNullSubjectUtf8Throws() {
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre4jUtils.convertOvectorToStringIndices("test", (byte[]) null, new long[]{0, 5}));
+    }
+
+    // === getGroupNames ===
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getGroupNamesNoNames(IPcre2 api) {
+        var code = new Pcre2Code(api, "(a)(b)");
+        var names = Pcre4jUtils.getGroupNames(code);
+        assertEquals(2, names.length);
+        // All unnamed groups should be null
+        for (var name : names) {
+            assertEquals(null, name);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getGroupNamesWithNames(IPcre2 api) {
+        var code = new Pcre2Code(api, "(?<first>a)(?<second>b)");
+        var names = Pcre4jUtils.getGroupNames(code);
+        assertEquals(2, names.length);
+        assertEquals("first", names[0]);
+        assertEquals("second", names[1]);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getGroupNamesMixedNaming(IPcre2 api) {
+        var code = new Pcre2Code(api, "(?<first>a)(b)(?<third>c)");
+        var names = Pcre4jUtils.getGroupNames(code);
+        assertEquals(3, names.length);
+        assertEquals("first", names[0]);
+        assertEquals(null, names[1]);
+        assertEquals("third", names[2]);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getGroupNamesNullThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getGroupNames(null));
+    }
+
+    // === getMatchGroups ===
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getMatchGroupsWithMatchData(IPcre2 api) {
+        var code = new Pcre2Code(api, "(hello) (world)");
+        var matchData = new Pcre2MatchData(code);
+        code.match("hello world", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null);
+
+        var groups = Pcre4jUtils.getMatchGroups(code, "hello world", matchData);
+        assertEquals(3, groups.length); // full match + 2 groups
+        assertEquals("hello world", groups[0]);
+        assertEquals("hello", groups[1]);
+        assertEquals("world", groups[2]);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getMatchGroupsWithOvector(IPcre2 api) {
+        var code = new Pcre2Code(api, "(hello) (world)");
+        var matchData = new Pcre2MatchData(code);
+        code.match("hello world", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null);
+        var ovector = matchData.ovector();
+
+        var groups = Pcre4jUtils.getMatchGroups(code, "hello world", ovector);
+        assertEquals(3, groups.length);
+        assertEquals("hello world", groups[0]);
+        assertEquals("hello", groups[1]);
+        assertEquals("world", groups[2]);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getMatchGroupsNullCodeThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre4jUtils.getMatchGroups(null, "test", new long[]{0, 4}));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getMatchGroupsNullSubjectThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre4jUtils.getMatchGroups(code, null, new long[]{0, 4}));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getMatchGroupsNullOvectorThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre4jUtils.getMatchGroups(code, "test", (long[]) null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getMatchGroupsNullMatchDataThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre4jUtils.getMatchGroups(code, "test", (Pcre2MatchData) null));
+    }
+
+    // === getNamedMatchGroups ===
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getNamedMatchGroupsNullMatchDataThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "(?<greeting>hello)");
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre4jUtils.getNamedMatchGroups(code, "hello", (Pcre2MatchData) null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getNamedMatchGroupsNullCodeThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre4jUtils.getNamedMatchGroups(null, "test", new long[]{0, 4}));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getNamedMatchGroupsNullSubjectThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre4jUtils.getNamedMatchGroups(code, null, new long[]{0, 4}));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void getNamedMatchGroupsNullOvectorThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "test");
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre4jUtils.getNamedMatchGroups(code, "test", (long[]) null));
+    }
+
+}


### PR DESCRIPTION
## Summary
- Add 8 new test files covering all major lib module classes: `Pcre2Code`, `Pcre2MatchData`, `Pcre2JitCode`, context classes, utility methods, enums, and error types
- Increase lib module instruction coverage from 21% to 81% (target: ≥70%)
- Increase lib module branch coverage from 13% to 74% (target: ≥50%)

Fixes #222

## Test plan
- [x] All 501 lib module tests pass against both JNA and FFM backends
- [x] Checkstyle passes with no violations
- [x] JaCoCo reports 81% instruction and 74% branch coverage
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)