### PR TITLE
(fix) docs: fix Javadoc link in README to point to rendered docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,4 +335,4 @@ The `ffm` module is packaged as a Multi-Release JAR supporting both:
 
 ## Javadoc
 
-Please see [the Javadoc Index](./gh-pages/javadoc/index.md) for the detailed API documentation.
+Please see [the Javadoc Index](https://alexey-pelykh.com/pcre4j/javadoc/) for the detailed API documentation.


### PR DESCRIPTION
## Summary
* Fix Javadoc link in README to point to rendered GitHub Pages URL (`https://alexey-pelykh.com/pcre4j/javadoc/`) instead of the source markdown file (`./gh-pages/javadoc/index.md`)

Fixes #361

## Test plan
- [ ] Verify the link in the rendered README on the PR page navigates to the Javadoc index

🤖 Generated with [Claude Code](https://claude.com/claude-code)