### PR TITLE
(docs) code-of-conduct: use private reporting channel for enforcement

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at https://github.com/alexey-pelykh/pcre4j/issues. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at https://github.com/alexey-pelykh/pcre4j/security/advisories/new. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 


### PR DESCRIPTION
## Summary

- Replace public issue tracker URL with private security advisories URL in the Code of Conduct enforcement section, ensuring reporters of abusive or harassing behavior can do so confidentially

## Test plan

- [ ] Verify the security advisories link resolves correctly: https://github.com/alexey-pelykh/pcre4j/security/advisories/new
- [ ] Confirm no other references to the public issue tracker exist in the Code of Conduct

Fixes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)