### PR TITLE
(chore) repo: gitignore stale test/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,6 +186,9 @@ replay_pid*
 **/build/
 !src/**/build/
 
+# Stale build output from previously-existing test module (not in settings.gradle.kts)
+/test/
+
 # Ignore Gradle GUI config
 gradle-app.setting
 


### PR DESCRIPTION
## Summary
- Explicitly gitignore the stale `test/` directory that contains only build artifacts from a previously-existing test module (not declared in `settings.gradle.kts`)
- The `test/build/` directory was already covered by the `**/build/` gitignore pattern, but this makes the intent explicit and covers any future non-build files that might accidentally appear in `test/`

## Test plan
- [x] Verified `test/` directory only contains stale build output (compiled classes, javadoc)
- [x] Verified `test` module is not in `settings.gradle.kts`
- [x] Verified `.gitignore` entry is correctly placed in the Gradle section

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)