### PR TITLE
(fix) lib: rename misnamed Clean record parameter in Pcre2JitStack

### DIFF
--- a/lib/src/main/java/org/pcre4j/Pcre2JitStack.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2JitStack.java
@@ -93,10 +93,10 @@ public class Pcre2JitStack {
         return handle;
     }
 
-    private record Clean(IPcre2 api, long matchContext) implements Runnable {
+    private record Clean(IPcre2 api, long jitStack) implements Runnable {
         @Override
         public void run() {
-            api.jitStackFree(matchContext);
+            api.jitStackFree(jitStack);
         }
     }
 


### PR DESCRIPTION
## Summary
* Rename the `Clean` record parameter in `Pcre2JitStack` from `matchContext` to `jitStack` to correctly reflect the resource type it manages, consistent with the naming convention used across all other `Clean` records in the codebase

Fixes #337

## Test plan
- [x] `lib:compileJava` passes
- [x] `lib:checkstyleMain` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)