### PR TITLE
(fix) api: catch IOException instead of Exception in Pcre2LibraryFinder.runCommand

### DIFF
--- a/api/src/main/java/org/pcre4j/api/Pcre2LibraryFinder.java
+++ b/api/src/main/java/org/pcre4j/api/Pcre2LibraryFinder.java
@@ -15,6 +15,7 @@
 package org.pcre4j.api;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -355,7 +356,7 @@ public final class Pcre2LibraryFinder {
             LOG.log(Level.FINE, "Command interrupted: " + String.join(" ", command), e);
             Thread.currentThread().interrupt();
             return null;
-        } catch (Exception e) {
+        } catch (IOException e) {
             LOG.log(Level.FINE, "Command failed: " + String.join(" ", command), e);
             return null;
         }


### PR DESCRIPTION
## Summary
- Narrow the catch clause in `Pcre2LibraryFinder.runCommand` from `Exception` to `IOException`, since `ProcessBuilder.start()` only throws `IOException` and `InterruptedException` is already handled by a preceding catch block
- Catching `Exception` was overly broad and could mask programming errors (e.g. `NullPointerException`, `IllegalArgumentException`)

Fixes #343

## Test plan
- [x] Existing `Pcre2LibraryFinderTest` passes (covers successful command, non-existent command, failing command scenarios)
- [x] Checkstyle passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)