### PR TITLE
(fix) lib: remove double-wrapping of exceptions in Pcre2CompileContext

### DIFF
--- a/lib/src/main/java/org/pcre4j/Pcre2CompileContext.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2CompileContext.java
@@ -99,7 +99,7 @@ public class Pcre2CompileContext {
         final var result = api.setNewline(handle, newline.value());
         if (result != 0) {
             final var errorMessage = Pcre4jUtils.getErrorMessage(api, result);
-            throw new RuntimeException("Failed set the newline convention", new IllegalStateException(errorMessage));
+            throw new IllegalStateException(errorMessage);
         }
     }
 
@@ -115,7 +115,7 @@ public class Pcre2CompileContext {
         final var result = api.setBsr(handle, bsr.value());
         if (result != 0) {
             final var errorMessage = Pcre4jUtils.getErrorMessage(api, result);
-            throw new RuntimeException("Failed to set the BSR convention", new IllegalStateException(errorMessage));
+            throw new IllegalStateException(errorMessage);
         }
     }
 
@@ -135,8 +135,7 @@ public class Pcre2CompileContext {
         final var result = api.setParensNestLimit(handle, limit);
         if (result != 0) {
             final var errorMessage = Pcre4jUtils.getErrorMessage(api, result);
-            throw new RuntimeException("Failed to set the parentheses nest limit",
-                    new IllegalStateException(errorMessage));
+            throw new IllegalStateException(errorMessage);
         }
     }
 
@@ -156,8 +155,7 @@ public class Pcre2CompileContext {
         final var result = api.setMaxPatternLength(handle, length);
         if (result != 0) {
             final var errorMessage = Pcre4jUtils.getErrorMessage(api, result);
-            throw new RuntimeException("Failed to set the maximum pattern length",
-                    new IllegalStateException(errorMessage));
+            throw new IllegalStateException(errorMessage);
         }
     }
 
@@ -186,8 +184,7 @@ public class Pcre2CompileContext {
         final var result = api.setCompileExtraOptions(handle, extraOptionsValue);
         if (result != 0) {
             final var errorMessage = Pcre4jUtils.getErrorMessage(api, result);
-            throw new RuntimeException("Failed to set the extra compile options",
-                    new IllegalStateException(errorMessage));
+            throw new IllegalStateException(errorMessage);
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove double-wrapping of exceptions in `Pcre2CompileContext` where `RuntimeException` unnecessarily wrapped `IllegalStateException`
- All 5 setter methods (`setNewline`, `setBsr`, `setParensNestLimit`, `setMaxPatternLength`, `setCompileExtraOptions`) now throw `IllegalStateException` directly with the PCRE2 error message, consistent with the rest of the codebase

## Test plan
- [x] `lib:compileJava` passes
- [x] `lib:checkstyleMain` passes
- [x] `ffm:test` passes (JNA tests blocked by pre-existing dependency verification issue unrelated to this change)

Fixes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)