### PR TITLE
(chore) lib: simplify convertOvectorToStringIndices method

### DIFF
--- a/lib/src/test/java/org/pcre4j/Pcre4jUtilsExtendedTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre4jUtilsExtendedTests.java
@@ -395,7 +395,7 @@ public class Pcre4jUtilsExtendedTests {
     @Test
     void convertOvectorToStringIndicesNullOvectorThrows() {
         assertThrows(IllegalArgumentException.class, () ->
-                Pcre4jUtils.convertOvectorToStringIndices("test", (long[]) null));
+                Pcre4jUtils.convertOvectorToStringIndices("test", null));
     }
 
     @Test
@@ -408,23 +408,6 @@ public class Pcre4jUtilsExtendedTests {
     void convertOvectorToStringIndicesOddLengthThrows() {
         assertThrows(IllegalArgumentException.class, () ->
                 Pcre4jUtils.convertOvectorToStringIndices("test", new long[]{0, 5, 1}));
-    }
-
-    @Test
-    void convertOvectorToStringIndicesWithUtf8ByteArray() {
-        var subject = "hello";
-        var subjectUtf8 = subject.getBytes(java.nio.charset.StandardCharsets.UTF_8);
-        var ovector = new long[]{0, 5};
-        assertArrayEquals(
-                new int[]{0, 5},
-                Pcre4jUtils.convertOvectorToStringIndices(subject, subjectUtf8, ovector)
-        );
-    }
-
-    @Test
-    void convertOvectorToStringIndicesNullSubjectUtf8Throws() {
-        assertThrows(IllegalArgumentException.class, () ->
-                Pcre4jUtils.convertOvectorToStringIndices("test", (byte[]) null, new long[]{0, 5}));
     }
 
     // === getGroupNames ===

--- a/regex/src/main/java/org/pcre4j/regex/Matcher.java
+++ b/regex/src/main/java/org/pcre4j/regex/Matcher.java
@@ -2037,9 +2037,8 @@ public class Matcher implements java.util.regex.MatchResult {
      */
     private void processMatchResult(Pcre2MatchData matchData, RegionSubject regionSubject) {
         lastMatchData = matchData;
-        final var subjectBytes = regionSubject.subject().getBytes(StandardCharsets.UTF_8);
         lastMatchIndices = Pcre4jUtils.convertOvectorToStringIndices(
-                regionSubject.subject(), subjectBytes, matchData.ovector()
+                regionSubject.subject(), matchData.ovector()
         );
 
         // Adjust indices back to full input coordinate space


### PR DESCRIPTION
## Summary

- Remove the unused `subjectUtf8` parameter overload from `convertOvectorToStringIndices` — the `byte[]` parameter was accepted but never used in the computation
- Simplify the byte-offset-to-string-index mapping algorithm by replacing stream-based min/max calculations with a simple forward walk through the subject string
- Update `Matcher.java` to use the simplified 2-arg method, removing the unnecessary `getBytes()` call

Fixes #348

## Test plan

- [x] All existing `Pcre4jUtilsTests` and `Pcre4jUtilsExtendedTests` pass
- [x] All `regex` module tests pass (verifies `Matcher` integration)
- [x] Checkstyle passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)