### PR TITLE
(docs) changelog: document 18-month release gap context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.4.4] - 2026-01-18
 
+> **Note:** The 18-month gap between 0.4.3 and 0.4.4 reflects a period where the project was on hold.
+> Development resumed in January 2026 with renewed focus on `java.util.regex` API compatibility and
+> expanded PCRE2 API coverage.
+
 ### Fixed
 
 - Allow matching empty strings ([#68](https://github.com/alexey-pelykh/pcre4j/pull/68))


### PR DESCRIPTION
## Summary
- Add a note to the 0.4.4 changelog entry explaining the 18-month release gap between 0.4.3 (2024-06-28) and 0.4.4 (2026-01-18), providing context that the project was on hold and resumed with renewed focus on java.util.regex API compatibility and expanded PCRE2 API coverage.

Fixes #364

## Test plan
- [ ] Verify CHANGELOG.md renders correctly with the blockquote note
- [ ] Confirm no other files were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)