### PR TITLE
(docs) readme: link to SECURITY.md from ReDoS Protection section

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ Regular Expression Denial of Service (ReDoS) occurs when a crafted input causes 
 backtracking in a regex engine, leading to excessive CPU usage. PCRE4J provides several layers
 of protection against ReDoS attacks.
 
+For reporting security vulnerabilities, please see the [Security Policy](./SECURITY.md).
+
 ### JIT Compilation (Enabled by Default)
 
 The `regex` module enables PCRE2 JIT compilation by default when the platform supports it.


### PR DESCRIPTION
## Summary
- Add a link to SECURITY.md from the ReDoS Protection section in README.md, so users reading about security protections can easily find the vulnerability reporting policy

Closes #358

## Test plan
- [x] Verify the markdown link renders correctly and points to `./SECURITY.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)