### PR TITLE
(fix) docs: fix Javadoc index package name from org.pcre4j.lib to org.pcre4j

### DIFF
--- a/gh-pages/javadoc/index.md
+++ b/gh-pages/javadoc/index.md
@@ -1,7 +1,7 @@
 # PCRE4J Package Index
 
 - [`org.pcre4j.api`](./api)
-- [`org.pcre4j.lib`](./lib)
+- [`org.pcre4j`](./lib)
 - [`org.pcre4j.jna`](./jna)
 - [`org.pcre4j.ffm`](./ffm)
 - [`org.pcre4j.regex`](./regex)


### PR DESCRIPTION
## Summary
- Fix incorrect package name `org.pcre4j.lib` → `org.pcre4j` in the Javadoc package index (`gh-pages/javadoc/index.md`)
- The `lib` module's actual Java package is `org.pcre4j`, not `org.pcre4j.lib`

Fixes #357

## Test plan
- [x] Verified actual package declarations in `lib/src/main/java/org/pcre4j/*.java` confirm the package is `org.pcre4j`
- [x] Verified other entries in the index (`api`, `jna`, `ffm`, `regex`) are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)