### PR TITLE
(chore) api: remove redundant public modifiers from interface members

### DIFF
--- a/api/src/main/java/org/pcre4j/api/IPcre2.java
+++ b/api/src/main/java/org/pcre4j/api/IPcre2.java
@@ -26,487 +26,487 @@ public interface IPcre2 {
     /**
      * Force pattern anchoring
      */
-    public static final int ANCHORED = 0x80000000;
+    static final int ANCHORED = 0x80000000;
 
     /**
      * Do not check the pattern for UTF validity (only relevant if UTF is set)
      */
-    public static final int NO_UTF_CHECK = 0x40000000;
+    static final int NO_UTF_CHECK = 0x40000000;
 
     /**
      * Pattern can match only at end of subject
      */
-    public static final int ENDANCHORED = 0x20000000;
+    static final int ENDANCHORED = 0x20000000;
 
     /**
      * Allow empty classes
      */
-    public static final int ALLOW_EMPTY_CLASS = 0x00000001;
+    static final int ALLOW_EMPTY_CLASS = 0x00000001;
 
     /**
      * Alternative handling of ⧵u, ⧵U, and ⧵x
      */
-    public static final int ALT_BSUX = 0x00000002;
+    static final int ALT_BSUX = 0x00000002;
 
     /**
      * Compile automatic callouts
      */
-    public static final int AUTO_CALLOUT = 0x00000004;
+    static final int AUTO_CALLOUT = 0x00000004;
 
     /**
      * Do caseless matching
      */
-    public static final int CASELESS = 0x00000008;
+    static final int CASELESS = 0x00000008;
 
     /**
      * $ not to match newline at end
      */
-    public static final int DOLLAR_ENDONLY = 0x00000010;
+    static final int DOLLAR_ENDONLY = 0x00000010;
 
     /**
      * . matches anything including NL
      */
-    public static final int DOTALL = 0x00000020;
+    static final int DOTALL = 0x00000020;
 
     /**
      * Allow duplicate names for subpatterns
      */
-    public static final int DUPNAMES = 0x00000040;
+    static final int DUPNAMES = 0x00000040;
 
     /**
      * Ignore white space and # comments
      */
-    public static final int EXTENDED = 0x00000080;
+    static final int EXTENDED = 0x00000080;
 
     /**
      * Force matching to be before newline
      */
-    public static final int FIRSTLINE = 0x00000100;
+    static final int FIRSTLINE = 0x00000100;
 
     /**
      * Match unset backreferences
      */
-    public static final int MATCH_UNSET_BACKREF = 0x00000200;
+    static final int MATCH_UNSET_BACKREF = 0x00000200;
 
     /**
      * ^ and $ match newlines within data
      */
-    public static final int MULTILINE = 0x00000400;
+    static final int MULTILINE = 0x00000400;
 
     /**
      * Lock out PCRE2_UCP, e.g. via (*UCP)
      */
-    public static final int NEVER_UCP = 0x00000800;
+    static final int NEVER_UCP = 0x00000800;
 
     /**
      * Lock out PCRE2_UTF, e.g. via (*UTF)
      */
-    public static final int NEVER_UTF = 0x00001000;
+    static final int NEVER_UTF = 0x00001000;
 
     /**
      * Disable numbered capturing parentheses (named ones available)
      */
-    public static final int NO_AUTO_CAPTURE = 0x00002000;
+    static final int NO_AUTO_CAPTURE = 0x00002000;
 
     /**
      * Disable auto-possessification
      */
-    public static final int NO_AUTO_POSSESS = 0x00004000;
+    static final int NO_AUTO_POSSESS = 0x00004000;
 
     /**
      * Disable automatic anchoring for .*
      */
-    public static final int NO_DOTSTAR_ANCHOR = 0x00008000;
+    static final int NO_DOTSTAR_ANCHOR = 0x00008000;
 
     /**
      * Disable match-time start optimizations
      */
-    public static final int NO_START_OPTIMIZE = 0x00010000;
+    static final int NO_START_OPTIMIZE = 0x00010000;
 
     /**
      * Use Unicode properties for \d, \w, etc.
      */
-    public static final int UCP = 0x00020000;
+    static final int UCP = 0x00020000;
 
     /**
      * Invert greediness of quantifiers
      */
-    public static final int UNGREEDY = 0x00040000;
+    static final int UNGREEDY = 0x00040000;
 
     /**
      * Treat pattern and subjects as UTF strings
      */
-    public static final int UTF = 0x00080000;
+    static final int UTF = 0x00080000;
 
     /**
      * Lock out the use of \C in patterns
      */
-    public static final int NEVER_BACKSLASH_C = 0x00100000;
+    static final int NEVER_BACKSLASH_C = 0x00100000;
 
     /**
      * Alternative handling of ^ in multiline mode
      */
-    public static final int ALT_CIRCUMFLEX = 0x00200000;
+    static final int ALT_CIRCUMFLEX = 0x00200000;
 
     /**
      * Process backslashes in verb names
      */
-    public static final int ALT_VERBNAMES = 0x00400000;
+    static final int ALT_VERBNAMES = 0x00400000;
 
     /**
      * Enable offset limit for unanchored matching
      */
-    public static final int USE_OFFSET_LIMIT = 0x00800000;
+    static final int USE_OFFSET_LIMIT = 0x00800000;
 
-    public static final int EXTENDED_MORE = 0x01000000;
+    static final int EXTENDED_MORE = 0x01000000;
 
     /**
      * Pattern characters are all literal
      */
-    public static final int LITERAL = 0x02000000;
+    static final int LITERAL = 0x02000000;
 
     /**
      * Enable support for matching invalid UTF
      */
-    public static final int MATCH_INVALID_UTF = 0x04000000;
+    static final int MATCH_INVALID_UTF = 0x04000000;
 
-    public static final int EXTRA_ALLOW_SURROGATE_ESCAPES = 0x00000001;
-    public static final int EXTRA_BAD_ESCAPE_IS_LITERAL = 0x00000002;
-    public static final int EXTRA_MATCH_WORD = 0x00000004;
-    public static final int EXTRA_MATCH_LINE = 0x00000008;
-    public static final int EXTRA_ESCAPED_CR_IS_LF = 0x00000010;
-    public static final int EXTRA_ALT_BSUX = 0x00000020;
-    public static final int EXTRA_ALLOW_LOOKAROUND_BSK = 0x00000040;
-    public static final int EXTRA_CASELESS_RESTRICT = 0x00000080;
-    public static final int EXTRA_ASCII_BSD = 0x00000100;
-    public static final int EXTRA_ASCII_BSS = 0x00000200;
-    public static final int EXTRA_ASCII_BSW = 0x00000400;
-    public static final int EXTRA_ASCII_POSIX = 0x00000800;
-    public static final int EXTRA_ASCII_DIGIT = 0x00001000;
+    static final int EXTRA_ALLOW_SURROGATE_ESCAPES = 0x00000001;
+    static final int EXTRA_BAD_ESCAPE_IS_LITERAL = 0x00000002;
+    static final int EXTRA_MATCH_WORD = 0x00000004;
+    static final int EXTRA_MATCH_LINE = 0x00000008;
+    static final int EXTRA_ESCAPED_CR_IS_LF = 0x00000010;
+    static final int EXTRA_ALT_BSUX = 0x00000020;
+    static final int EXTRA_ALLOW_LOOKAROUND_BSK = 0x00000040;
+    static final int EXTRA_CASELESS_RESTRICT = 0x00000080;
+    static final int EXTRA_ASCII_BSD = 0x00000100;
+    static final int EXTRA_ASCII_BSS = 0x00000200;
+    static final int EXTRA_ASCII_BSW = 0x00000400;
+    static final int EXTRA_ASCII_POSIX = 0x00000800;
+    static final int EXTRA_ASCII_DIGIT = 0x00001000;
 
     /**
      * Compile code for full matching
      */
-    public static final int JIT_COMPLETE = 0x00000001;
+    static final int JIT_COMPLETE = 0x00000001;
 
     /**
      * Compile code for soft partial matching
      */
-    public static final int JIT_PARTIAL_SOFT = 0x00000002;
+    static final int JIT_PARTIAL_SOFT = 0x00000002;
 
     /**
      * Compile code for hard partial matching
      */
-    public static final int JIT_PARTIAL_HARD = 0x00000004;
+    static final int JIT_PARTIAL_HARD = 0x00000004;
 
     /**
      * @deprecated Use {@link #MATCH_INVALID_UTF}
      */
     @Deprecated
-    public static final int JIT_INVALID_UTF = 0x00000100;
+    static final int JIT_INVALID_UTF = 0x00000100;
 
     /**
      * Subject string is not the beginning of a line
      */
-    public static final int NOTBOL = 0x00000001;
+    static final int NOTBOL = 0x00000001;
 
     /**
      * Subject string is not the end of a line
      */
-    public static final int NOTEOL = 0x00000002;
+    static final int NOTEOL = 0x00000002;
 
     /**
      * An empty string is not a valid match
      */
-    public static final int NOTEMPTY = 0x00000004;
+    static final int NOTEMPTY = 0x00000004;
 
     /**
      * An empty string at the start of the subject is not a valid match
      */
-    public static final int NOTEMPTY_ATSTART = 0x00000008;
+    static final int NOTEMPTY_ATSTART = 0x00000008;
 
     /**
      * Return {@link IPcre2#ERROR_PARTIAL} for a partial match even if there is a full match
      */
-    public static final int PARTIAL_SOFT = 0x00000010;
+    static final int PARTIAL_SOFT = 0x00000010;
 
     /**
      * Return {@link IPcre2#ERROR_PARTIAL} for a partial match if no full matches are found
      */
-    public static final int PARTIAL_HARD = 0x00000020;
-    public static final int DFA_RESTART = 0x00000040;
-    public static final int DFA_SHORTEST = 0x00000080;
-    public static final int SUBSTITUTE_GLOBAL = 0x00000100;
-    public static final int SUBSTITUTE_EXTENDED = 0x00000200;
-    public static final int SUBSTITUTE_UNSET_EMPTY = 0x00000400;
-    public static final int SUBSTITUTE_UNKNOWN_UNSET = 0x00000800;
-    public static final int SUBSTITUTE_OVERFLOW_LENGTH = 0x00001000;
+    static final int PARTIAL_HARD = 0x00000020;
+    static final int DFA_RESTART = 0x00000040;
+    static final int DFA_SHORTEST = 0x00000080;
+    static final int SUBSTITUTE_GLOBAL = 0x00000100;
+    static final int SUBSTITUTE_EXTENDED = 0x00000200;
+    static final int SUBSTITUTE_UNSET_EMPTY = 0x00000400;
+    static final int SUBSTITUTE_UNKNOWN_UNSET = 0x00000800;
+    static final int SUBSTITUTE_OVERFLOW_LENGTH = 0x00001000;
 
     /**
      * Do not use JIT matching
      */
-    public static final int NO_JIT = 0x00002000;
+    static final int NO_JIT = 0x00002000;
 
     /**
      * On success, make a private subject copy
      */
-    public static final int COPY_MATCHED_SUBJECT = 0x00004000;
+    static final int COPY_MATCHED_SUBJECT = 0x00004000;
 
-    public static final int SUBSTITUTE_LITERAL = 0x00008000;
-    public static final int SUBSTITUTE_MATCHED = 0x00010000;
-    public static final int SUBSTITUTE_REPLACEMENT_ONLY = 0x00020000;
-    public static final int DISABLE_RECURSELOOP_CHECK = 0x00040000;
+    static final int SUBSTITUTE_LITERAL = 0x00008000;
+    static final int SUBSTITUTE_MATCHED = 0x00010000;
+    static final int SUBSTITUTE_REPLACEMENT_ONLY = 0x00020000;
+    static final int DISABLE_RECURSELOOP_CHECK = 0x00040000;
 
-    public static final int CONVERT_UTF = 0x00000001;
-    public static final int CONVERT_NO_UTF_CHECK = 0x00000002;
-    public static final int CONVERT_POSIX_BASIC = 0x00000004;
-    public static final int CONVERT_POSIX_EXTENDED = 0x00000008;
-    public static final int CONVERT_GLOB = 0x00000010;
-    public static final int CONVERT_GLOB_NO_WILD_SEPARATOR = 0x00000030;
-    public static final int CONVERT_GLOB_NO_STARSTAR = 0x00000050;
+    static final int CONVERT_UTF = 0x00000001;
+    static final int CONVERT_NO_UTF_CHECK = 0x00000002;
+    static final int CONVERT_POSIX_BASIC = 0x00000004;
+    static final int CONVERT_POSIX_EXTENDED = 0x00000008;
+    static final int CONVERT_GLOB = 0x00000010;
+    static final int CONVERT_GLOB_NO_WILD_SEPARATOR = 0x00000030;
+    static final int CONVERT_GLOB_NO_STARSTAR = 0x00000050;
 
     /**
      * Carriage return only (\r)
      */
-    public static final int NEWLINE_CR = 1;
+    static final int NEWLINE_CR = 1;
 
     /**
      * Linefeed only (\n)
      */
-    public static final int NEWLINE_LF = 2;
+    static final int NEWLINE_LF = 2;
 
     /**
      * CR followed by LF only (\r\n)
      */
-    public static final int NEWLINE_CRLF = 3;
+    static final int NEWLINE_CRLF = 3;
 
     /**
      * Any Unicode newline sequence
      */
-    public static final int NEWLINE_ANY = 4;
+    static final int NEWLINE_ANY = 4;
 
     /**
      * Any of {@link #NEWLINE_CR}, {@link #NEWLINE_LF}, or {@link #NEWLINE_CRLF}
      */
-    public static final int NEWLINE_ANYCRLF = 5;
+    static final int NEWLINE_ANYCRLF = 5;
 
     /**
      * NUL character (\0)
      */
-    public static final int NEWLINE_NUL = 6;
+    static final int NEWLINE_NUL = 6;
 
     /**
      * \R corresponds to the Unicode line endings
      */
-    public static final int BSR_UNICODE = 1;
+    static final int BSR_UNICODE = 1;
 
     /**
      * \R corresponds to CR, LF, and CRLF only
      */
-    public static final int BSR_ANYCRLF = 2;
+    static final int BSR_ANYCRLF = 2;
 
-    public static final int ERROR_END_BACKSLASH = 101;
-    public static final int ERROR_END_BACKSLASH_C = 102;
-    public static final int ERROR_UNKNOWN_ESCAPE = 103;
-    public static final int ERROR_QUANTIFIER_OUT_OF_ORDER = 104;
-    public static final int ERROR_QUANTIFIER_TOO_BIG = 105;
-    public static final int ERROR_MISSING_SQUARE_BRACKET = 106;
-    public static final int ERROR_ESCAPE_INVALID_IN_CLASS = 107;
-    public static final int ERROR_CLASS_RANGE_ORDER = 108;
-    public static final int ERROR_QUANTIFIER_INVALID = 109;
-    public static final int ERROR_INTERNAL_UNEXPECTED_REPEAT = 110;
-    public static final int ERROR_INVALID_AFTER_PARENS_QUERY = 111;
-    public static final int ERROR_POSIX_CLASS_NOT_IN_CLASS = 112;
-    public static final int ERROR_POSIX_NO_SUPPORT_COLLATING = 113;
-    public static final int ERROR_MISSING_CLOSING_PARENTHESIS = 114;
-    public static final int ERROR_BAD_SUBPATTERN_REFERENCE = 115;
-    public static final int ERROR_NULL_PATTERN = 116;
-    public static final int ERROR_BAD_OPTIONS = 117;
-    public static final int ERROR_MISSING_COMMENT_CLOSING = 118;
-    public static final int ERROR_PARENTHESES_NEST_TOO_DEEP = 119;
-    public static final int ERROR_PATTERN_TOO_LARGE = 120;
-    public static final int ERROR_HEAP_FAILED = 121;
-    public static final int ERROR_UNMATCHED_CLOSING_PARENTHESIS = 122;
-    public static final int ERROR_INTERNAL_CODE_OVERFLOW = 123;
-    public static final int ERROR_MISSING_CONDITION_CLOSING = 124;
-    public static final int ERROR_LOOKBEHIND_NOT_FIXED_LENGTH = 125;
-    public static final int ERROR_ZERO_RELATIVE_REFERENCE = 126;
-    public static final int ERROR_TOO_MANY_CONDITION_BRANCHES = 127;
-    public static final int ERROR_CONDITION_ASSERTION_EXPECTED = 128;
-    public static final int ERROR_BAD_RELATIVE_REFERENCE = 129;
-    public static final int ERROR_UNKNOWN_POSIX_CLASS = 130;
-    public static final int ERROR_INTERNAL_STUDY_ERROR = 131;
-    public static final int ERROR_UNICODE_NOT_SUPPORTED = 132;
-    public static final int ERROR_PARENTHESES_STACK_CHECK = 133;
-    public static final int ERROR_CODE_POINT_TOO_BIG = 134;
-    public static final int ERROR_LOOKBEHIND_TOO_COMPLICATED = 135;
-    public static final int ERROR_LOOKBEHIND_INVALID_BACKSLASH_C = 136;
-    public static final int ERROR_UNSUPPORTED_ESCAPE_SEQUENCE = 137;
-    public static final int ERROR_CALLOUT_NUMBER_TOO_BIG = 138;
-    public static final int ERROR_MISSING_CALLOUT_CLOSING = 139;
-    public static final int ERROR_ESCAPE_INVALID_IN_VERB = 140;
-    public static final int ERROR_UNRECOGNIZED_AFTER_QUERY_P = 141;
-    public static final int ERROR_MISSING_NAME_TERMINATOR = 142;
-    public static final int ERROR_DUPLICATE_SUBPATTERN_NAME = 143;
-    public static final int ERROR_INVALID_SUBPATTERN_NAME = 144;
-    public static final int ERROR_UNICODE_PROPERTIES_UNAVAILABLE = 145;
-    public static final int ERROR_MALFORMED_UNICODE_PROPERTY = 146;
-    public static final int ERROR_UNKNOWN_UNICODE_PROPERTY = 147;
-    public static final int ERROR_SUBPATTERN_NAME_TOO_LONG = 148;
-    public static final int ERROR_TOO_MANY_NAMED_SUBPATTERNS = 149;
-    public static final int ERROR_CLASS_INVALID_RANGE = 150;
-    public static final int ERROR_OCTAL_BYTE_TOO_BIG = 151;
-    public static final int ERROR_INTERNAL_OVERRAN_WORKSPACE = 152;
-    public static final int ERROR_INTERNAL_MISSING_SUBPATTERN = 153;
-    public static final int ERROR_DEFINE_TOO_MANY_BRANCHES = 154;
-    public static final int ERROR_BACKSLASH_O_MISSING_BRACE = 155;
-    public static final int ERROR_INTERNAL_UNKNOWN_NEWLINE = 156;
-    public static final int ERROR_BACKSLASH_G_SYNTAX = 157;
-    public static final int ERROR_PARENS_QUERY_R_MISSING_CLOSING = 158;
+    static final int ERROR_END_BACKSLASH = 101;
+    static final int ERROR_END_BACKSLASH_C = 102;
+    static final int ERROR_UNKNOWN_ESCAPE = 103;
+    static final int ERROR_QUANTIFIER_OUT_OF_ORDER = 104;
+    static final int ERROR_QUANTIFIER_TOO_BIG = 105;
+    static final int ERROR_MISSING_SQUARE_BRACKET = 106;
+    static final int ERROR_ESCAPE_INVALID_IN_CLASS = 107;
+    static final int ERROR_CLASS_RANGE_ORDER = 108;
+    static final int ERROR_QUANTIFIER_INVALID = 109;
+    static final int ERROR_INTERNAL_UNEXPECTED_REPEAT = 110;
+    static final int ERROR_INVALID_AFTER_PARENS_QUERY = 111;
+    static final int ERROR_POSIX_CLASS_NOT_IN_CLASS = 112;
+    static final int ERROR_POSIX_NO_SUPPORT_COLLATING = 113;
+    static final int ERROR_MISSING_CLOSING_PARENTHESIS = 114;
+    static final int ERROR_BAD_SUBPATTERN_REFERENCE = 115;
+    static final int ERROR_NULL_PATTERN = 116;
+    static final int ERROR_BAD_OPTIONS = 117;
+    static final int ERROR_MISSING_COMMENT_CLOSING = 118;
+    static final int ERROR_PARENTHESES_NEST_TOO_DEEP = 119;
+    static final int ERROR_PATTERN_TOO_LARGE = 120;
+    static final int ERROR_HEAP_FAILED = 121;
+    static final int ERROR_UNMATCHED_CLOSING_PARENTHESIS = 122;
+    static final int ERROR_INTERNAL_CODE_OVERFLOW = 123;
+    static final int ERROR_MISSING_CONDITION_CLOSING = 124;
+    static final int ERROR_LOOKBEHIND_NOT_FIXED_LENGTH = 125;
+    static final int ERROR_ZERO_RELATIVE_REFERENCE = 126;
+    static final int ERROR_TOO_MANY_CONDITION_BRANCHES = 127;
+    static final int ERROR_CONDITION_ASSERTION_EXPECTED = 128;
+    static final int ERROR_BAD_RELATIVE_REFERENCE = 129;
+    static final int ERROR_UNKNOWN_POSIX_CLASS = 130;
+    static final int ERROR_INTERNAL_STUDY_ERROR = 131;
+    static final int ERROR_UNICODE_NOT_SUPPORTED = 132;
+    static final int ERROR_PARENTHESES_STACK_CHECK = 133;
+    static final int ERROR_CODE_POINT_TOO_BIG = 134;
+    static final int ERROR_LOOKBEHIND_TOO_COMPLICATED = 135;
+    static final int ERROR_LOOKBEHIND_INVALID_BACKSLASH_C = 136;
+    static final int ERROR_UNSUPPORTED_ESCAPE_SEQUENCE = 137;
+    static final int ERROR_CALLOUT_NUMBER_TOO_BIG = 138;
+    static final int ERROR_MISSING_CALLOUT_CLOSING = 139;
+    static final int ERROR_ESCAPE_INVALID_IN_VERB = 140;
+    static final int ERROR_UNRECOGNIZED_AFTER_QUERY_P = 141;
+    static final int ERROR_MISSING_NAME_TERMINATOR = 142;
+    static final int ERROR_DUPLICATE_SUBPATTERN_NAME = 143;
+    static final int ERROR_INVALID_SUBPATTERN_NAME = 144;
+    static final int ERROR_UNICODE_PROPERTIES_UNAVAILABLE = 145;
+    static final int ERROR_MALFORMED_UNICODE_PROPERTY = 146;
+    static final int ERROR_UNKNOWN_UNICODE_PROPERTY = 147;
+    static final int ERROR_SUBPATTERN_NAME_TOO_LONG = 148;
+    static final int ERROR_TOO_MANY_NAMED_SUBPATTERNS = 149;
+    static final int ERROR_CLASS_INVALID_RANGE = 150;
+    static final int ERROR_OCTAL_BYTE_TOO_BIG = 151;
+    static final int ERROR_INTERNAL_OVERRAN_WORKSPACE = 152;
+    static final int ERROR_INTERNAL_MISSING_SUBPATTERN = 153;
+    static final int ERROR_DEFINE_TOO_MANY_BRANCHES = 154;
+    static final int ERROR_BACKSLASH_O_MISSING_BRACE = 155;
+    static final int ERROR_INTERNAL_UNKNOWN_NEWLINE = 156;
+    static final int ERROR_BACKSLASH_G_SYNTAX = 157;
+    static final int ERROR_PARENS_QUERY_R_MISSING_CLOSING = 158;
     @Deprecated
-    public static final int ERROR_VERB_ARGUMENT_NOT_ALLOWED = 159;
-    public static final int ERROR_VERB_UNKNOWN = 160;
-    public static final int ERROR_SUBPATTERN_NUMBER_TOO_BIG = 161;
-    public static final int ERROR_SUBPATTERN_NAME_EXPECTED = 162;
-    public static final int ERROR_INTERNAL_PARSED_OVERFLOW = 163;
-    public static final int ERROR_INVALID_OCTAL = 164;
-    public static final int ERROR_SUBPATTERN_NAMES_MISMATCH = 165;
-    public static final int ERROR_MARK_MISSING_ARGUMENT = 166;
-    public static final int ERROR_INVALID_HEXADECIMAL = 167;
-    public static final int ERROR_BACKSLASH_C_SYNTAX = 168;
-    public static final int ERROR_BACKSLASH_K_SYNTAX = 169;
-    public static final int ERROR_INTERNAL_BAD_CODE_LOOKBEHINDS = 170;
-    public static final int ERROR_BACKSLASH_N_IN_CLASS = 171;
-    public static final int ERROR_CALLOUT_STRING_TOO_LONG = 172;
-    public static final int ERROR_UNICODE_DISALLOWED_CODE_POINT = 173;
-    public static final int ERROR_UTF_IS_DISABLED = 174;
-    public static final int ERROR_UCP_IS_DISABLED = 175;
-    public static final int ERROR_VERB_NAME_TOO_LONG = 176;
-    public static final int ERROR_BACKSLASH_U_CODE_POINT_TOO_BIG = 177;
-    public static final int ERROR_MISSING_OCTAL_OR_HEX_DIGITS = 178;
-    public static final int ERROR_VERSION_CONDITION_SYNTAX = 179;
-    public static final int ERROR_INTERNAL_BAD_CODE_AUTO_POSSESS = 180;
-    public static final int ERROR_CALLOUT_NO_STRING_DELIMITER = 181;
-    public static final int ERROR_CALLOUT_BAD_STRING_DELIMITER = 182;
-    public static final int ERROR_BACKSLASH_C_CALLER_DISABLED = 183;
-    public static final int ERROR_QUERY_BARJX_NEST_TOO_DEEP = 184;
-    public static final int ERROR_BACKSLASH_C_LIBRARY_DISABLED = 185;
-    public static final int ERROR_PATTERN_TOO_COMPLICATED = 186;
-    public static final int ERROR_LOOKBEHIND_TOO_LONG = 187;
-    public static final int ERROR_PATTERN_STRING_TOO_LONG = 188;
-    public static final int ERROR_INTERNAL_BAD_CODE = 189;
-    public static final int ERROR_INTERNAL_BAD_CODE_IN_SKIP = 190;
-    public static final int ERROR_NO_SURROGATES_IN_UTF16 = 191;
-    public static final int ERROR_BAD_LITERAL_OPTIONS = 192;
-    public static final int ERROR_SUPPORTED_ONLY_IN_UNICODE = 193;
-    public static final int ERROR_INVALID_HYPHEN_IN_OPTIONS = 194;
-    public static final int ERROR_ALPHA_ASSERTION_UNKNOWN = 195;
-    public static final int ERROR_SCRIPT_RUN_NOT_AVAILABLE = 196;
-    public static final int ERROR_TOO_MANY_CAPTURES = 197;
-    public static final int ERROR_CONDITION_ATOMIC_ASSERTION_EXPECTED = 198;
-    public static final int ERROR_BACKSLASH_K_IN_LOOKAROUND = 199;
+    static final int ERROR_VERB_ARGUMENT_NOT_ALLOWED = 159;
+    static final int ERROR_VERB_UNKNOWN = 160;
+    static final int ERROR_SUBPATTERN_NUMBER_TOO_BIG = 161;
+    static final int ERROR_SUBPATTERN_NAME_EXPECTED = 162;
+    static final int ERROR_INTERNAL_PARSED_OVERFLOW = 163;
+    static final int ERROR_INVALID_OCTAL = 164;
+    static final int ERROR_SUBPATTERN_NAMES_MISMATCH = 165;
+    static final int ERROR_MARK_MISSING_ARGUMENT = 166;
+    static final int ERROR_INVALID_HEXADECIMAL = 167;
+    static final int ERROR_BACKSLASH_C_SYNTAX = 168;
+    static final int ERROR_BACKSLASH_K_SYNTAX = 169;
+    static final int ERROR_INTERNAL_BAD_CODE_LOOKBEHINDS = 170;
+    static final int ERROR_BACKSLASH_N_IN_CLASS = 171;
+    static final int ERROR_CALLOUT_STRING_TOO_LONG = 172;
+    static final int ERROR_UNICODE_DISALLOWED_CODE_POINT = 173;
+    static final int ERROR_UTF_IS_DISABLED = 174;
+    static final int ERROR_UCP_IS_DISABLED = 175;
+    static final int ERROR_VERB_NAME_TOO_LONG = 176;
+    static final int ERROR_BACKSLASH_U_CODE_POINT_TOO_BIG = 177;
+    static final int ERROR_MISSING_OCTAL_OR_HEX_DIGITS = 178;
+    static final int ERROR_VERSION_CONDITION_SYNTAX = 179;
+    static final int ERROR_INTERNAL_BAD_CODE_AUTO_POSSESS = 180;
+    static final int ERROR_CALLOUT_NO_STRING_DELIMITER = 181;
+    static final int ERROR_CALLOUT_BAD_STRING_DELIMITER = 182;
+    static final int ERROR_BACKSLASH_C_CALLER_DISABLED = 183;
+    static final int ERROR_QUERY_BARJX_NEST_TOO_DEEP = 184;
+    static final int ERROR_BACKSLASH_C_LIBRARY_DISABLED = 185;
+    static final int ERROR_PATTERN_TOO_COMPLICATED = 186;
+    static final int ERROR_LOOKBEHIND_TOO_LONG = 187;
+    static final int ERROR_PATTERN_STRING_TOO_LONG = 188;
+    static final int ERROR_INTERNAL_BAD_CODE = 189;
+    static final int ERROR_INTERNAL_BAD_CODE_IN_SKIP = 190;
+    static final int ERROR_NO_SURROGATES_IN_UTF16 = 191;
+    static final int ERROR_BAD_LITERAL_OPTIONS = 192;
+    static final int ERROR_SUPPORTED_ONLY_IN_UNICODE = 193;
+    static final int ERROR_INVALID_HYPHEN_IN_OPTIONS = 194;
+    static final int ERROR_ALPHA_ASSERTION_UNKNOWN = 195;
+    static final int ERROR_SCRIPT_RUN_NOT_AVAILABLE = 196;
+    static final int ERROR_TOO_MANY_CAPTURES = 197;
+    static final int ERROR_CONDITION_ATOMIC_ASSERTION_EXPECTED = 198;
+    static final int ERROR_BACKSLASH_K_IN_LOOKAROUND = 199;
 
-    public static final int ERROR_NOMATCH = -1;
-    public static final int ERROR_PARTIAL = -2;
-    public static final int ERROR_UTF8_ERR1 = -3;
-    public static final int ERROR_UTF8_ERR2 = -4;
-    public static final int ERROR_UTF8_ERR3 = -5;
-    public static final int ERROR_UTF8_ERR4 = -6;
-    public static final int ERROR_UTF8_ERR5 = -7;
-    public static final int ERROR_UTF8_ERR6 = -8;
-    public static final int ERROR_UTF8_ERR7 = -9;
-    public static final int ERROR_UTF8_ERR8 = -10;
-    public static final int ERROR_UTF8_ERR9 = -11;
-    public static final int ERROR_UTF8_ERR10 = -12;
-    public static final int ERROR_UTF8_ERR11 = -13;
-    public static final int ERROR_UTF8_ERR12 = -14;
-    public static final int ERROR_UTF8_ERR13 = -15;
-    public static final int ERROR_UTF8_ERR14 = -16;
-    public static final int ERROR_UTF8_ERR15 = -17;
-    public static final int ERROR_UTF8_ERR16 = -18;
-    public static final int ERROR_UTF8_ERR17 = -19;
-    public static final int ERROR_UTF8_ERR18 = -20;
-    public static final int ERROR_UTF8_ERR19 = -21;
-    public static final int ERROR_UTF8_ERR20 = -22;
-    public static final int ERROR_UTF8_ERR21 = -23;
-    public static final int ERROR_UTF16_ERR1 = -24;
-    public static final int ERROR_UTF16_ERR2 = -25;
-    public static final int ERROR_UTF16_ERR3 = -26;
-    public static final int ERROR_UTF32_ERR1 = -27;
-    public static final int ERROR_UTF32_ERR2 = -28;
-    public static final int ERROR_BADDATA = -29;
-    public static final int ERROR_MIXEDTABLES = -30;
-    public static final int ERROR_BADMAGIC = -31;
-    public static final int ERROR_BADMODE = -32;
-    public static final int ERROR_BADOFFSET = -33;
-    public static final int ERROR_BADOPTION = -34;
-    public static final int ERROR_BADREPLACEMENT = -35;
-    public static final int ERROR_BADUTFOFFSET = -36;
-    public static final int ERROR_CALLOUT = -37;
-    public static final int ERROR_DFA_BADRESTART = -38;
-    public static final int ERROR_DFA_RECURSE = -39;
-    public static final int ERROR_DFA_UCOND = -40;
-    public static final int ERROR_DFA_UFUNC = -41;
-    public static final int ERROR_DFA_UITEM = -42;
-    public static final int ERROR_DFA_WSSIZE = -43;
-    public static final int ERROR_INTERNAL = -44;
-    public static final int ERROR_JIT_BADOPTION = -45;
-    public static final int ERROR_JIT_STACKLIMIT = -46;
-    public static final int ERROR_MATCHLIMIT = -47;
-    public static final int ERROR_NOMEMORY = -48;
-    public static final int ERROR_NOSUBSTRING = -49;
-    public static final int ERROR_NOUNIQUESUBSTRING = -50;
-    public static final int ERROR_NULL = -51;
-    public static final int ERROR_RECURSELOOP = -52;
-    public static final int ERROR_DEPTHLIMIT = -53;
+    static final int ERROR_NOMATCH = -1;
+    static final int ERROR_PARTIAL = -2;
+    static final int ERROR_UTF8_ERR1 = -3;
+    static final int ERROR_UTF8_ERR2 = -4;
+    static final int ERROR_UTF8_ERR3 = -5;
+    static final int ERROR_UTF8_ERR4 = -6;
+    static final int ERROR_UTF8_ERR5 = -7;
+    static final int ERROR_UTF8_ERR6 = -8;
+    static final int ERROR_UTF8_ERR7 = -9;
+    static final int ERROR_UTF8_ERR8 = -10;
+    static final int ERROR_UTF8_ERR9 = -11;
+    static final int ERROR_UTF8_ERR10 = -12;
+    static final int ERROR_UTF8_ERR11 = -13;
+    static final int ERROR_UTF8_ERR12 = -14;
+    static final int ERROR_UTF8_ERR13 = -15;
+    static final int ERROR_UTF8_ERR14 = -16;
+    static final int ERROR_UTF8_ERR15 = -17;
+    static final int ERROR_UTF8_ERR16 = -18;
+    static final int ERROR_UTF8_ERR17 = -19;
+    static final int ERROR_UTF8_ERR18 = -20;
+    static final int ERROR_UTF8_ERR19 = -21;
+    static final int ERROR_UTF8_ERR20 = -22;
+    static final int ERROR_UTF8_ERR21 = -23;
+    static final int ERROR_UTF16_ERR1 = -24;
+    static final int ERROR_UTF16_ERR2 = -25;
+    static final int ERROR_UTF16_ERR3 = -26;
+    static final int ERROR_UTF32_ERR1 = -27;
+    static final int ERROR_UTF32_ERR2 = -28;
+    static final int ERROR_BADDATA = -29;
+    static final int ERROR_MIXEDTABLES = -30;
+    static final int ERROR_BADMAGIC = -31;
+    static final int ERROR_BADMODE = -32;
+    static final int ERROR_BADOFFSET = -33;
+    static final int ERROR_BADOPTION = -34;
+    static final int ERROR_BADREPLACEMENT = -35;
+    static final int ERROR_BADUTFOFFSET = -36;
+    static final int ERROR_CALLOUT = -37;
+    static final int ERROR_DFA_BADRESTART = -38;
+    static final int ERROR_DFA_RECURSE = -39;
+    static final int ERROR_DFA_UCOND = -40;
+    static final int ERROR_DFA_UFUNC = -41;
+    static final int ERROR_DFA_UITEM = -42;
+    static final int ERROR_DFA_WSSIZE = -43;
+    static final int ERROR_INTERNAL = -44;
+    static final int ERROR_JIT_BADOPTION = -45;
+    static final int ERROR_JIT_STACKLIMIT = -46;
+    static final int ERROR_MATCHLIMIT = -47;
+    static final int ERROR_NOMEMORY = -48;
+    static final int ERROR_NOSUBSTRING = -49;
+    static final int ERROR_NOUNIQUESUBSTRING = -50;
+    static final int ERROR_NULL = -51;
+    static final int ERROR_RECURSELOOP = -52;
+    static final int ERROR_DEPTHLIMIT = -53;
     @Deprecated
-    public static final int ERROR_RECURSIONLIMIT = -53;
-    public static final int ERROR_UNAVAILABLE = -54;
-    public static final int ERROR_UNSET = -55;
-    public static final int ERROR_BADOFFSETLIMIT = -56;
-    public static final int ERROR_BADREPESCAPE = -57;
-    public static final int ERROR_REPMISSINGBRACE = -58;
-    public static final int ERROR_BADSUBSTITUTION = -59;
-    public static final int ERROR_BADSUBSPATTERN = -60;
-    public static final int ERROR_TOOMANYREPLACE = -61;
-    public static final int ERROR_BADSERIALIZEDDATA = -62;
-    public static final int ERROR_HEAPLIMIT = -63;
-    public static final int ERROR_CONVERT_SYNTAX = -64;
-    public static final int ERROR_INTERNAL_DUPMATCH = -65;
-    public static final int ERROR_DFA_UINVALID_UTF = -66;
-    public static final int ERROR_INVALIDOFFSET = -67;
+    static final int ERROR_RECURSIONLIMIT = -53;
+    static final int ERROR_UNAVAILABLE = -54;
+    static final int ERROR_UNSET = -55;
+    static final int ERROR_BADOFFSETLIMIT = -56;
+    static final int ERROR_BADREPESCAPE = -57;
+    static final int ERROR_REPMISSINGBRACE = -58;
+    static final int ERROR_BADSUBSTITUTION = -59;
+    static final int ERROR_BADSUBSPATTERN = -60;
+    static final int ERROR_TOOMANYREPLACE = -61;
+    static final int ERROR_BADSERIALIZEDDATA = -62;
+    static final int ERROR_HEAPLIMIT = -63;
+    static final int ERROR_CONVERT_SYNTAX = -64;
+    static final int ERROR_INTERNAL_DUPMATCH = -65;
+    static final int ERROR_DFA_UINVALID_UTF = -66;
+    static final int ERROR_INVALIDOFFSET = -67;
 
     /**
      * Final options after compiling
      */
-    public static final int INFO_ALLOPTIONS = 0;
+    static final int INFO_ALLOPTIONS = 0;
 
     /**
      * Options passed to {@link #compile}
      */
-    public static final int INFO_ARGOPTIONS = 1;
+    static final int INFO_ARGOPTIONS = 1;
 
     /**
      * Number of highest backreference
      */
-    public static final int INFO_BACKREFMAX = 2;
+    static final int INFO_BACKREFMAX = 2;
 
     /**
      * What \R matches:
      * PCRE2_BSR_UNICODE: Unicode line endings
      * PCRE2_BSR_ANYCRLF: CR, LF, or CRLF only
      */
-    public static final int INFO_BSR = 3;
+    static final int INFO_BSR = 3;
 
     /**
      * Number of capturing subpatterns
      */
-    public static final int INFO_CAPTURECOUNT = 4;
+    static final int INFO_CAPTURECOUNT = 4;
 
     /**
      * First code unit when type is 1
      */
-    public static final int INFO_FIRSTCODEUNIT = 5;
+    static final int INFO_FIRSTCODEUNIT = 5;
 
     /**
      * Type of start-of-match information
@@ -514,74 +514,74 @@ public interface IPcre2 {
      * 1 first code unit is set
      * 2 start of string or after newline
      */
-    public static final int INFO_FIRSTCODETYPE = 6;
+    static final int INFO_FIRSTCODETYPE = 6;
 
     /**
      * Bitmap of first code units, or 0
      */
-    public static final int INFO_FIRSTBITMAP = 7;
+    static final int INFO_FIRSTBITMAP = 7;
 
     /**
      * Return 1 if explicit CR or LF matches exist in the pattern
      */
-    public static final int INFO_HASCRORLF = 8;
+    static final int INFO_HASCRORLF = 8;
 
     /**
      * Return 1 if (?J) or (?-J) was used
      */
-    public static final int INFO_JCHANGED = 9;
+    static final int INFO_JCHANGED = 9;
 
     /**
      * Size of JIT compiled code, or 0
      */
-    public static final int INFO_JITSIZE = 10;
+    static final int INFO_JITSIZE = 10;
 
     /**
      * Last code unit when type is 1
      */
-    public static final int INFO_LASTCODEUNIT = 11;
+    static final int INFO_LASTCODEUNIT = 11;
 
     /**
      * Type of must-be-present information
      * 0 nothing set
      * 1 code unit is set
      */
-    public static final int INFO_LASTCODETYPE = 12;
+    static final int INFO_LASTCODETYPE = 12;
 
     /**
      * 1 if the pattern can match an empty string, 0 otherwise
      */
-    public static final int INFO_MATCHEMPTY = 13;
+    static final int INFO_MATCHEMPTY = 13;
 
     /**
      * Match limit if set, otherwise {@link #ERROR_UNSET}
      */
-    public static final int INFO_MATCHLIMIT = 14;
+    static final int INFO_MATCHLIMIT = 14;
 
     /**
      * Length (in characters) of the longest lookbehind assertion
      */
-    public static final int INFO_MAXLOOKBEHIND = 15;
+    static final int INFO_MAXLOOKBEHIND = 15;
 
     /**
      * Lower bound length of matching strings
      */
-    public static final int INFO_MINLENGTH = 16;
+    static final int INFO_MINLENGTH = 16;
 
     /**
      * Number of named subpatterns
      */
-    public static final int INFO_NAMECOUNT = 17;
+    static final int INFO_NAMECOUNT = 17;
 
     /**
      * Size of name table entries
      */
-    public static final int INFO_NAMEENTRYSIZE = 18;
+    static final int INFO_NAMEENTRYSIZE = 18;
 
     /**
      * Pointer to name table
      */
-    public static final int INFO_NAMETABLE = 19;
+    static final int INFO_NAMETABLE = 19;
 
     /**
      * Code for the newline sequence:
@@ -592,63 +592,63 @@ public interface IPcre2 {
      * {@link #NEWLINE_ANYCRLF}
      * {@link #NEWLINE_NUL}
      */
-    public static final int INFO_NEWLINE = 20;
+    static final int INFO_NEWLINE = 20;
 
     /**
      * Backtracking depth limit if set, otherwise {@link #ERROR_UNSET}
      */
-    public static final int INFO_DEPTHLIMIT = 21;
+    static final int INFO_DEPTHLIMIT = 21;
 
     /**
      * Obsolete synonym for {@link #INFO_DEPTHLIMIT}
      */
     @Deprecated
-    public static final int INFO_RECURSIONLIMIT = 21;
+    static final int INFO_RECURSIONLIMIT = 21;
 
     /**
      * Size of compiled pattern
      */
-    public static final int INFO_SIZE = 22;
+    static final int INFO_SIZE = 22;
 
     /**
      * Return 1 if pattern contains \C
      */
-    public static final int INFO_HASBACKSLASHC = 23;
+    static final int INFO_HASBACKSLASHC = 23;
 
     /**
      * Size of backtracking frame
      */
-    public static final int INFO_FRAMESIZE = 24;
+    static final int INFO_FRAMESIZE = 24;
 
     /**
      * Heap memory limit if set, otherwise {@link #ERROR_UNSET}
      */
-    public static final int INFO_HEAPLIMIT = 25;
+    static final int INFO_HEAPLIMIT = 25;
 
     /**
      * Extra options that were passed in the compile context
      */
-    public static final int INFO_EXTRAOPTIONS = 26;
+    static final int INFO_EXTRAOPTIONS = 26;
 
-    public static final int CONFIG_BSR = 0;
-    public static final int CONFIG_JIT = 1;
-    public static final int CONFIG_JITTARGET = 2;
-    public static final int CONFIG_LINKSIZE = 3;
-    public static final int CONFIG_MATCHLIMIT = 4;
-    public static final int CONFIG_NEWLINE = 5;
-    public static final int CONFIG_PARENSLIMIT = 6;
-    public static final int CONFIG_DEPTHLIMIT = 7;
+    static final int CONFIG_BSR = 0;
+    static final int CONFIG_JIT = 1;
+    static final int CONFIG_JITTARGET = 2;
+    static final int CONFIG_LINKSIZE = 3;
+    static final int CONFIG_MATCHLIMIT = 4;
+    static final int CONFIG_NEWLINE = 5;
+    static final int CONFIG_PARENSLIMIT = 6;
+    static final int CONFIG_DEPTHLIMIT = 7;
     @Deprecated
-    public static final int CONFIG_RECURSIONLIMIT = 7;
+    static final int CONFIG_RECURSIONLIMIT = 7;
     @Deprecated
-    public static final int CONFIG_STACKRECURSE = 8;
-    public static final int CONFIG_UNICODE = 9;
-    public static final int CONFIG_UNICODE_VERSION = 10;
-    public static final int CONFIG_VERSION = 11;
-    public static final int CONFIG_HEAPLIMIT = 12;
-    public static final int CONFIG_NEVER_BACKSLASH_C = 13;
-    public static final int CONFIG_COMPILED_WIDTHS = 14;
-    public static final int CONFIG_TABLES_LENGTH = 15;
+    static final int CONFIG_STACKRECURSE = 8;
+    static final int CONFIG_UNICODE = 9;
+    static final int CONFIG_UNICODE_VERSION = 10;
+    static final int CONFIG_VERSION = 11;
+    static final int CONFIG_HEAPLIMIT = 12;
+    static final int CONFIG_NEVER_BACKSLASH_C = 13;
+    static final int CONFIG_COMPILED_WIDTHS = 14;
+    static final int CONFIG_TABLES_LENGTH = 15;
 
     /**
      * Get the amount of memory needed to store the information referred to by {@param what} about the optional features
@@ -662,7 +662,7 @@ public interface IPcre2 {
      * @param what the information to query the memory requirements for
      * @return the amount of memory needed to store the information referred to by {@param what}.
      */
-    public int config(int what);
+    int config(int what);
 
     /**
      * Get the information referred to by {@param what} about the optional features of the PCRE2 library.
@@ -676,7 +676,7 @@ public interface IPcre2 {
      * @param where the array to store the information
      * @return Non-negative value on success, otherwise a negative error code.
      */
-    public int config(int what, int[] where);
+    int config(int what, int[] where);
 
     /**
      * Get the information referred to by {@param what} about the optional features of the PCRE2 library.
@@ -690,7 +690,7 @@ public interface IPcre2 {
      * @param where a buffer to store the information
      * @return Non-negative value on success, otherwise a negative error code.
      */
-    public int config(int what, ByteBuffer where);
+    int config(int what, ByteBuffer where);
 
     /**
      * Create a new general context.
@@ -700,7 +700,7 @@ public interface IPcre2 {
      * @param memoryData    the memory data to pass to the private malloc and free functions
      * @return the general context handle
      */
-    public long generalContextCreate(long privateMalloc, long privateFree, long memoryData);
+    long generalContextCreate(long privateMalloc, long privateFree, long memoryData);
 
     /**
      * Create a copy of a general context.
@@ -708,14 +708,14 @@ public interface IPcre2 {
      * @param gcontext the general context handle to copy
      * @return the new general context handle
      */
-    public long generalContextCopy(long gcontext);
+    long generalContextCopy(long gcontext);
 
     /**
      * Free a general context.
      *
      * @param gcontext the general context handle
      */
-    public void generalContextFree(long gcontext);
+    void generalContextFree(long gcontext);
 
     /**
      * Build character tables in the current locale.
@@ -734,7 +734,7 @@ public interface IPcre2 {
      * @return a pointer to the character tables, or 0 if memory allocation fails
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_maketables.html">pcre2_maketables</a>
      */
-    public long maketables(long gcontext);
+    long maketables(long gcontext);
 
     /**
      * Free character tables that were obtained from {@link #maketables}.
@@ -749,7 +749,7 @@ public interface IPcre2 {
      * @param tables   the pointer to the character tables to free (may be 0, in which case the function does nothing)
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_maketables_free.html">pcre2_maketables_free</a>
      */
-    public void maketablesFree(long gcontext, long tables);
+    void maketablesFree(long gcontext, long tables);
 
     /**
      * Create a new compile context.
@@ -757,7 +757,7 @@ public interface IPcre2 {
      * @param gcontext the general context handle or 0
      * @return the compile context handle
      */
-    public long compileContextCreate(long gcontext);
+    long compileContextCreate(long gcontext);
 
     /**
      * Create a copy of a compile context.
@@ -765,14 +765,14 @@ public interface IPcre2 {
      * @param ccontext the compile context handle to copy
      * @return the new compile context handle
      */
-    public long compileContextCopy(long ccontext);
+    long compileContextCopy(long ccontext);
 
     /**
      * Free a compile context.
      *
      * @param ccontext the compile context handle
      */
-    public void compileContextFree(long ccontext);
+    void compileContextFree(long ccontext);
 
     /**
      * Compile a regular expression pattern.
@@ -785,7 +785,7 @@ public interface IPcre2 {
      * @return a compiled pattern handle
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_compile.html">pcre2_compile</a>
      */
-    public long compile(String pattern, int options, int[] errorcode, long[] erroroffset, long ccontext);
+    long compile(String pattern, int options, int[] errorcode, long[] erroroffset, long ccontext);
 
     /**
      * Create a copy of a compiled pattern.
@@ -798,7 +798,7 @@ public interface IPcre2 {
      * @return the new compiled pattern handle, or 0 if the input is 0 or memory allocation fails
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_code_copy.html">pcre2_code_copy</a>
      */
-    public long codeCopy(long code);
+    long codeCopy(long code);
 
     /**
      * Create a copy of a compiled pattern and its character tables.
@@ -815,7 +815,7 @@ public interface IPcre2 {
      * @return the new compiled pattern handle, or 0 if the input is 0 or memory allocation fails
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_code_copy_with_tables.html">pcre2_code_copy_with_tables</a>
      */
-    public long codeCopyWithTables(long code);
+    long codeCopyWithTables(long code);
 
     /**
      * Free a compiled pattern resources.
@@ -823,7 +823,7 @@ public interface IPcre2 {
      * @param code the compiled pattern handle
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_code_free.html">pcre2_code_free</a>
      */
-    public void codeFree(long code);
+    void codeFree(long code);
 
     /**
      * Enumerate callouts in a compiled pattern.
@@ -839,7 +839,7 @@ public interface IPcre2 {
      * @return 0 for successful completion, or a non-zero value if the callback returns non-zero or an error occurs
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_callout_enumerate.html">pcre2_callout_enumerate</a>
      */
-    public int calloutEnumerate(long code, long callback, long calloutData);
+    int calloutEnumerate(long code, long callback, long calloutData);
 
     /**
      * Get the error message for the given error code.
@@ -850,7 +850,7 @@ public interface IPcre2 {
      * {@param errorcode} is not a valid error code, {@link #ERROR_BADDATA} is returned
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_get_error_message.html">pcre2_get_error_message</a>
      */
-    public int getErrorMessage(int errorcode, ByteBuffer buffer);
+    int getErrorMessage(int errorcode, ByteBuffer buffer);
 
     /**
      * Retrieve size of the information about a compiled pattern.
@@ -864,7 +864,7 @@ public interface IPcre2 {
      * {@link #ERROR_BADMODE} the pattern was compiled in the wrong mode
      * {@link #ERROR_UNSET} the requested information is not set
      */
-    public int patternInfo(long code, int what);
+    int patternInfo(long code, int what);
 
     /**
      * Retrieve the information about a compiled pattern as Integer.
@@ -887,7 +887,7 @@ public interface IPcre2 {
      * {@link #ERROR_BADMODE} the pattern was compiled in the wrong mode
      * {@link #ERROR_UNSET} the requested information is not set
      */
-    public int patternInfo(long code, int what, int[] where);
+    int patternInfo(long code, int what, int[] where);
 
     /**
      * Retrieve the information about a compiled pattern as Long.
@@ -907,7 +907,7 @@ public interface IPcre2 {
      * {@link #ERROR_BADMODE} the pattern was compiled in the wrong mode
      * {@link #ERROR_UNSET} the requested information is not set
      */
-    public int patternInfo(long code, int what, long[] where);
+    int patternInfo(long code, int what, long[] where);
 
     /**
      * Retrieve the information about a compiled pattern as byte buffer.
@@ -925,7 +925,7 @@ public interface IPcre2 {
      * {@link #ERROR_BADMODE} the pattern was compiled in the wrong mode
      * {@link #ERROR_UNSET} the requested information is not set
      */
-    public int patternInfo(long code, int what, ByteBuffer where);
+    int patternInfo(long code, int what, ByteBuffer where);
 
     /**
      * JIT-compile a compiled pattern.
@@ -934,7 +934,7 @@ public interface IPcre2 {
      * @param options option bits
      * @return 0 on success, otherwise a negative error code
      */
-    public int jitCompile(long code, int options);
+    int jitCompile(long code, int options);
 
     /**
      * Match a compiled pattern against a subject string.
@@ -948,7 +948,7 @@ public interface IPcre2 {
      * @return the number of captures plus one, zero if the {@code matchData} is too small, or a negative value if there
      * was no match or an actual error occurred
      */
-    public int jitMatch(long code, String subject, int startoffset, int options, long matchData, long mcontext);
+    int jitMatch(long code, String subject, int startoffset, int options, long matchData, long mcontext);
 
     /**
      * Create a JIT stack.
@@ -958,14 +958,14 @@ public interface IPcre2 {
      * @param gcontext  the general context handle or 0
      * @return the JIT stack handle
      */
-    public long jitStackCreate(long startsize, long maxsize, long gcontext);
+    long jitStackCreate(long startsize, long maxsize, long gcontext);
 
     /**
      * Free a JIT stack.
      *
      * @param jitStack the JIT stack handle
      */
-    public void jitStackFree(long jitStack);
+    void jitStackFree(long jitStack);
 
     /**
      * Assign the JIT stack to a match context.
@@ -974,7 +974,7 @@ public interface IPcre2 {
      * @param callback a callback function handle or 0
      * @param data     a JIT stack handle or a value to be passed to the callback function
      */
-    public void jitStackAssign(long mcontext, long callback, long data);
+    void jitStackAssign(long mcontext, long callback, long data);
 
     /**
      * Free unused JIT executable memory.
@@ -992,7 +992,7 @@ public interface IPcre2 {
      * @param gcontext the general context handle that was used for JIT compilation, or 0 if default was used
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_jit_free_unused_memory.html">pcre2_jit_free_unused_memory</a>
      */
-    public void jitFreeUnusedMemory(long gcontext);
+    void jitFreeUnusedMemory(long gcontext);
 
     /**
      * Create a new match data block.
@@ -1001,7 +1001,7 @@ public interface IPcre2 {
      * @param gcontext the general context handle or 0
      * @return the match data handle
      */
-    public long matchDataCreate(int ovecsize, long gcontext);
+    long matchDataCreate(int ovecsize, long gcontext);
 
     /**
      * Create a new match data block from a compiled pattern.
@@ -1010,14 +1010,14 @@ public interface IPcre2 {
      * @param gcontext the general context handle or 0
      * @return the match data handle
      */
-    public long matchDataCreateFromPattern(long code, long gcontext);
+    long matchDataCreateFromPattern(long code, long gcontext);
 
     /**
      * Free a match data block.
      *
      * @param matchData the match data handle
      */
-    public void matchDataFree(long matchData);
+    void matchDataFree(long matchData);
 
     /**
      * Create a new match context.
@@ -1025,7 +1025,7 @@ public interface IPcre2 {
      * @param gcontext the general context handle or 0
      * @return the match context handle
      */
-    public long matchContextCreate(long gcontext);
+    long matchContextCreate(long gcontext);
 
     /**
      * Create a copy of a match context.
@@ -1033,14 +1033,14 @@ public interface IPcre2 {
      * @param mcontext the match context handle to copy
      * @return the new match context handle
      */
-    public long matchContextCopy(long mcontext);
+    long matchContextCopy(long mcontext);
 
     /**
      * Free a match context.
      *
      * @param mcontext the match context handle
      */
-    public void matchContextFree(long mcontext);
+    void matchContextFree(long mcontext);
 
     /**
      * Create a new convert context.
@@ -1053,7 +1053,7 @@ public interface IPcre2 {
      * @return the convert context handle, or 0 if memory allocation fails
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_convert_context_create.html">pcre2_convert_context_create</a>
      */
-    public long convertContextCreate(long gcontext);
+    long convertContextCreate(long gcontext);
 
     /**
      * Create a copy of a convert context.
@@ -1062,7 +1062,7 @@ public interface IPcre2 {
      * @return the new convert context handle, or 0 if the input is 0 or memory allocation fails
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_convert_context_copy.html">pcre2_convert_context_copy</a>
      */
-    public long convertContextCopy(long cvcontext);
+    long convertContextCopy(long cvcontext);
 
     /**
      * Free a convert context.
@@ -1072,7 +1072,7 @@ public interface IPcre2 {
      * @param cvcontext the convert context handle (may be 0, in which case the function does nothing)
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_convert_context_free.html">pcre2_convert_context_free</a>
      */
-    public void convertContextFree(long cvcontext);
+    void convertContextFree(long cvcontext);
 
     /**
      * Set the escape character for glob pattern conversion.
@@ -1090,7 +1090,7 @@ public interface IPcre2 {
      * @return 0 on success, or {@link #ERROR_BADDATA} if the escape character is invalid
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_set_glob_escape.html">pcre2_set_glob_escape</a>
      */
-    public int setGlobEscape(long cvcontext, int escapeChar);
+    int setGlobEscape(long cvcontext, int escapeChar);
 
     /**
      * Set the path separator character for glob pattern conversion.
@@ -1106,7 +1106,7 @@ public interface IPcre2 {
      * @return 0 on success, or {@link #ERROR_BADDATA} if the separator character is invalid
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_set_glob_separator.html">pcre2_set_glob_separator</a>
      */
-    public int setGlobSeparator(long cvcontext, int separatorChar);
+    int setGlobSeparator(long cvcontext, int separatorChar);
 
     /**
      * Convert a foreign pattern (glob or POSIX) to a PCRE2 regular expression.
@@ -1146,7 +1146,7 @@ public interface IPcre2 {
      *         {@link #ERROR_CONVERT_SYNTAX} if the pattern has invalid syntax
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_pattern_convert.html">pcre2_pattern_convert</a>
      */
-    public int patternConvert(String pattern, int options, long[] buffer, long[] blength, long cvcontext);
+    int patternConvert(String pattern, int options, long[] buffer, long[] blength, long cvcontext);
 
     /**
      * Free memory allocated by {@link #patternConvert(String, int, long[], long[], long)}.
@@ -1162,7 +1162,7 @@ public interface IPcre2 {
      *                         function does nothing)
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_converted_pattern_free.html">pcre2_converted_pattern_free</a>
      */
-    public void convertedPatternFree(long convertedPattern);
+    void convertedPatternFree(long convertedPattern);
 
     /**
      * Match a compiled pattern against a subject string.
@@ -1176,7 +1176,7 @@ public interface IPcre2 {
      * @return the number of captures plus one, zero if the {@code matchData} is too small, or a negative value if there
      * was no match or an actual error occurred
      */
-    public int match(long code, String subject, int startoffset, int options, long matchData, long mcontext);
+    int match(long code, String subject, int startoffset, int options, long matchData, long mcontext);
 
     /**
      * Match a compiled pattern against a subject string using the alternative DFA matching algorithm.
@@ -1216,7 +1216,7 @@ public interface IPcre2 {
      *         {@link #ERROR_DFA_BADRESTART} if {@link #DFA_RESTART} is used incorrectly
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_dfa_match.html">pcre2_dfa_match</a>
      */
-    public int dfaMatch(
+    int dfaMatch(
             long code,
             String subject,
             int startoffset,
@@ -1233,7 +1233,7 @@ public interface IPcre2 {
      * @param matchData the match data handle
      * @return the number of the offset pairs
      */
-    public int getOvectorCount(long matchData);
+    int getOvectorCount(long matchData);
 
     /**
      * Get the size of a match data block in bytes.
@@ -1246,7 +1246,7 @@ public interface IPcre2 {
      * @return the size of the match data block in bytes
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_get_match_data_size.html">pcre2_get_match_data_size</a>
      */
-    public long getMatchDataSize(long matchData);
+    long getMatchDataSize(long matchData);
 
     /**
      * Get the output vector of the match data
@@ -1254,7 +1254,7 @@ public interface IPcre2 {
      * @param matchData the match data handle
      * @param ovector   the array to store the output vector
      */
-    public void getOvector(long matchData, long[] ovector);
+    void getOvector(long matchData, long[] ovector);
 
     /**
      * Get the starting character offset from a match.
@@ -1270,7 +1270,7 @@ public interface IPcre2 {
      * @return the code unit offset of the character at which the match started
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_get_startchar.html">pcre2_get_startchar</a>
      */
-    public long getStartchar(long matchData);
+    long getStartchar(long matchData);
 
     /**
      * Get the last (*MARK), (*PRUNE), or (*THEN) name that was encountered during matching.
@@ -1289,7 +1289,7 @@ public interface IPcre2 {
      * @return the address of a zero-terminated string containing the mark name, or 0 if no mark name is available
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_get_mark.html">pcre2_get_mark</a>
      */
-    public long getMark(long matchData);
+    long getMark(long matchData);
 
     /**
      * Set the newline convention within a compile context
@@ -1298,7 +1298,7 @@ public interface IPcre2 {
      * @param newline  the newline convention
      * @return 0 on success, otherwise a negative error code
      */
-    public int setNewline(long ccontext, int newline);
+    int setNewline(long ccontext, int newline);
 
     /**
      * Set what \R matches within a compile context.
@@ -1311,7 +1311,7 @@ public interface IPcre2 {
      * @return 0 on success, otherwise a negative error code
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_set_bsr.html">pcre2_set_bsr</a>
      */
-    public int setBsr(long ccontext, int value);
+    int setBsr(long ccontext, int value);
 
     /**
      * Set the parentheses nesting limit within a compile context.
@@ -1325,7 +1325,7 @@ public interface IPcre2 {
      * @return 0 always
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_set_parens_nest_limit.html">pcre2_set_parens_nest_limit</a>
      */
-    public int setParensNestLimit(long ccontext, int limit);
+    int setParensNestLimit(long ccontext, int limit);
 
     /**
      * Set the maximum length of pattern that can be compiled.
@@ -1343,7 +1343,7 @@ public interface IPcre2 {
      * @return 0 always
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_set_max_pattern_length.html">pcre2_set_max_pattern_length</a>
      */
-    public int setMaxPatternLength(long ccontext, long length);
+    int setMaxPatternLength(long ccontext, long length);
 
     /**
      * Set additional compile options within a compile context.
@@ -1371,7 +1371,7 @@ public interface IPcre2 {
      * @return 0 always
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_set_compile_extra_options.html">pcre2_set_compile_extra_options</a>
      */
-    public int setCompileExtraOptions(long ccontext, int extraOptions);
+    int setCompileExtraOptions(long ccontext, int extraOptions);
 
     /**
      * Set custom character tables for pattern compilation within a compile context.
@@ -1389,7 +1389,7 @@ public interface IPcre2 {
      * @return 0 always
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_set_character_tables.html">pcre2_set_character_tables</a>
      */
-    public int setCharacterTables(long ccontext, long tables);
+    int setCharacterTables(long ccontext, long tables);
 
     /**
      * Set a compile recursion guard function within a compile context.
@@ -1414,7 +1414,7 @@ public interface IPcre2 {
      * @return 0 always
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_set_compile_recursion_guard.html">pcre2_set_compile_recursion_guard</a>
      */
-    public int setCompileRecursionGuard(long ccontext, long guardFunction, long userData);
+    int setCompileRecursionGuard(long ccontext, long guardFunction, long userData);
 
     /**
      * Set the match limit within a match context.
@@ -1427,7 +1427,7 @@ public interface IPcre2 {
      * @return 0 always
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_set_match_limit.html">pcre2_set_match_limit</a>
      */
-    public int setMatchLimit(long mcontext, int limit);
+    int setMatchLimit(long mcontext, int limit);
 
     /**
      * Set the backtracking depth limit within a match context.
@@ -1440,7 +1440,7 @@ public interface IPcre2 {
      * @return 0 always
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_set_depth_limit.html">pcre2_set_depth_limit</a>
      */
-    public int setDepthLimit(long mcontext, int limit);
+    int setDepthLimit(long mcontext, int limit);
 
     /**
      * Set the heap memory limit within a match context.
@@ -1453,7 +1453,7 @@ public interface IPcre2 {
      * @return 0 always
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_set_heap_limit.html">pcre2_set_heap_limit</a>
      */
-    public int setHeapLimit(long mcontext, int limit);
+    int setHeapLimit(long mcontext, int limit);
 
     /**
      * Set the offset limit within a match context.
@@ -1466,7 +1466,7 @@ public interface IPcre2 {
      * @return 0 always
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_set_offset_limit.html">pcre2_set_offset_limit</a>
      */
-    public int setOffsetLimit(long mcontext, long limit);
+    int setOffsetLimit(long mcontext, long limit);
 
     /**
      * Set up a callout function within a match context.
@@ -1487,7 +1487,7 @@ public interface IPcre2 {
      * @return 0 always
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_set_callout.html">pcre2_set_callout</a>
      */
-    public int setCallout(long mcontext, long callback, long calloutData);
+    int setCallout(long mcontext, long callback, long calloutData);
 
     /**
      * Match a compiled pattern against a subject string and perform substitution.
@@ -1505,7 +1505,7 @@ public interface IPcre2 {
      * @return the number of substitutions made, or a negative error code
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_substitute.html">pcre2_substitute</a>
      */
-    public int substitute(
+    int substitute(
             long code,
             String subject,
             int startoffset,
@@ -1531,7 +1531,7 @@ public interface IPcre2 {
      * {@link #ERROR_NOMEMORY} memory could not be obtained
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_substring_get_bynumber.html">pcre2_substring_get_bynumber</a>
      */
-    public int substringGetByNumber(long matchData, int number, long[] bufferptr, long[] bufflen);
+    int substringGetByNumber(long matchData, int number, long[] bufferptr, long[] bufflen);
 
     /**
      * Copy a captured substring by its number into a caller-provided buffer.
@@ -1551,7 +1551,7 @@ public interface IPcre2 {
      * {@link #ERROR_NOMEMORY} the buffer is too small
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_substring_copy_bynumber.html">pcre2_substring_copy_bynumber</a>
      */
-    public int substringCopyByNumber(long matchData, int number, ByteBuffer buffer, long[] bufflen);
+    int substringCopyByNumber(long matchData, int number, ByteBuffer buffer, long[] bufflen);
 
     /**
      * Extract a captured substring by its name into newly allocated memory.
@@ -1567,7 +1567,7 @@ public interface IPcre2 {
      * {@link #ERROR_NOMEMORY} memory could not be obtained
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_substring_get_byname.html">pcre2_substring_get_byname</a>
      */
-    public int substringGetByName(long matchData, String name, long[] bufferptr, long[] bufflen);
+    int substringGetByName(long matchData, String name, long[] bufferptr, long[] bufflen);
 
     /**
      * Copy a captured substring by its name into a caller-provided buffer.
@@ -1587,7 +1587,7 @@ public interface IPcre2 {
      * {@link #ERROR_NOMEMORY} the buffer is too small
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_substring_copy_byname.html">pcre2_substring_copy_byname</a>
      */
-    public int substringCopyByName(long matchData, String name, ByteBuffer buffer, long[] bufflen);
+    int substringCopyByName(long matchData, String name, ByteBuffer buffer, long[] bufflen);
 
     /**
      * Get the length of a captured substring by its group name.
@@ -1605,7 +1605,7 @@ public interface IPcre2 {
      * {@link #ERROR_UNSET} the group did not participate in the match
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_substring_length_byname.html">pcre2_substring_length_byname</a>
      */
-    public int substringLengthByName(long matchData, String name, long[] length);
+    int substringLengthByName(long matchData, String name, long[] length);
 
     /**
      * Get the length of a captured substring by its group number.
@@ -1623,7 +1623,7 @@ public interface IPcre2 {
      * {@link #ERROR_UNSET} the group did not participate in the match
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_substring_length_bynumber.html">pcre2_substring_length_bynumber</a>
      */
-    public int substringLengthByNumber(long matchData, int number, long[] length);
+    int substringLengthByNumber(long matchData, int number, long[] length);
 
     /**
      * Free memory that was allocated by {@link #substringGetByNumber} or {@link #substringGetByName}.
@@ -1631,7 +1631,7 @@ public interface IPcre2 {
      * @param buffer the pointer to the string to free (may be 0, in which case the function does nothing)
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_substring_free.html">pcre2_substring_free</a>
      */
-    public void substringFree(long buffer);
+    void substringFree(long buffer);
 
     /**
      * Extract all captured substrings into newly allocated memory.
@@ -1651,7 +1651,7 @@ public interface IPcre2 {
      * @return zero on success, otherwise {@link #ERROR_NOMEMORY} if memory could not be obtained
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_substring_list_get.html">pcre2_substring_list_get</a>
      */
-    public int substringListGet(long matchData, long[] listptr, long[] lengthsptr);
+    int substringListGet(long matchData, long[] listptr, long[] lengthsptr);
 
     /**
      * Free memory that was allocated by {@link #substringListGet}.
@@ -1659,7 +1659,7 @@ public interface IPcre2 {
      * @param list the pointer to the string list to free (may be 0, in which case the function does nothing)
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_substring_list_free.html">pcre2_substring_list_free</a>
      */
-    public void substringListFree(long list);
+    void substringListFree(long list);
 
     /**
      * Convert a named capturing group to its group number.
@@ -1672,7 +1672,7 @@ public interface IPcre2 {
      *                                  the {@code (?J)} option)
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_substring_number_from_name.html">pcre2_substring_number_from_name</a>
      */
-    public int substringNumberFromName(long code, String name);
+    int substringNumberFromName(long code, String name);
 
     /**
      * Find the first and last name table entries for a given capture group name.
@@ -1696,7 +1696,7 @@ public interface IPcre2 {
      *         On failure: {@link #ERROR_NOSUBSTRING} if the name is not found
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_substring_nametable_scan.html">pcre2_substring_nametable_scan</a>
      */
-    public int substringNametableScan(long code, String name, long[] first, long[] last);
+    int substringNametableScan(long code, String name, long[] first, long[] last);
 
     /**
      * Serialize one or more compiled patterns to a byte array.
@@ -1730,7 +1730,7 @@ public interface IPcre2 {
      *         {@link #ERROR_MIXEDTABLES} if patterns were compiled with different character tables
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_serialize_encode.html">pcre2_serialize_encode</a>
      */
-    public int serializeEncode(long[] codes, int numberOfCodes, long[] serializedBytes, long[] serializedSize,
+    int serializeEncode(long[] codes, int numberOfCodes, long[] serializedBytes, long[] serializedSize,
             long gcontext);
 
     /**
@@ -1759,7 +1759,7 @@ public interface IPcre2 {
      *         {@link #ERROR_NULL} if {@code codes} or {@code bytes} is null
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_serialize_decode.html">pcre2_serialize_decode</a>
      */
-    public int serializeDecode(long[] codes, int numberOfCodes, byte[] bytes, long gcontext);
+    int serializeDecode(long[] codes, int numberOfCodes, byte[] bytes, long gcontext);
 
     /**
      * Free memory that was allocated by {@link #serializeEncode} for holding a serialized byte stream.
@@ -1771,7 +1771,7 @@ public interface IPcre2 {
      *              does nothing)
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_serialize_free.html">pcre2_serialize_free</a>
      */
-    public void serializeFree(long bytes);
+    void serializeFree(long bytes);
 
     /**
      * Get the number of serialized patterns in a byte stream.
@@ -1791,7 +1791,7 @@ public interface IPcre2 {
      *         {@link #ERROR_NULL} if {@code bytes} is null
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_serialize_get_number_of_codes.html">pcre2_serialize_get_number_of_codes</a>
      */
-    public int serializeGetNumberOfCodes(byte[] bytes);
+    int serializeGetNumberOfCodes(byte[] bytes);
 
     /**
      * Read bytes from a native memory pointer.
@@ -1802,5 +1802,5 @@ public interface IPcre2 {
      * @param length  the number of bytes to read
      * @return the bytes read from the pointer
      */
-    public byte[] readBytes(long pointer, int length);
+    byte[] readBytes(long pointer, int length);
 }


### PR DESCRIPTION
## Summary
- Remove redundant `public` modifiers from all constants (`static final` fields) and method declarations in the `IPcre2` interface
- In Java, all interface members are implicitly `public`, making these modifiers unnecessary visual noise

Closes #331

## Test plan
- [x] `api` module compiles successfully
- [x] `ffm` module compiles and tests pass
- [x] Checkstyle passes
- [ ] CI validates full build across all modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)