### PR TITLE
(chore) ci: add concurrency controls to prevent duplicate runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,10 @@ on:
     # Weekly full compatibility run (Sundays at 06:00 UTC)
     - cron: '0 6 * * 0'
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,10 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
## Summary
- Add `concurrency` controls to CI workflow: groups runs by PR number or branch ref, cancels in-progress runs when superseded by newer commits
- Add `concurrency` controls to Release workflow: groups by tag ref with `cancel-in-progress: false` to ensure releases are never cancelled

Fixes #287

## Test plan
- [ ] CI workflow triggers correctly on PR push and cancels previous runs
- [ ] Release workflow does not cancel in-progress deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)