### PR TITLE
(fix) api: replace invalid {@param} JavaDoc tags with {@code}

### DIFF
--- a/api/src/main/java/org/pcre4j/api/IPcre2.java
+++ b/api/src/main/java/org/pcre4j/api/IPcre2.java
@@ -651,7 +651,7 @@ public interface IPcre2 {
     static final int CONFIG_TABLES_LENGTH = 15;
 
     /**
-     * Get the amount of memory needed to store the information referred to by {@param what} about the optional features
+     * Get the amount of memory needed to store the information referred to by {@code what} about the optional features
      * of the PCRE2 library.
      * <p>
      * Suitable for any information except:
@@ -660,12 +660,12 @@ public interface IPcre2 {
      * {@link #CONFIG_VERSION} PCRE2 version
      *
      * @param what the information to query the memory requirements for
-     * @return the amount of memory needed to store the information referred to by {@param what}.
+     * @return the amount of memory needed to store the information referred to by {@code what}.
      */
     int config(int what);
 
     /**
-     * Get the information referred to by {@param what} about the optional features of the PCRE2 library.
+     * Get the information referred to by {@code what} about the optional features of the PCRE2 library.
      * <p>
      * Suitable for any information except:
      * {@link #CONFIG_JITTARGET} Target architecture for the JIT compiler
@@ -679,7 +679,7 @@ public interface IPcre2 {
     int config(int what, int[] where);
 
     /**
-     * Get the information referred to by {@param what} about the optional features of the PCRE2 library.
+     * Get the information referred to by {@code what} about the optional features of the PCRE2 library.
      * <p>
      * Suitable only for the following information:
      * {@link #CONFIG_JITTARGET} Target architecture for the JIT compiler
@@ -847,7 +847,7 @@ public interface IPcre2 {
      * @param errorcode the error code
      * @param buffer    the buffer to store the error message
      * @return the length of the error message or {@link #ERROR_NOMEMORY} if the buffer is too small and if
-     * {@param errorcode} is not a valid error code, {@link #ERROR_BADDATA} is returned
+     * {@code errorcode} is not a valid error code, {@link #ERROR_BADDATA} is returned
      * @see <a href="https://www.pcre.org/current/doc/html/pcre2_get_error_message.html">pcre2_get_error_message</a>
      */
     int getErrorMessage(int errorcode, ByteBuffer buffer);
@@ -860,7 +860,7 @@ public interface IPcre2 {
      * @return Size of the information, otherwise an error code:
      * {@link #ERROR_NULL} the argument code is 0
      * {@link #ERROR_BADMAGIC} the "magic number" was not found
-     * {@link #ERROR_BADOPTION} the value of {@param what} is invalid
+     * {@link #ERROR_BADOPTION} the value of {@code what} is invalid
      * {@link #ERROR_BADMODE} the pattern was compiled in the wrong mode
      * {@link #ERROR_UNSET} the requested information is not set
      */
@@ -883,7 +883,7 @@ public interface IPcre2 {
      * @return Zero on success, otherwise an error code:
      * {@link #ERROR_NULL} the argument code is 0
      * {@link #ERROR_BADMAGIC} the "magic number" was not found
-     * {@link #ERROR_BADOPTION} the value of {@param what} is invalid
+     * {@link #ERROR_BADOPTION} the value of {@code what} is invalid
      * {@link #ERROR_BADMODE} the pattern was compiled in the wrong mode
      * {@link #ERROR_UNSET} the requested information is not set
      */
@@ -903,7 +903,7 @@ public interface IPcre2 {
      * @return Zero on success, otherwise an error code:
      * {@link #ERROR_NULL} the argument code is 0
      * {@link #ERROR_BADMAGIC} the "magic number" was not found
-     * {@link #ERROR_BADOPTION} the value of {@param what} is invalid
+     * {@link #ERROR_BADOPTION} the value of {@code what} is invalid
      * {@link #ERROR_BADMODE} the pattern was compiled in the wrong mode
      * {@link #ERROR_UNSET} the requested information is not set
      */
@@ -921,7 +921,7 @@ public interface IPcre2 {
      * @return Zero on success, otherwise an error code:
      * {@link #ERROR_NULL} the argument code is 0
      * {@link #ERROR_BADMAGIC} the "magic number" was not found
-     * {@link #ERROR_BADOPTION} the value of {@param what} is invalid
+     * {@link #ERROR_BADOPTION} the value of {@code what} is invalid
      * {@link #ERROR_BADMODE} the pattern was compiled in the wrong mode
      * {@link #ERROR_UNSET} the requested information is not set
      */


### PR DESCRIPTION
## Summary
- Replace 9 instances of invalid `{@param name}` inline JavaDoc tags with `{@code name}` in `IPcre2.java`
- `{@param}` is a block tag only; the correct inline tag for referencing parameter names in prose is `{@code}`
- Affected methods: `config()`, `getErrorMessage()`, `patternInfo()` overloads

**Note**: One additional instance of the same issue exists in `lib/src/main/java/org/pcre4j/Pcre2Code.java:555` — not included in this PR as it's outside the `api` module scope of #298.

## Test plan
- [x] `api:checkstyleMain` passes
- [x] `api:javadoc` generates without errors from the changed tags
- [ ] CI passes

Fixes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)