### PR TITLE
(chore) lib: fix modifier order in Pcre2JitCode

### DIFF
--- a/lib/src/main/java/org/pcre4j/Pcre2JitCode.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2JitCode.java
@@ -26,7 +26,7 @@ public class Pcre2JitCode extends Pcre2Code {
     /**
      * The supported match options for JIT-compiled patterns.
      */
-    private final static EnumSet<Pcre2MatchOption> SUPPORTED_MATCH_OPTIONS = EnumSet.of(
+    private static final EnumSet<Pcre2MatchOption> SUPPORTED_MATCH_OPTIONS = EnumSet.of(
             Pcre2MatchOption.NOTBOL,
             Pcre2MatchOption.NOTEOL,
             Pcre2MatchOption.NOTEMPTY,


### PR DESCRIPTION
## Summary
- Fix modifier order from `private final static` to `private static final` in `Pcre2JitCode` to follow the standard Java modifier ordering (JLS §8.1.1)

Fixes #304

## Test plan
- [x] `lib:compileJava` passes
- [x] `lib:checkstyleMain` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)