### PR TITLE
(chore) ci: pin GitHub Actions to SHA digests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,25 +47,25 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # Always need JDK 21 for building base MRJAR classes
       - name: Set up temurin-jdk-21 (for MRJAR base)
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
           java-version: 21
 
       # Always need JDK 22 for building MRJAR overlay classes
       - name: Set up temurin-jdk-22 (for MRJAR overlay)
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
           java-version: 22
 
       # Set up the test runtime Java version (available via toolchain, not JAVA_HOME)
       - name: Set up ${{ matrix.java-distribution }}-jdk-${{ matrix.java-version }} (test runtime)
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: ${{ matrix.java-distribution }}
           java-version: ${{ matrix.java-version }}
@@ -75,7 +75,7 @@ jobs:
         run: echo "JAVA_HOME=$JAVA_HOME_21_X64" >> $GITHUB_ENV
 
       - name: Cache Gradle packages
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
         with:
           path: |
             ~/.gradle/caches
@@ -85,7 +85,7 @@ jobs:
 
       - name: Cache PCRE2
         if: ${{ matrix.os == 'ubuntu-24.04' }}
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
         id: cache-pcre2
         with:
           path: /opt/pcre2
@@ -128,26 +128,26 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # Need both JDKs for MRJAR build
       - name: Set up temurin-jdk-21 (for MRJAR base)
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
           java-version: 21
 
       - name: Set up temurin-jdk-22 (for MRJAR overlay)
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
           java-version: 22
 
       - name: Set up Git Hub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Cache Gradle packages
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
         with:
           path: |
             ~/.gradle/caches
@@ -159,7 +159,7 @@ jobs:
         run: ./gradlew checkstyleMain checkstyleTest
 
       - name: Cache PCRE2
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
         id: cache-pcre2
         with:
           path: /opt/pcre2
@@ -207,13 +207,13 @@ jobs:
           cp -a regex/build/docs/javadoc/. build/gh-pages/javadoc/regex
 
       - name: Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: build/reports/jacoco/jacocoAggregatedTestReport/jacoco.xml
 
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: build/gh-pages
 
@@ -258,8 +258,8 @@ jobs:
 
     steps:
       - name: Set up Git Hub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Publish GitHub Pages
         id: publish-github-pages
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,23 +18,23 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # Need both JDKs for MRJAR build
       - name: Set up temurin-jdk-21 (for MRJAR base)
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
           java-version: 21
 
       - name: Set up temurin-jdk-22 (for MRJAR overlay)
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
           java-version: 22
 
       - name: Cache Gradle packages
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions in `ci.yaml` and `release.yaml` to immutable SHA digests instead of mutable version tags
- Retains original version tag as inline comments for readability (e.g., `# v6`)

**Pinned actions:**
| Action | SHA | Tag |
|--------|-----|-----|
| `actions/checkout` | `de0fac2e` | v6 |
| `actions/setup-java` | `be666c2f` | v5 |
| `actions/cache` | `cdf6c1fa` | v5 |
| `actions/configure-pages` | `983d7736` | v5 |
| `codecov/codecov-action` | `671740ac` | v5 |
| `actions/upload-pages-artifact` | `7b1f4a76` | v4 |
| `actions/deploy-pages` | `d6db9016` | v4 |

Fixes #278

## Test plan

- [ ] CI workflow runs successfully with SHA-pinned actions
- [ ] All jobs (compatibility, package, publish-github-pages) resolve actions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)