### PR TITLE
(fix) lib: use CONFIG_NEVER_BACKSLASH_C in isBackslashCDisabled()

### DIFF
--- a/lib/src/main/java/org/pcre4j/Pcre4jUtils.java
+++ b/lib/src/main/java/org/pcre4j/Pcre4jUtils.java
@@ -185,7 +185,7 @@ public final class Pcre4jUtils {
         }
 
         final var backslashCDisabled = new int[1];
-        final var result = api.config(IPcre2.CONFIG_BSR, backslashCDisabled);
+        final var result = api.config(IPcre2.CONFIG_NEVER_BACKSLASH_C, backslashCDisabled);
         if (result < 0) {
             throw new IllegalStateException(getErrorMessage(api, result));
         }


### PR DESCRIPTION
## Summary

- Fix `isBackslashCDisabled()` using wrong PCRE2 config constant: `CONFIG_BSR` (index 0, backslash-R default) instead of `CONFIG_NEVER_BACKSLASH_C` (index 13)

Fixes #280

## Test plan

- [x] FFM tests pass locally (including `isBackslashCDisabled` test)
- [ ] CI passes on all backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)