### PR TITLE
(chore) repo: add defensive .gitignore patterns for sensitive files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,32 @@ gradle-app.setting
 .project
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
+
+## Defensive patterns for sensitive files
+
+# Private keys and certificates
+*.pem
+*.key
+*.p12
+*.pfx
+*.jks
+*.jceks
+*.keystore
+
+# GPG keys
+*.gpg
+*.asc
+
+# Environment and secrets files
+.env
+.env.*
+
+# Gradle user-specific properties (may contain credentials)
+gradle.properties
+local.properties
+
+# Maven settings (may contain repository credentials)
+settings.xml
+
+# JReleaser local overrides (may contain secrets)
+jreleaser-local.yml


### PR DESCRIPTION
## Summary

- Add defensive `.gitignore` patterns to prevent accidental commit of sensitive files
- Covers private keys/certificates (`.pem`, `.key`, `.p12`, `.pfx`, `.jks`, `.jceks`, `.keystore`)
- Covers GPG keys (`.gpg`, `.asc`)
- Covers environment/secrets files (`.env`, `.env.*`)
- Covers Gradle/Maven credential files (`gradle.properties`, `local.properties`, `settings.xml`)
- Covers JReleaser local overrides (`jreleaser-local.yml`)

Closes #297

## Test plan

- [x] Verified no tracked files match the new patterns
- [x] Verified build succeeds (pre-existing JNA verification issue unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)