### PR TITLE
(fix) build: replace System.getProperty() with providers.systemProperty()

### DIFF
--- a/ffm/build.gradle.kts
+++ b/ffm/build.gradle.kts
@@ -125,17 +125,17 @@ tasks.test {
 
     systemProperty(
         "java.library.path", listOf(
-            System.getProperty("pcre2.library.path"),
-            System.getProperty("java.library.path")
+            providers.systemProperty("pcre2.library.path").orNull,
+            providers.systemProperty("java.library.path").orNull
         ).joinToString(":")
     )
 
-    val pcre2LibraryName = System.getProperty("pcre2.library.name")
+    val pcre2LibraryName = providers.systemProperty("pcre2.library.name").orNull
     if (pcre2LibraryName != null) {
         systemProperty("pcre2.library.name", pcre2LibraryName)
     }
 
-    val pcre2FunctionSuffix = System.getProperty("pcre2.function.suffix")
+    val pcre2FunctionSuffix = providers.systemProperty("pcre2.function.suffix").orNull
     if (pcre2FunctionSuffix != null) {
         systemProperty("pcre2.function.suffix", pcre2FunctionSuffix)
     }
@@ -204,17 +204,17 @@ val testJava22 by tasks.registering(Test::class) {
 
     systemProperty(
         "java.library.path", listOf(
-            System.getProperty("pcre2.library.path"),
-            System.getProperty("java.library.path")
+            providers.systemProperty("pcre2.library.path").orNull,
+            providers.systemProperty("java.library.path").orNull
         ).joinToString(":")
     )
 
-    val pcre2LibraryName = System.getProperty("pcre2.library.name")
+    val pcre2LibraryName = providers.systemProperty("pcre2.library.name").orNull
     if (pcre2LibraryName != null) {
         systemProperty("pcre2.library.name", pcre2LibraryName)
     }
 
-    val pcre2FunctionSuffix = System.getProperty("pcre2.function.suffix")
+    val pcre2FunctionSuffix = providers.systemProperty("pcre2.function.suffix").orNull
     if (pcre2FunctionSuffix != null) {
         systemProperty("pcre2.function.suffix", pcre2FunctionSuffix)
     }

--- a/jna/build.gradle.kts
+++ b/jna/build.gradle.kts
@@ -63,17 +63,17 @@ tasks.withType<Test> {
 
     systemProperty(
         "jna.library.path", listOf(
-            System.getProperty("pcre2.library.path"),
-            System.getProperty("jna.library.path")
+            providers.systemProperty("pcre2.library.path").orNull,
+            providers.systemProperty("jna.library.path").orNull
         ).joinToString(":")
     )
 
-    val pcre2LibraryName = System.getProperty("pcre2.library.name")
+    val pcre2LibraryName = providers.systemProperty("pcre2.library.name").orNull
     if (pcre2LibraryName != null) {
         systemProperty("pcre2.library.name", pcre2LibraryName)
     }
 
-    val pcre2FunctionSuffix = System.getProperty("pcre2.function.suffix")
+    val pcre2FunctionSuffix = providers.systemProperty("pcre2.function.suffix").orNull
     if (pcre2FunctionSuffix != null) {
         systemProperty("pcre2.function.suffix", pcre2FunctionSuffix)
     }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -66,24 +66,24 @@ tasks.test {
 
     systemProperty(
         "jna.library.path", listOf(
-            System.getProperty("pcre2.library.path"),
-            System.getProperty("jna.library.path")
+            providers.systemProperty("pcre2.library.path").orNull,
+            providers.systemProperty("jna.library.path").orNull
         ).joinToString(":")
     )
 
     systemProperty(
         "java.library.path", listOf(
-            System.getProperty("pcre2.library.path"),
-            System.getProperty("java.library.path")
+            providers.systemProperty("pcre2.library.path").orNull,
+            providers.systemProperty("java.library.path").orNull
         ).joinToString(":")
     )
 
-    val pcre2LibraryName = System.getProperty("pcre2.library.name")
+    val pcre2LibraryName = providers.systemProperty("pcre2.library.name").orNull
     if (pcre2LibraryName != null) {
         systemProperty("pcre2.library.name", pcre2LibraryName)
     }
 
-    val pcre2FunctionSuffix = System.getProperty("pcre2.function.suffix")
+    val pcre2FunctionSuffix = providers.systemProperty("pcre2.function.suffix").orNull
     if (pcre2FunctionSuffix != null) {
         systemProperty("pcre2.function.suffix", pcre2FunctionSuffix)
     }

--- a/regex/build.gradle.kts
+++ b/regex/build.gradle.kts
@@ -64,24 +64,24 @@ tasks.test {
 
     systemProperty(
         "jna.library.path", listOf(
-            System.getProperty("pcre2.library.path"),
-            System.getProperty("jna.library.path")
+            providers.systemProperty("pcre2.library.path").orNull,
+            providers.systemProperty("jna.library.path").orNull
         ).joinToString(":")
     )
 
     systemProperty(
         "java.library.path", listOf(
-            System.getProperty("pcre2.library.path"),
-            System.getProperty("java.library.path")
+            providers.systemProperty("pcre2.library.path").orNull,
+            providers.systemProperty("java.library.path").orNull
         ).joinToString(":")
     )
 
-    val pcre2LibraryName = System.getProperty("pcre2.library.name")
+    val pcre2LibraryName = providers.systemProperty("pcre2.library.name").orNull
     if (pcre2LibraryName != null) {
         systemProperty("pcre2.library.name", pcre2LibraryName)
     }
 
-    val pcre2FunctionSuffix = System.getProperty("pcre2.function.suffix")
+    val pcre2FunctionSuffix = providers.systemProperty("pcre2.function.suffix").orNull
     if (pcre2FunctionSuffix != null) {
         systemProperty("pcre2.function.suffix", pcre2FunctionSuffix)
     }


### PR DESCRIPTION
## Summary

- Replace all `System.getProperty()` calls with `providers.systemProperty().orNull` in test task configurations across `lib`, `jna`, `ffm`, and `regex` module build scripts
- Uses Gradle's Provider API for proper configuration avoidance and lazy evaluation of system properties

Fixes #284

## Test plan

- [x] Verified no `System.getProperty()` calls remain in any `*.gradle.kts` files
- [x] FFM module builds and both test suites pass (Java 21 + Java 22+ MRJAR)
- [x] API module builds and tests pass
- [x] All Gradle build scripts parse and configure correctly
- [ ] CI verifies full build across all modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)