### PR TITLE
(chore) test: add tests for Pattern.matches(), asPredicate(), asMatchPredicate()

### DIFF
--- a/regex/src/test/java/org/pcre4j/regex/PatternTests.java
+++ b/regex/src/test/java/org/pcre4j/regex/PatternTests.java
@@ -951,4 +951,161 @@ public class PatternTests {
         }
     }
 
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchesStaticFullMatch(IPcre2 api) {
+        var regex = "\\d+";
+
+        assertEquals(
+                java.util.regex.Pattern.matches(regex, "12345"),
+                Pattern.matches(api, regex, "12345")
+        );
+        assertTrue(Pattern.matches(api, regex, "12345"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchesStaticNoMatch(IPcre2 api) {
+        var regex = "\\d+";
+
+        assertEquals(
+                java.util.regex.Pattern.matches(regex, "abc"),
+                Pattern.matches(api, regex, "abc")
+        );
+        assertFalse(Pattern.matches(api, regex, "abc"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchesStaticPartialInputDoesNotMatch(IPcre2 api) {
+        var regex = "\\d+";
+
+        assertEquals(
+                java.util.regex.Pattern.matches(regex, "123abc"),
+                Pattern.matches(api, regex, "123abc")
+        );
+        assertFalse(Pattern.matches(api, regex, "123abc"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void matchesStaticEmptyInput(IPcre2 api) {
+        var regex = ".*";
+
+        assertEquals(
+                java.util.regex.Pattern.matches(regex, ""),
+                Pattern.matches(api, regex, "")
+        );
+        assertTrue(Pattern.matches(api, regex, ""));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void asPredicateFindsPartialMatch(IPcre2 api) {
+        var regex = "\\d+";
+        var javaPredicate = java.util.regex.Pattern.compile(regex).asPredicate();
+        var pcre4jPredicate = Pattern.compile(api, regex).asPredicate();
+
+        assertEquals(javaPredicate.test("abc123def"), pcre4jPredicate.test("abc123def"));
+        assertTrue(pcre4jPredicate.test("abc123def"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void asPredicateFullMatch(IPcre2 api) {
+        var regex = "\\d+";
+        var javaPredicate = java.util.regex.Pattern.compile(regex).asPredicate();
+        var pcre4jPredicate = Pattern.compile(api, regex).asPredicate();
+
+        assertEquals(javaPredicate.test("12345"), pcre4jPredicate.test("12345"));
+        assertTrue(pcre4jPredicate.test("12345"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void asPredicateNoMatch(IPcre2 api) {
+        var regex = "\\d+";
+        var javaPredicate = java.util.regex.Pattern.compile(regex).asPredicate();
+        var pcre4jPredicate = Pattern.compile(api, regex).asPredicate();
+
+        assertEquals(javaPredicate.test("abc"), pcre4jPredicate.test("abc"));
+        assertFalse(pcre4jPredicate.test("abc"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void asPredicateEmptyInput(IPcre2 api) {
+        var regex = "\\d+";
+        var javaPredicate = java.util.regex.Pattern.compile(regex).asPredicate();
+        var pcre4jPredicate = Pattern.compile(api, regex).asPredicate();
+
+        assertEquals(javaPredicate.test(""), pcre4jPredicate.test(""));
+        assertFalse(pcre4jPredicate.test(""));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void asMatchPredicateFullMatch(IPcre2 api) {
+        var regex = "\\d+";
+        var javaPredicate = java.util.regex.Pattern.compile(regex).asMatchPredicate();
+        var pcre4jPredicate = Pattern.compile(api, regex).asMatchPredicate();
+
+        assertEquals(javaPredicate.test("12345"), pcre4jPredicate.test("12345"));
+        assertTrue(pcre4jPredicate.test("12345"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void asMatchPredicatePartialInputDoesNotMatch(IPcre2 api) {
+        var regex = "\\d+";
+        var javaPredicate = java.util.regex.Pattern.compile(regex).asMatchPredicate();
+        var pcre4jPredicate = Pattern.compile(api, regex).asMatchPredicate();
+
+        assertEquals(javaPredicate.test("abc123def"), pcre4jPredicate.test("abc123def"));
+        assertFalse(pcre4jPredicate.test("abc123def"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void asMatchPredicateNoMatch(IPcre2 api) {
+        var regex = "\\d+";
+        var javaPredicate = java.util.regex.Pattern.compile(regex).asMatchPredicate();
+        var pcre4jPredicate = Pattern.compile(api, regex).asMatchPredicate();
+
+        assertEquals(javaPredicate.test("abc"), pcre4jPredicate.test("abc"));
+        assertFalse(pcre4jPredicate.test("abc"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void asMatchPredicateEmptyInput(IPcre2 api) {
+        var regex = "\\d+";
+        var javaPredicate = java.util.regex.Pattern.compile(regex).asMatchPredicate();
+        var pcre4jPredicate = Pattern.compile(api, regex).asMatchPredicate();
+
+        assertEquals(javaPredicate.test(""), pcre4jPredicate.test(""));
+        assertFalse(pcre4jPredicate.test(""));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    void asPredicateVsAsMatchPredicate(IPcre2 api) {
+        var regex = "\\d+";
+        var asPredicate = Pattern.compile(api, regex).asPredicate();
+        var asMatchPredicate = Pattern.compile(api, regex).asMatchPredicate();
+
+        // asPredicate uses find() - matches partial input
+        assertTrue(asPredicate.test("abc123def"));
+        // asMatchPredicate uses matches() - requires full match
+        assertFalse(asMatchPredicate.test("abc123def"));
+
+        // Both match when input fully matches the pattern
+        assertTrue(asPredicate.test("12345"));
+        assertTrue(asMatchPredicate.test("12345"));
+
+        // Neither matches when pattern not found at all
+        assertFalse(asPredicate.test("abc"));
+        assertFalse(asMatchPredicate.test("abc"));
+    }
+
 }


### PR DESCRIPTION
## Summary

- Add parameterized tests for `Pattern.matches(IPcre2, String, CharSequence)` static method covering full match, no match, partial input, and empty input scenarios
- Add parameterized tests for `Pattern.asPredicate()` covering partial match (find), full match, no match, and empty input scenarios
- Add parameterized tests for `Pattern.asMatchPredicate()` covering full match, partial input rejection, no match, and empty input scenarios
- Add a comparison test verifying the behavioral difference between `asPredicate()` (uses `find()`) and `asMatchPredicate()` (uses `matches()`)
- Fix missing dependency verification checksums for JNA 5.18.1

All tests follow existing project conventions: parameterized with both JNA and FFM backends, comparing PCRE4J behavior against `java.util.regex.Pattern`.

Closes #291

## Test plan

- [x] All new tests pass with both JNA and FFM backends
- [x] Checkstyle passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)