### PR TITLE
(chore) test: extract shared loadBackend/parameters into BackendProvider test fixture

### DIFF
--- a/lib/src/test/java/org/pcre4j/Pcre2CodeErrorHandlingTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodeErrorHandlingTests.java
@@ -15,13 +15,10 @@
 package org.pcre4j;
 
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.EnumSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -32,34 +29,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class Pcre2CodeErrorHandlingTests {
 
-    private static IPcre2 loadBackend(String className) {
-        try {
-            return (IPcre2) Class.forName(className).getDeclaredConstructor().newInstance();
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Backend " + className + " not found on classpath", e);
-        } catch (InvocationTargetException | InstantiationException | IllegalAccessException
-                 | NoSuchMethodException e) {
-            throw new RuntimeException("Failed to instantiate backend " + className, e);
-        }
-    }
-
-    private static Stream<Arguments> parameters() {
-        return Stream.of(
-                Arguments.of(loadBackend("org.pcre4j.jna.Pcre2")),
-                Arguments.of(loadBackend("org.pcre4j.ffm.Pcre2"))
-        );
-    }
-
     // --- Pcre2Code constructor null checks ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void constructorNullApiThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> new Pcre2Code(null, "test"));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void constructorNullPatternThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> new Pcre2Code(api, null));
     }
@@ -67,7 +46,7 @@ public class Pcre2CodeErrorHandlingTests {
     // --- Various invalid patterns ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void unmatchedBracketThrows(IPcre2 api) {
         var error = assertThrows(Pcre2CompileError.class, () -> new Pcre2Code(api, "[abc"));
         assertNotNull(error.pattern());
@@ -76,25 +55,25 @@ public class Pcre2CodeErrorHandlingTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void unmatchedParenthesisThrows(IPcre2 api) {
         assertThrows(Pcre2CompileError.class, () -> new Pcre2Code(api, "(abc"));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void invalidQuantifierThrows(IPcre2 api) {
         assertThrows(Pcre2CompileError.class, () -> new Pcre2Code(api, "?"));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void invalidEscapeThrows(IPcre2 api) {
         assertThrows(Pcre2CompileError.class, () -> new Pcre2Code(api, "\\"));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void invalidRepetitionRangeThrows(IPcre2 api) {
         assertThrows(Pcre2CompileError.class, () -> new Pcre2Code(api, "a{5,3}"));
     }
@@ -102,7 +81,7 @@ public class Pcre2CodeErrorHandlingTests {
     // --- Pcre2CompileError fields ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void compileErrorContainsPatternInfo(IPcre2 api) {
         var error = assertThrows(Pcre2CompileError.class, () -> new Pcre2Code(api, "(?P<>)"));
         assertNotNull(error.getMessage());
@@ -111,7 +90,7 @@ public class Pcre2CodeErrorHandlingTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void compileErrorLongPatternRegion(IPcre2 api) {
         // Pattern with error far from the start to exercise getPatternRegion truncation
         // Use a long valid prefix followed by an invalid construct
@@ -124,7 +103,7 @@ public class Pcre2CodeErrorHandlingTests {
     // --- match() null/invalid parameter checks ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchNullSubjectThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         var matchData = new Pcre2MatchData(code);
@@ -133,7 +112,7 @@ public class Pcre2CodeErrorHandlingTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchNegativeStartOffsetThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         var matchData = new Pcre2MatchData(code);
@@ -142,7 +121,7 @@ public class Pcre2CodeErrorHandlingTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchNullMatchDataThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertThrows(IllegalArgumentException.class, () ->
@@ -150,7 +129,7 @@ public class Pcre2CodeErrorHandlingTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchNoMatchReturnsNegative(IPcre2 api) {
         var code = new Pcre2Code(api, "xyz");
         var matchData = new Pcre2MatchData(code);
@@ -161,7 +140,7 @@ public class Pcre2CodeErrorHandlingTests {
     // --- substitute() null/invalid parameter checks ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void substituteNullSubjectThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertThrows(IllegalArgumentException.class, () ->
@@ -169,7 +148,7 @@ public class Pcre2CodeErrorHandlingTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void substituteNegativeStartOffsetThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertThrows(IllegalArgumentException.class, () ->
@@ -177,7 +156,7 @@ public class Pcre2CodeErrorHandlingTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void substituteStartOffsetPastEndThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertThrows(IllegalArgumentException.class, () ->
@@ -185,7 +164,7 @@ public class Pcre2CodeErrorHandlingTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void substituteNullReplacementThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertThrows(IllegalArgumentException.class, () ->
@@ -195,13 +174,13 @@ public class Pcre2CodeErrorHandlingTests {
     // --- Pcre2MatchData constructor null checks ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchDataNullApiThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> new Pcre2MatchData(null, 10));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchDataNullCodeThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> new Pcre2MatchData(null));
     }
@@ -209,25 +188,25 @@ public class Pcre2CodeErrorHandlingTests {
     // --- Context null checks ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void compileContextNullApiThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> new Pcre2CompileContext(null, null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchContextNullApiThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> new Pcre2MatchContext(null, null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void generalContextNullApiThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> new Pcre2GeneralContext(null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitStackNullApiThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () ->
                 new Pcre2JitStack(null, 32 * 1024, 512 * 1024, null));
@@ -236,14 +215,14 @@ public class Pcre2CodeErrorHandlingTests {
     // --- JitCode error handling ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitCodeBadPatternThrows(IPcre2 api) {
         assertThrows(Pcre2CompileError.class, () ->
                 new Pcre2JitCode(api, "?", null, null, null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitCodeMatchNullSubjectThrows(IPcre2 api) {
         var code = new Pcre2JitCode(api, "test", null, null, null);
         var matchData = new Pcre2MatchData(code);
@@ -252,7 +231,7 @@ public class Pcre2CodeErrorHandlingTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitCodeMatchNegativeOffsetThrows(IPcre2 api) {
         var code = new Pcre2JitCode(api, "test", null, null, null);
         var matchData = new Pcre2MatchData(code);
@@ -261,7 +240,7 @@ public class Pcre2CodeErrorHandlingTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitCodeMatchOffsetPastEndThrows(IPcre2 api) {
         var code = new Pcre2JitCode(api, "test", null, null, null);
         var matchData = new Pcre2MatchData(code);
@@ -270,7 +249,7 @@ public class Pcre2CodeErrorHandlingTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitCodeMatchNullMatchDataThrows(IPcre2 api) {
         var code = new Pcre2JitCode(api, "test", null, null, null);
         assertThrows(IllegalArgumentException.class, () ->

--- a/lib/src/test/java/org/pcre4j/Pcre2CodePatternInfoTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodePatternInfoTests.java
@@ -15,13 +15,10 @@
 package org.pcre4j;
 
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.EnumSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,35 +32,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class Pcre2CodePatternInfoTests {
 
-    private static IPcre2 loadBackend(String className) {
-        try {
-            return (IPcre2) Class.forName(className).getDeclaredConstructor().newInstance();
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Backend " + className + " not found on classpath", e);
-        } catch (InvocationTargetException | InstantiationException | IllegalAccessException
-                 | NoSuchMethodException e) {
-            throw new RuntimeException("Failed to instantiate backend " + className, e);
-        }
-    }
-
-    private static Stream<Arguments> parameters() {
-        return Stream.of(
-                Arguments.of(loadBackend("org.pcre4j.jna.Pcre2")),
-                Arguments.of(loadBackend("org.pcre4j.ffm.Pcre2"))
-        );
-    }
-
     // --- backRefMax ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void backRefMaxNoBackrefs(IPcre2 api) {
         var code = new Pcre2Code(api, "hello");
         assertEquals(0, code.backRefMax());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void backRefMaxWithBackrefs(IPcre2 api) {
         var code = new Pcre2Code(api, "(a)(b)\\2");
         assertEquals(2, code.backRefMax());
@@ -72,7 +51,7 @@ public class Pcre2CodePatternInfoTests {
     // --- argOptions ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void argOptionsDefault(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         var options = code.argOptions();
@@ -82,7 +61,7 @@ public class Pcre2CodePatternInfoTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void argOptionsWithCaseless(IPcre2 api) {
         var code = new Pcre2Code(api, "test", EnumSet.of(Pcre2CompileOption.CASELESS));
         var options = code.argOptions();
@@ -90,7 +69,7 @@ public class Pcre2CodePatternInfoTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void argOptionsWithMultipleOptions(IPcre2 api) {
         var code = new Pcre2Code(api, "test",
                 EnumSet.of(Pcre2CompileOption.CASELESS, Pcre2CompileOption.DOTALL));
@@ -102,21 +81,21 @@ public class Pcre2CodePatternInfoTests {
     // --- captureCount ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void captureCountNoGroups(IPcre2 api) {
         var code = new Pcre2Code(api, "hello");
         assertEquals(0, code.captureCount());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void captureCountWithGroups(IPcre2 api) {
         var code = new Pcre2Code(api, "(a)(b)(c)");
         assertEquals(3, code.captureCount());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void captureCountNonCapturing(IPcre2 api) {
         var code = new Pcre2Code(api, "(?:a)(b)");
         assertEquals(1, code.captureCount());
@@ -125,7 +104,7 @@ public class Pcre2CodePatternInfoTests {
     // --- bsr ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void bsrReturnsValidValue(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         var bsr = code.bsr();
@@ -136,7 +115,7 @@ public class Pcre2CodePatternInfoTests {
     // --- frameSize ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void frameSizePositive(IPcre2 api) {
         var code = new Pcre2Code(api, "(a)(b)");
         assertTrue(code.frameSize() > 0);
@@ -145,7 +124,7 @@ public class Pcre2CodePatternInfoTests {
     // --- firstCodeType ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void firstCodeTypeAnchored(IPcre2 api) {
         // Pattern anchored with ^ and starting with a literal should return 1 (first code unit set)
         var code = new Pcre2Code(api, "^test");
@@ -153,7 +132,7 @@ public class Pcre2CodePatternInfoTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void firstCodeTypeNoFixedStart(IPcre2 api) {
         // Pattern starting with .* is implicitly anchored, returns 2
         var code = new Pcre2Code(api, ".*test");
@@ -163,7 +142,7 @@ public class Pcre2CodePatternInfoTests {
     // --- hasBackslashC ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hasBackslashCFalse(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertFalse(code.hasBackslashC());
@@ -172,14 +151,14 @@ public class Pcre2CodePatternInfoTests {
     // --- hasCrOrLf ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hasCrOrLfFalse(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertFalse(code.hasCrOrLf());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hasCrOrLfTrue(IPcre2 api) {
         var code = new Pcre2Code(api, "test\\r");
         // The pattern has an explicit CR
@@ -189,14 +168,14 @@ public class Pcre2CodePatternInfoTests {
     // --- jChanged ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jChangedFalse(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertFalse(code.jChanged());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jChangedTrue(IPcre2 api) {
         var code = new Pcre2Code(api, "(?J)(?<name>a)(?<name>b)");
         assertTrue(code.jChanged());
@@ -205,14 +184,14 @@ public class Pcre2CodePatternInfoTests {
     // --- jitSize ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitSizeZeroForNonJit(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertEquals(0, code.jitSize());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitSizePositiveForJit(IPcre2 api) {
         var code = new Pcre2JitCode(api, "test", null, null, null);
         assertTrue(code.jitSize() > 0);
@@ -221,14 +200,14 @@ public class Pcre2CodePatternInfoTests {
     // --- matchEmpty ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchEmptyFalse(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertFalse(code.matchEmpty());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchEmptyTrue(IPcre2 api) {
         var code = new Pcre2Code(api, "a*");
         assertTrue(code.matchEmpty());
@@ -237,14 +216,14 @@ public class Pcre2CodePatternInfoTests {
     // --- maxLookBehind ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void maxLookBehindZero(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertEquals(0, code.maxLookBehind());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void maxLookBehindPositive(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<=abc)test");
         assertEquals(3, code.maxLookBehind());
@@ -253,14 +232,14 @@ public class Pcre2CodePatternInfoTests {
     // --- minLength ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void minLengthSimple(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertEquals(4, code.minLength());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void minLengthWithOptional(IPcre2 api) {
         // "te?st" matches "tst" (3 chars) or "test" (4 chars), minimum is 3
         var code = new Pcre2Code(api, "te?st");
@@ -270,14 +249,14 @@ public class Pcre2CodePatternInfoTests {
     // --- nameCount ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void nameCountZero(IPcre2 api) {
         var code = new Pcre2Code(api, "(a)(b)");
         assertEquals(0, code.nameCount());
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void nameCountWithNamedGroups(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<first>a)(?<second>b)");
         assertEquals(2, code.nameCount());
@@ -286,7 +265,7 @@ public class Pcre2CodePatternInfoTests {
     // --- newline ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void newlineReturnsValidValue(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         var newline = code.newline();
@@ -296,7 +275,7 @@ public class Pcre2CodePatternInfoTests {
     // --- nameEntrySize ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void nameEntrySizeWithNamedGroups(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<first>a)");
         assertTrue(code.nameEntrySize() > 0);
@@ -305,14 +284,14 @@ public class Pcre2CodePatternInfoTests {
     // --- nameTable ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void nameTableEmpty(IPcre2 api) {
         var code = new Pcre2Code(api, "(a)(b)");
         assertEquals(0, code.nameTable().length);
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void nameTableWithNamedGroups(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<first>a)(?<second>b)");
         var nameTable = code.nameTable();
@@ -332,7 +311,7 @@ public class Pcre2CodePatternInfoTests {
     // --- size ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void sizePositive(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertTrue(code.size() > 0);
@@ -341,7 +320,7 @@ public class Pcre2CodePatternInfoTests {
     // --- api() and handle() ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void apiReturnsNonNull(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertNotNull(code.api());
@@ -349,7 +328,7 @@ public class Pcre2CodePatternInfoTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void handleReturnsNonZero(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertTrue(code.handle() != 0);
@@ -358,7 +337,7 @@ public class Pcre2CodePatternInfoTests {
     // --- groupNumberFromName ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void groupNumberFromNameValid(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<first>a)(?<second>b)");
         assertEquals(1, code.groupNumberFromName("first"));
@@ -366,21 +345,21 @@ public class Pcre2CodePatternInfoTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void groupNumberFromNameNullThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<name>a)");
         assertThrows(IllegalArgumentException.class, () -> code.groupNumberFromName(null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void groupNumberFromNameNonexistentThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<name>a)");
         assertThrows(Pcre2NoSubstringError.class, () -> code.groupNumberFromName("nonexistent"));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void groupNumberFromNameDuplicateThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<name>a)|(?<name>b)",
                 EnumSet.of(Pcre2CompileOption.DUPNAMES));
@@ -390,7 +369,7 @@ public class Pcre2CodePatternInfoTests {
     // --- scanNametable ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void scanNametableValid(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<first>a)(?<second>b)");
         var groups = code.scanNametable("first");
@@ -398,7 +377,7 @@ public class Pcre2CodePatternInfoTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void scanNametableDuplicateNames(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<name>a)|(?<name>b)",
                 EnumSet.of(Pcre2CompileOption.DUPNAMES));
@@ -409,14 +388,14 @@ public class Pcre2CodePatternInfoTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void scanNametableNullThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<name>a)");
         assertThrows(IllegalArgumentException.class, () -> code.scanNametable(null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void scanNametableNonexistentThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<name>a)");
         assertThrows(Pcre2NoSubstringError.class, () -> code.scanNametable("nonexistent"));

--- a/lib/src/test/java/org/pcre4j/Pcre2CodeSubstituteTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodeSubstituteTests.java
@@ -15,13 +15,10 @@
 package org.pcre4j;
 
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.EnumSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -31,26 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 public class Pcre2CodeSubstituteTests {
 
-    private static IPcre2 loadBackend(String className) {
-        try {
-            return (IPcre2) Class.forName(className).getDeclaredConstructor().newInstance();
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Backend " + className + " not found on classpath", e);
-        } catch (InvocationTargetException | InstantiationException | IllegalAccessException
-                 | NoSuchMethodException e) {
-            throw new RuntimeException("Failed to instantiate backend " + className, e);
-        }
-    }
-
-    private static Stream<Arguments> parameters() {
-        return Stream.of(
-                Arguments.of(loadBackend("org.pcre4j.jna.Pcre2")),
-                Arguments.of(loadBackend("org.pcre4j.ffm.Pcre2"))
-        );
-    }
-
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void substituteSimple(IPcre2 api) {
         var code = new Pcre2Code(api, "world");
         var result = code.substitute("hello world", 0, null, null, null, "earth");
@@ -58,7 +37,7 @@ public class Pcre2CodeSubstituteTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void substituteGlobal(IPcre2 api) {
         var code = new Pcre2Code(api, "o");
         var result = code.substitute("foo boo", 0,
@@ -67,7 +46,7 @@ public class Pcre2CodeSubstituteTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void substituteWithBackreference(IPcre2 api) {
         var code = new Pcre2Code(api, "(\\w+) (\\w+)");
         var result = code.substitute("hello world", 0, null, null, null, "$2 $1");
@@ -75,7 +54,7 @@ public class Pcre2CodeSubstituteTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void substituteWithNamedGroup(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<first>\\w+) (?<second>\\w+)");
         var result = code.substitute("hello world", 0, null, null, null, "${second} ${first}");
@@ -83,7 +62,7 @@ public class Pcre2CodeSubstituteTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void substituteNoMatch(IPcre2 api) {
         var code = new Pcre2Code(api, "xyz");
         var result = code.substitute("hello world", 0, null, null, null, "abc");
@@ -91,7 +70,7 @@ public class Pcre2CodeSubstituteTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void substituteEmptyReplacement(IPcre2 api) {
         var code = new Pcre2Code(api, "world");
         var result = code.substitute("hello world", 0, null, null, null, "");
@@ -99,7 +78,7 @@ public class Pcre2CodeSubstituteTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void substituteWithStartOffset(IPcre2 api) {
         var code = new Pcre2Code(api, "o");
         var result = code.substitute("foo boo", 2, null, null, null, "0");
@@ -108,7 +87,7 @@ public class Pcre2CodeSubstituteTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void substituteUnicode(IPcre2 api) {
         var code = new Pcre2Code(api, "caf\u00e9");
         var result = code.substitute("I love caf\u00e9", 0, null, null, null, "coffee");
@@ -116,7 +95,7 @@ public class Pcre2CodeSubstituteTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void substituteNullOptionsUsesEmpty(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         var result = code.substitute("test", 0, null, null, null, "replaced");
@@ -125,7 +104,7 @@ public class Pcre2CodeSubstituteTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void substituteLargeReplacementTriggersReallocation(IPcre2 api) {
         // Create a replacement much larger than the subject to exercise buffer reallocation
         var code = new Pcre2Code(api, "a");
@@ -135,7 +114,7 @@ public class Pcre2CodeSubstituteTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void substituteGlobalWithLargeOutput(IPcre2 api) {
         // Many substitutions that expand the output significantly
         var code = new Pcre2Code(api, ".");

--- a/lib/src/test/java/org/pcre4j/Pcre2CodeTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodeTests.java
@@ -15,12 +15,8 @@
 package org.pcre4j;
 
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
-
-import java.lang.reflect.InvocationTargetException;
-import java.util.stream.Stream;
 
 import java.util.EnumSet;
 
@@ -30,32 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Pcre2CodeTests {
 
-    /**
-     * Reflectively instantiates an {@link IPcre2} backend by class name.
-     *
-     * @param className the fully qualified class name of the backend
-     * @return the backend instance
-     */
-    private static IPcre2 loadBackend(String className) {
-        try {
-            return (IPcre2) Class.forName(className).getDeclaredConstructor().newInstance();
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Backend " + className + " not found on classpath", e);
-        } catch (InvocationTargetException | InstantiationException | IllegalAccessException
-                 | NoSuchMethodException e) {
-            throw new RuntimeException("Failed to instantiate backend " + className, e);
-        }
-    }
-
-    private static Stream<Arguments> parameters() {
-        return Stream.of(
-                Arguments.of(loadBackend("org.pcre4j.jna.Pcre2")),
-                Arguments.of(loadBackend("org.pcre4j.ffm.Pcre2"))
-        );
-    }
-
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void badPattern(IPcre2 api) {
         assertThrows(Pcre2CompileError.class, () -> {
             new Pcre2Code(api, "?");
@@ -63,7 +35,7 @@ public class Pcre2CodeTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void emptyStringMatch(IPcre2 api) {
         var code = new Pcre2Code(api, "^$");
         var matchData = new Pcre2MatchData(code);
@@ -72,7 +44,7 @@ public class Pcre2CodeTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void emptyStringMatchJit(IPcre2 api) {
         var code = new Pcre2JitCode(api, "^$", null, null, null);
         var matchData = new Pcre2MatchData(code);
@@ -81,7 +53,7 @@ public class Pcre2CodeTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchAtEndOfString(IPcre2 api) {
         // Pattern $ matches at end of string, startOffset at length should work
         var code = new Pcre2Code(api, "$");
@@ -92,7 +64,7 @@ public class Pcre2CodeTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchAtEndOfStringJit(IPcre2 api) {
         // Pattern $ matches at end of string, startOffset at length should work with JIT
         var code = new Pcre2JitCode(api, "$", null, null, null);
@@ -103,7 +75,7 @@ public class Pcre2CodeTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void startOffsetPastEndThrows(IPcre2 api) {
         var code = new Pcre2Code(api, ".");
         var matchData = new Pcre2MatchData(code);
@@ -113,7 +85,7 @@ public class Pcre2CodeTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void startOffsetPastEndThrowsJit(IPcre2 api) {
         var code = new Pcre2JitCode(api, ".", null, null, null);
         var matchData = new Pcre2MatchData(code);
@@ -123,28 +95,28 @@ public class Pcre2CodeTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchLimitThrowsWhenUnset(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertThrows(IllegalStateException.class, code::matchLimit);
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void depthLimitThrowsWhenUnset(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertThrows(IllegalStateException.class, code::depthLimit);
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void heapLimitThrowsWhenUnset(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertThrows(IllegalStateException.class, code::heapLimit);
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void firstCodeTypeReturnsValidValue(IPcre2 api) {
         // Test that firstCodeType returns a valid value (0, 1, or 2)
         var code = new Pcre2Code(api, "test");
@@ -154,7 +126,7 @@ public class Pcre2CodeTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void firstCodeTypeForLiteralPattern(IPcre2 api) {
         // Pattern starting with a literal character should return 1 (first code unit is set)
         var code = new Pcre2Code(api, "test");

--- a/lib/src/test/java/org/pcre4j/Pcre2ContextTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2ContextTests.java
@@ -15,13 +15,10 @@
 package org.pcre4j;
 
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.EnumSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,28 +32,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class Pcre2ContextTests {
 
-    private static IPcre2 loadBackend(String className) {
-        try {
-            return (IPcre2) Class.forName(className).getDeclaredConstructor().newInstance();
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Backend " + className + " not found on classpath", e);
-        } catch (InvocationTargetException | InstantiationException | IllegalAccessException
-                 | NoSuchMethodException e) {
-            throw new RuntimeException("Failed to instantiate backend " + className, e);
-        }
-    }
-
-    private static Stream<Arguments> parameters() {
-        return Stream.of(
-                Arguments.of(loadBackend("org.pcre4j.jna.Pcre2")),
-                Arguments.of(loadBackend("org.pcre4j.ffm.Pcre2"))
-        );
-    }
-
     // === Pcre2GeneralContext ===
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void generalContextCreation(IPcre2 api) {
         var ctx = new Pcre2GeneralContext(api);
         assertNotNull(ctx);
@@ -66,14 +45,14 @@ public class Pcre2ContextTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void generalContextUsableForCompileContext(IPcre2 api) {
         var generalCtx = new Pcre2GeneralContext(api);
         assertDoesNotThrow(() -> new Pcre2CompileContext(api, generalCtx));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void generalContextUsableForMatchContext(IPcre2 api) {
         var generalCtx = new Pcre2GeneralContext(api);
         assertDoesNotThrow(() -> new Pcre2MatchContext(api, generalCtx));
@@ -82,7 +61,7 @@ public class Pcre2ContextTests {
     // === Pcre2CompileContext ===
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void compileContextCreation(IPcre2 api) {
         var ctx = new Pcre2CompileContext(api, null);
         assertNotNull(ctx);
@@ -92,7 +71,7 @@ public class Pcre2ContextTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void compileContextSetNewline(IPcre2 api) {
         var ctx = new Pcre2CompileContext(api, null);
         assertDoesNotThrow(() -> ctx.setNewline(Pcre2Newline.LF));
@@ -104,14 +83,14 @@ public class Pcre2ContextTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void compileContextSetNewlineNullThrows(IPcre2 api) {
         var ctx = new Pcre2CompileContext(api, null);
         assertThrows(IllegalArgumentException.class, () -> ctx.setNewline(null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void compileContextSetBsr(IPcre2 api) {
         var ctx = new Pcre2CompileContext(api, null);
         assertDoesNotThrow(() -> ctx.setBsr(Pcre2Bsr.UNICODE));
@@ -119,35 +98,35 @@ public class Pcre2ContextTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void compileContextSetBsrNullThrows(IPcre2 api) {
         var ctx = new Pcre2CompileContext(api, null);
         assertThrows(IllegalArgumentException.class, () -> ctx.setBsr(null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void compileContextSetParensNestLimit(IPcre2 api) {
         var ctx = new Pcre2CompileContext(api, null);
         assertDoesNotThrow(() -> ctx.setParensNestLimit(100));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void compileContextSetMaxPatternLength(IPcre2 api) {
         var ctx = new Pcre2CompileContext(api, null);
         assertDoesNotThrow(() -> ctx.setMaxPatternLength(1024));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void compileContextSetCompileExtraOptions(IPcre2 api) {
         var ctx = new Pcre2CompileContext(api, null);
         assertDoesNotThrow(() -> ctx.setCompileExtraOptions(Pcre2CompileExtraOption.BAD_ESCAPE_IS_LITERAL));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void compileContextSetCompileExtraOptionsNullThrows(IPcre2 api) {
         var ctx = new Pcre2CompileContext(api, null);
         assertThrows(IllegalArgumentException.class, () ->
@@ -155,7 +134,7 @@ public class Pcre2ContextTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void compileContextSetCompileExtraOptionsNullElementThrows(IPcre2 api) {
         var ctx = new Pcre2CompileContext(api, null);
         assertThrows(IllegalArgumentException.class, () ->
@@ -163,7 +142,7 @@ public class Pcre2ContextTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void compileContextUsedInCompilation(IPcre2 api) {
         var ctx = new Pcre2CompileContext(api, null);
         ctx.setNewline(Pcre2Newline.CR);
@@ -177,7 +156,7 @@ public class Pcre2ContextTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void compileContextParensLimitEnforced(IPcre2 api) {
         var ctx = new Pcre2CompileContext(api, null);
         ctx.setParensNestLimit(2);
@@ -188,7 +167,7 @@ public class Pcre2ContextTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void compileContextMaxPatternLengthEnforced(IPcre2 api) {
         var ctx = new Pcre2CompileContext(api, null);
         ctx.setMaxPatternLength(3);
@@ -201,7 +180,7 @@ public class Pcre2ContextTests {
     // === Pcre2MatchContext ===
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchContextCreation(IPcre2 api) {
         var ctx = new Pcre2MatchContext(api, null);
         assertNotNull(ctx);
@@ -211,63 +190,63 @@ public class Pcre2ContextTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchContextSetMatchLimit(IPcre2 api) {
         var ctx = new Pcre2MatchContext(api, null);
         assertDoesNotThrow(() -> ctx.setMatchLimit(1000));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchContextSetMatchLimitNegativeThrows(IPcre2 api) {
         var ctx = new Pcre2MatchContext(api, null);
         assertThrows(IllegalArgumentException.class, () -> ctx.setMatchLimit(-1));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchContextSetDepthLimit(IPcre2 api) {
         var ctx = new Pcre2MatchContext(api, null);
         assertDoesNotThrow(() -> ctx.setDepthLimit(500));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchContextSetDepthLimitNegativeThrows(IPcre2 api) {
         var ctx = new Pcre2MatchContext(api, null);
         assertThrows(IllegalArgumentException.class, () -> ctx.setDepthLimit(-1));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchContextSetHeapLimit(IPcre2 api) {
         var ctx = new Pcre2MatchContext(api, null);
         assertDoesNotThrow(() -> ctx.setHeapLimit(1024));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchContextSetHeapLimitNegativeThrows(IPcre2 api) {
         var ctx = new Pcre2MatchContext(api, null);
         assertThrows(IllegalArgumentException.class, () -> ctx.setHeapLimit(-1));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchContextSetOffsetLimit(IPcre2 api) {
         var ctx = new Pcre2MatchContext(api, null);
         assertDoesNotThrow(() -> ctx.setOffsetLimit(100));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchContextSetOffsetLimitNegativeThrows(IPcre2 api) {
         var ctx = new Pcre2MatchContext(api, null);
         assertThrows(IllegalArgumentException.class, () -> ctx.setOffsetLimit(-1));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchContextAssignJitStack(IPcre2 api) {
         var matchCtx = new Pcre2MatchContext(api, null);
         var jitStack = new Pcre2JitStack(api, 32 * 1024, 512 * 1024, null);
@@ -275,14 +254,14 @@ public class Pcre2ContextTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchContextAssignJitStackNullThrows(IPcre2 api) {
         var matchCtx = new Pcre2MatchContext(api, null);
         assertThrows(IllegalArgumentException.class, () -> matchCtx.assignJitStack(null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchContextLowMatchLimitCausesError(IPcre2 api) {
         var ctx = new Pcre2MatchContext(api, null);
         ctx.setMatchLimit(1); // Extremely low limit
@@ -298,7 +277,7 @@ public class Pcre2ContextTests {
     // === Pcre2JitStack ===
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitStackCreation(IPcre2 api) {
         var stack = new Pcre2JitStack(api, 32 * 1024, 512 * 1024, null);
         assertNotNull(stack);
@@ -308,7 +287,7 @@ public class Pcre2ContextTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitStackWithGeneralContext(IPcre2 api) {
         var generalCtx = new Pcre2GeneralContext(api);
         var stack = new Pcre2JitStack(api, 32 * 1024, 512 * 1024, generalCtx);
@@ -317,7 +296,7 @@ public class Pcre2ContextTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitStackUsedInMatch(IPcre2 api) {
         var matchCtx = new Pcre2MatchContext(api, null);
         var jitStack = new Pcre2JitStack(api, 32 * 1024, 512 * 1024, null);

--- a/lib/src/test/java/org/pcre4j/Pcre2JitCodeTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2JitCodeTests.java
@@ -15,13 +15,10 @@
 package org.pcre4j;
 
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.EnumSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -33,26 +30,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class Pcre2JitCodeTests {
 
-    private static IPcre2 loadBackend(String className) {
-        try {
-            return (IPcre2) Class.forName(className).getDeclaredConstructor().newInstance();
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Backend " + className + " not found on classpath", e);
-        } catch (InvocationTargetException | InstantiationException | IllegalAccessException
-                 | NoSuchMethodException e) {
-            throw new RuntimeException("Failed to instantiate backend " + className, e);
-        }
-    }
-
-    private static Stream<Arguments> parameters() {
-        return Stream.of(
-                Arguments.of(loadBackend("org.pcre4j.jna.Pcre2")),
-                Arguments.of(loadBackend("org.pcre4j.ffm.Pcre2"))
-        );
-    }
-
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getSupportedMatchOptions(IPcre2 api) {
         var options = Pcre2JitCode.getSupportedMatchOptions();
         assertNotNull(options);
@@ -68,7 +47,7 @@ public class Pcre2JitCodeTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitMatchSuccess(IPcre2 api) {
         var code = new Pcre2JitCode(api, "(hello) (world)", null, null, null);
         var matchData = new Pcre2MatchData(code);
@@ -78,7 +57,7 @@ public class Pcre2JitCodeTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitMatchNoMatch(IPcre2 api) {
         var code = new Pcre2JitCode(api, "xyz", null, null, null);
         var matchData = new Pcre2MatchData(code);
@@ -87,7 +66,7 @@ public class Pcre2JitCodeTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitMatchWithStartOffset(IPcre2 api) {
         var code = new Pcre2JitCode(api, "o", null, null, null);
         var matchData = new Pcre2MatchData(code);
@@ -102,7 +81,7 @@ public class Pcre2JitCodeTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitMatchWithMatchContext(IPcre2 api) {
         var matchCtx = new Pcre2MatchContext(api, null);
         var jitStack = new Pcre2JitStack(api, 32 * 1024, 512 * 1024, null);
@@ -115,7 +94,7 @@ public class Pcre2JitCodeTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitCodeWithSpecificJitOptions(IPcre2 api) {
         // Compile with only COMPLETE (not PARTIAL_SOFT and PARTIAL_HARD)
         var code = new Pcre2JitCode(api, "test", null,
@@ -126,7 +105,7 @@ public class Pcre2JitCodeTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitCodeWithCompileOptions(IPcre2 api) {
         var code = new Pcre2JitCode(api, "test",
                 EnumSet.of(Pcre2CompileOption.CASELESS), null, null);
@@ -136,7 +115,7 @@ public class Pcre2JitCodeTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitCodeWithCompileContext(IPcre2 api) {
         var compileCtx = new Pcre2CompileContext(api, null);
         compileCtx.setNewline(Pcre2Newline.LF);
@@ -148,7 +127,7 @@ public class Pcre2JitCodeTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitCodeWithMatchOptions(IPcre2 api) {
         var code = new Pcre2JitCode(api, "^test", null, null, null);
         var matchData = new Pcre2MatchData(code);
@@ -160,7 +139,7 @@ public class Pcre2JitCodeTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void jitCodePartialMatch(IPcre2 api) {
         var code = new Pcre2JitCode(api, "testing", null, null, null);
         var matchData = new Pcre2MatchData(code);

--- a/lib/src/test/java/org/pcre4j/Pcre2MatchDataTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2MatchDataTests.java
@@ -15,15 +15,12 @@
 package org.pcre4j;
 
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
 
-import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,28 +33,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class Pcre2MatchDataTests {
 
-    private static IPcre2 loadBackend(String className) {
-        try {
-            return (IPcre2) Class.forName(className).getDeclaredConstructor().newInstance();
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Backend " + className + " not found on classpath", e);
-        } catch (InvocationTargetException | InstantiationException | IllegalAccessException
-                 | NoSuchMethodException e) {
-            throw new RuntimeException("Failed to instantiate backend " + className, e);
-        }
-    }
-
-    private static Stream<Arguments> parameters() {
-        return Stream.of(
-                Arguments.of(loadBackend("org.pcre4j.jna.Pcre2")),
-                Arguments.of(loadBackend("org.pcre4j.ffm.Pcre2"))
-        );
-    }
-
     // --- api() and handle() ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void apiReturnsNonNull(IPcre2 api) {
         var matchData = new Pcre2MatchData(api, 10);
         assertNotNull(matchData.api());
@@ -65,7 +44,7 @@ public class Pcre2MatchDataTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void handleReturnsNonZero(IPcre2 api) {
         var matchData = new Pcre2MatchData(api, 10);
         assertTrue(matchData.handle() != 0);
@@ -74,7 +53,7 @@ public class Pcre2MatchDataTests {
     // --- ovectorCount ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void ovectorCountAfterMatch(IPcre2 api) {
         var code = new Pcre2Code(api, "(a)(b)(c)");
         var matchData = new Pcre2MatchData(code);
@@ -85,7 +64,7 @@ public class Pcre2MatchDataTests {
     // --- size ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void sizePositive(IPcre2 api) {
         var matchData = new Pcre2MatchData(api, 10);
         assertTrue(matchData.size() > 0);
@@ -94,7 +73,7 @@ public class Pcre2MatchDataTests {
     // --- ovector ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void ovectorReturnsByteOffsets(IPcre2 api) {
         var code = new Pcre2Code(api, "(ab)");
         var matchData = new Pcre2MatchData(code);
@@ -110,7 +89,7 @@ public class Pcre2MatchDataTests {
     // --- getSubstring(int) ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getSubstringByNumber(IPcre2 api) {
         var code = new Pcre2Code(api, "(hello) (world)");
         var matchData = new Pcre2MatchData(code);
@@ -127,7 +106,7 @@ public class Pcre2MatchDataTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getSubstringNegativeNumberThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(test)");
         var matchData = new Pcre2MatchData(code);
@@ -136,7 +115,7 @@ public class Pcre2MatchDataTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getSubstringOutOfBoundsThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(test)");
         var matchData = new Pcre2MatchData(code);
@@ -145,7 +124,7 @@ public class Pcre2MatchDataTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getSubstringUnsetGroupThrows(IPcre2 api) {
         // (a)|(b) - when "a" matches, group 2 is unset
         var code = new Pcre2Code(api, "(a)|(b)");
@@ -157,7 +136,7 @@ public class Pcre2MatchDataTests {
     // --- getSubstring(String) ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getSubstringByName(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<greeting>hello) (?<target>world)");
         var matchData = new Pcre2MatchData(code);
@@ -171,7 +150,7 @@ public class Pcre2MatchDataTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getSubstringByNameNullThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<name>test)");
         var matchData = new Pcre2MatchData(code);
@@ -180,7 +159,7 @@ public class Pcre2MatchDataTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getSubstringByNameNonexistentThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<name>test)");
         var matchData = new Pcre2MatchData(code);
@@ -191,7 +170,7 @@ public class Pcre2MatchDataTests {
     // --- copySubstring(int, ByteBuffer) ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void copySubstringByNumber(IPcre2 api) {
         var code = new Pcre2Code(api, "(hello)");
         var matchData = new Pcre2MatchData(code);
@@ -207,7 +186,7 @@ public class Pcre2MatchDataTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void copySubstringNegativeNumberThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(test)");
         var matchData = new Pcre2MatchData(code);
@@ -217,7 +196,7 @@ public class Pcre2MatchDataTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void copySubstringNullBufferThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(test)");
         var matchData = new Pcre2MatchData(code);
@@ -226,7 +205,7 @@ public class Pcre2MatchDataTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void copySubstringNonDirectBufferThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(test)");
         var matchData = new Pcre2MatchData(code);
@@ -236,7 +215,7 @@ public class Pcre2MatchDataTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void copySubstringOutOfBoundsThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(test)");
         var matchData = new Pcre2MatchData(code);
@@ -248,7 +227,7 @@ public class Pcre2MatchDataTests {
     // --- copySubstring(String, ByteBuffer) ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void copySubstringByName(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<word>hello)");
         var matchData = new Pcre2MatchData(code);
@@ -264,7 +243,7 @@ public class Pcre2MatchDataTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void copySubstringByNameNullNameThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<name>test)");
         var matchData = new Pcre2MatchData(code);
@@ -274,7 +253,7 @@ public class Pcre2MatchDataTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void copySubstringByNameNullBufferThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<name>test)");
         var matchData = new Pcre2MatchData(code);
@@ -283,7 +262,7 @@ public class Pcre2MatchDataTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void copySubstringByNameNonDirectBufferThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<name>test)");
         var matchData = new Pcre2MatchData(code);
@@ -293,7 +272,7 @@ public class Pcre2MatchDataTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void copySubstringByNameNonexistentThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<name>test)");
         var matchData = new Pcre2MatchData(code);
@@ -305,7 +284,7 @@ public class Pcre2MatchDataTests {
     // --- getSubstringLength(int) ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getSubstringLengthByNumber(IPcre2 api) {
         var code = new Pcre2Code(api, "(hello)");
         var matchData = new Pcre2MatchData(code);
@@ -315,7 +294,7 @@ public class Pcre2MatchDataTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getSubstringLengthNegativeThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(test)");
         var matchData = new Pcre2MatchData(code);
@@ -324,7 +303,7 @@ public class Pcre2MatchDataTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getSubstringLengthOutOfBoundsThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(test)");
         var matchData = new Pcre2MatchData(code);
@@ -335,7 +314,7 @@ public class Pcre2MatchDataTests {
     // --- getSubstringLength(String) ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getSubstringLengthByName(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<word>hello)");
         var matchData = new Pcre2MatchData(code);
@@ -344,7 +323,7 @@ public class Pcre2MatchDataTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getSubstringLengthByNameNullThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<name>test)");
         var matchData = new Pcre2MatchData(code);
@@ -353,7 +332,7 @@ public class Pcre2MatchDataTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getSubstringLengthByNameNonexistentThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<name>test)");
         var matchData = new Pcre2MatchData(code);
@@ -364,7 +343,7 @@ public class Pcre2MatchDataTests {
     // --- MatchData from pattern ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchDataFromPatternWorksCorrectly(IPcre2 api) {
         var code = new Pcre2Code(api, "(a)(b)(c)");
         var matchData = new Pcre2MatchData(code);

--- a/lib/src/test/java/org/pcre4j/Pcre4jUtilsExtendedTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre4jUtilsExtendedTests.java
@@ -16,14 +16,11 @@ package org.pcre4j;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
 import org.pcre4j.api.Pcre2UtfWidth;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.EnumSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,28 +35,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class Pcre4jUtilsExtendedTests {
 
-    private static IPcre2 loadBackend(String className) {
-        try {
-            return (IPcre2) Class.forName(className).getDeclaredConstructor().newInstance();
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Backend " + className + " not found on classpath", e);
-        } catch (InvocationTargetException | InstantiationException | IllegalAccessException
-                 | NoSuchMethodException e) {
-            throw new RuntimeException("Failed to instantiate backend " + className, e);
-        }
-    }
-
-    private static Stream<Arguments> parameters() {
-        return Stream.of(
-                Arguments.of(loadBackend("org.pcre4j.jna.Pcre2")),
-                Arguments.of(loadBackend("org.pcre4j.ffm.Pcre2"))
-        );
-    }
-
     // === Configuration query methods ===
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getVersion(IPcre2 api) {
         var version = Pcre4jUtils.getVersion(api);
         assertNotNull(version);
@@ -68,13 +47,13 @@ public class Pcre4jUtilsExtendedTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getVersionNullThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getVersion(null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void isVersionAtLeast(IPcre2 api) {
         // PCRE2 10.x should be present
         assertTrue(Pcre4jUtils.isVersionAtLeast(api, 10, 0));
@@ -83,20 +62,20 @@ public class Pcre4jUtilsExtendedTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void isVersionAtLeastSameMajorHigherMinor(IPcre2 api) {
         // Should handle same major with higher minor correctly
         assertTrue(Pcre4jUtils.isVersionAtLeast(api, 10, 0));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void isVersionAtLeastNullThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.isVersionAtLeast(null, 10, 0));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getUnicodeVersion(IPcre2 api) {
         var version = Pcre4jUtils.getUnicodeVersion(api);
         assertNotNull(version);
@@ -104,91 +83,91 @@ public class Pcre4jUtilsExtendedTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getUnicodeVersionNullThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getUnicodeVersion(null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void isUnicodeSupported(IPcre2 api) {
         // Standard PCRE2 builds support Unicode
         assertTrue(Pcre4jUtils.isUnicodeSupported(api));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void isUnicodeSupportedNullThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.isUnicodeSupported(null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getDefaultParenthesesNestingLimit(IPcre2 api) {
         var limit = Pcre4jUtils.getDefaultParenthesesNestingLimit(api);
         assertTrue(limit > 0, "Default parens nesting limit should be positive");
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getDefaultParenthesesNestingLimitNullThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getDefaultParenthesesNestingLimit(null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getDefaultNewline(IPcre2 api) {
         var newline = Pcre4jUtils.getDefaultNewline(api);
         assertNotNull(newline);
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getDefaultNewlineNullThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getDefaultNewline(null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void isBackslashCDisabled(IPcre2 api) {
         // Just verify it doesn't throw
         Pcre4jUtils.isBackslashCDisabled(api);
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void isBackslashCDisabledNullThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.isBackslashCDisabled(null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getDefaultMatchLimit(IPcre2 api) {
         var limit = Pcre4jUtils.getDefaultMatchLimit(api);
         assertTrue(limit > 0, "Default match limit should be positive");
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getDefaultMatchLimitNullThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getDefaultMatchLimit(null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getInternalLinkSize(IPcre2 api) {
         var linkSize = Pcre4jUtils.getInternalLinkSize(api);
         assertTrue(linkSize > 0, "Internal link size should be positive");
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getInternalLinkSizeNullThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getInternalLinkSize(null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getJitTarget(IPcre2 api) {
         var target = Pcre4jUtils.getJitTarget(api);
         // May return null if JIT not supported, or a non-empty string
@@ -198,52 +177,52 @@ public class Pcre4jUtilsExtendedTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getJitTargetNullThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getJitTarget(null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void isJitSupported(IPcre2 api) {
         // Just verify it doesn't throw; JIT support depends on build
         Pcre4jUtils.isJitSupported(api);
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void isJitSupportedNullThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.isJitSupported(null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getDefaultHeapLimit(IPcre2 api) {
         var limit = Pcre4jUtils.getDefaultHeapLimit(api);
         assertTrue(limit >= 0, "Default heap limit should be non-negative");
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getDefaultHeapLimitNullThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getDefaultHeapLimit(null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getDefaultDepthLimit(IPcre2 api) {
         var limit = Pcre4jUtils.getDefaultDepthLimit(api);
         assertTrue(limit > 0, "Default depth limit should be positive");
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getDefaultDepthLimitNullThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getDefaultDepthLimit(null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getCompiledWidths(IPcre2 api) {
         var widths = Pcre4jUtils.getCompiledWidths(api);
         assertNotNull(widths);
@@ -252,13 +231,13 @@ public class Pcre4jUtilsExtendedTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getCompiledWidthsNullThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getCompiledWidths(null));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getDefaultBsr(IPcre2 api) {
         var bsr = Pcre4jUtils.getDefaultBsr(api);
         assertNotNull(bsr);
@@ -266,7 +245,7 @@ public class Pcre4jUtilsExtendedTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getDefaultBsrNullThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getDefaultBsr(null));
     }
@@ -274,7 +253,7 @@ public class Pcre4jUtilsExtendedTests {
     // === getErrorMessage ===
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getErrorMessageValidCode(IPcre2 api) {
         // ERROR_NOMATCH is -1
         var msg = Pcre4jUtils.getErrorMessage(api, IPcre2.ERROR_NOMATCH);
@@ -283,7 +262,7 @@ public class Pcre4jUtilsExtendedTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getErrorMessageNullApiThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getErrorMessage(null, 0));
     }
@@ -413,7 +392,7 @@ public class Pcre4jUtilsExtendedTests {
     // === getGroupNames ===
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getGroupNamesNoNames(IPcre2 api) {
         var code = new Pcre2Code(api, "(a)(b)");
         var names = Pcre4jUtils.getGroupNames(code);
@@ -425,7 +404,7 @@ public class Pcre4jUtilsExtendedTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getGroupNamesWithNames(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<first>a)(?<second>b)");
         var names = Pcre4jUtils.getGroupNames(code);
@@ -435,7 +414,7 @@ public class Pcre4jUtilsExtendedTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getGroupNamesMixedNaming(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<first>a)(b)(?<third>c)");
         var names = Pcre4jUtils.getGroupNames(code);
@@ -446,7 +425,7 @@ public class Pcre4jUtilsExtendedTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getGroupNamesNullThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () -> Pcre4jUtils.getGroupNames(null));
     }
@@ -454,7 +433,7 @@ public class Pcre4jUtilsExtendedTests {
     // === getMatchGroups ===
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getMatchGroupsWithMatchData(IPcre2 api) {
         var code = new Pcre2Code(api, "(hello) (world)");
         var matchData = new Pcre2MatchData(code);
@@ -468,7 +447,7 @@ public class Pcre4jUtilsExtendedTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getMatchGroupsWithOvector(IPcre2 api) {
         var code = new Pcre2Code(api, "(hello) (world)");
         var matchData = new Pcre2MatchData(code);
@@ -483,14 +462,14 @@ public class Pcre4jUtilsExtendedTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getMatchGroupsNullCodeThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () ->
                 Pcre4jUtils.getMatchGroups(null, "test", new long[]{0, 4}));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getMatchGroupsNullSubjectThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertThrows(IllegalArgumentException.class, () ->
@@ -498,7 +477,7 @@ public class Pcre4jUtilsExtendedTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getMatchGroupsNullOvectorThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertThrows(IllegalArgumentException.class, () ->
@@ -506,7 +485,7 @@ public class Pcre4jUtilsExtendedTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getMatchGroupsNullMatchDataThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertThrows(IllegalArgumentException.class, () ->
@@ -516,7 +495,7 @@ public class Pcre4jUtilsExtendedTests {
     // === getNamedMatchGroups ===
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getNamedMatchGroupsNullMatchDataThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "(?<greeting>hello)");
         assertThrows(IllegalArgumentException.class, () ->
@@ -524,14 +503,14 @@ public class Pcre4jUtilsExtendedTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getNamedMatchGroupsNullCodeThrows(IPcre2 api) {
         assertThrows(IllegalArgumentException.class, () ->
                 Pcre4jUtils.getNamedMatchGroups(null, "test", new long[]{0, 4}));
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getNamedMatchGroupsNullSubjectThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertThrows(IllegalArgumentException.class, () ->
@@ -539,7 +518,7 @@ public class Pcre4jUtilsExtendedTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void getNamedMatchGroupsNullOvectorThrows(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         assertThrows(IllegalArgumentException.class, () ->

--- a/lib/src/test/java/org/pcre4j/ResourceCleanupTests.java
+++ b/lib/src/test/java/org/pcre4j/ResourceCleanupTests.java
@@ -15,37 +15,16 @@
 package org.pcre4j;
 
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
 
 import java.lang.ref.WeakReference;
-import java.lang.reflect.InvocationTargetException;
 import java.util.EnumSet;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ResourceCleanupTests {
-
-    private static IPcre2 loadBackend(String className) {
-        try {
-            return (IPcre2) Class.forName(className).getDeclaredConstructor().newInstance();
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Backend " + className + " not found on classpath", e);
-        } catch (InvocationTargetException | InstantiationException | IllegalAccessException
-                 | NoSuchMethodException e) {
-            throw new RuntimeException("Failed to instantiate backend " + className, e);
-        }
-    }
-
-    private static Stream<Arguments> parameters() {
-        return Stream.of(
-                Arguments.of(loadBackend("org.pcre4j.jna.Pcre2")),
-                Arguments.of(loadBackend("org.pcre4j.ffm.Pcre2"))
-        );
-    }
 
     /**
      * Triggers garbage collection and waits for a weak reference to be cleared.
@@ -70,7 +49,7 @@ public class ResourceCleanupTests {
     // --- Pcre2Code cleanup tests ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void pcre2CodeIsCollectedAfterRelease(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         var ref = new WeakReference<>(code);
@@ -79,7 +58,7 @@ public class ResourceCleanupTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void pcre2CodeCreationWorksAfterPriorCleanup(IPcre2 api) {
         var code = new Pcre2Code(api, "first");
         var ref = new WeakReference<>(code);
@@ -94,7 +73,7 @@ public class ResourceCleanupTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void pcre2CodeBulkCreationAndCleanup(IPcre2 api) {
         var lastRef = new WeakReference<>(new Object());
         for (int i = 0; i < 100; i++) {
@@ -113,7 +92,7 @@ public class ResourceCleanupTests {
     // --- Pcre2MatchData cleanup tests ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void pcre2MatchDataIsCollectedAfterRelease(IPcre2 api) {
         var matchData = new Pcre2MatchData(api, 10);
         var ref = new WeakReference<>(matchData);
@@ -122,7 +101,7 @@ public class ResourceCleanupTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void pcre2MatchDataFromPatternIsCollectedAfterRelease(IPcre2 api) {
         var code = new Pcre2Code(api, "(test)");
         var matchData = new Pcre2MatchData(code);
@@ -132,7 +111,7 @@ public class ResourceCleanupTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void pcre2MatchDataCreationWorksAfterPriorCleanup(IPcre2 api) {
         var matchData = new Pcre2MatchData(api, 10);
         var ref = new WeakReference<>(matchData);
@@ -147,7 +126,7 @@ public class ResourceCleanupTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void pcre2MatchDataBulkCreationAndCleanup(IPcre2 api) {
         var lastRef = new WeakReference<>(new Object());
         for (int i = 0; i < 100; i++) {
@@ -166,7 +145,7 @@ public class ResourceCleanupTests {
     // --- Pcre2GeneralContext cleanup tests ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void pcre2GeneralContextIsCollectedAfterRelease(IPcre2 api) {
         var ctx = new Pcre2GeneralContext(api);
         var ref = new WeakReference<>(ctx);
@@ -175,7 +154,7 @@ public class ResourceCleanupTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void pcre2GeneralContextCreationWorksAfterPriorCleanup(IPcre2 api) {
         var ctx = new Pcre2GeneralContext(api);
         var ref = new WeakReference<>(ctx);
@@ -191,7 +170,7 @@ public class ResourceCleanupTests {
     // --- Pcre2CompileContext cleanup tests ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void pcre2CompileContextIsCollectedAfterRelease(IPcre2 api) {
         var ctx = new Pcre2CompileContext(api, null);
         var ref = new WeakReference<>(ctx);
@@ -200,7 +179,7 @@ public class ResourceCleanupTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void pcre2CompileContextWithGeneralContextIsCollectedAfterRelease(IPcre2 api) {
         var generalCtx = new Pcre2GeneralContext(api);
         var compileCtx = new Pcre2CompileContext(api, generalCtx);
@@ -210,7 +189,7 @@ public class ResourceCleanupTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void pcre2CompileContextCreationWorksAfterPriorCleanup(IPcre2 api) {
         var ctx = new Pcre2CompileContext(api, null);
         ctx.setNewline(Pcre2Newline.LF);
@@ -227,7 +206,7 @@ public class ResourceCleanupTests {
     // --- Pcre2MatchContext cleanup tests ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void pcre2MatchContextIsCollectedAfterRelease(IPcre2 api) {
         var ctx = new Pcre2MatchContext(api, null);
         var ref = new WeakReference<>(ctx);
@@ -236,7 +215,7 @@ public class ResourceCleanupTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void pcre2MatchContextWithGeneralContextIsCollectedAfterRelease(IPcre2 api) {
         var generalCtx = new Pcre2GeneralContext(api);
         var matchCtx = new Pcre2MatchContext(api, generalCtx);
@@ -246,7 +225,7 @@ public class ResourceCleanupTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void pcre2MatchContextCreationWorksAfterPriorCleanup(IPcre2 api) {
         var ctx = new Pcre2MatchContext(api, null);
         ctx.setMatchLimit(1000);
@@ -263,7 +242,7 @@ public class ResourceCleanupTests {
     // --- Pcre2JitStack cleanup tests ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void pcre2JitStackIsCollectedAfterRelease(IPcre2 api) {
         var stack = new Pcre2JitStack(api, 32 * 1024, 512 * 1024, null);
         var ref = new WeakReference<>(stack);
@@ -272,7 +251,7 @@ public class ResourceCleanupTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void pcre2JitStackCreationWorksAfterPriorCleanup(IPcre2 api) {
         var stack = new Pcre2JitStack(api, 32 * 1024, 512 * 1024, null);
         var ref = new WeakReference<>(stack);
@@ -288,7 +267,7 @@ public class ResourceCleanupTests {
     // --- Cross-resource cleanup tests ---
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void allResourceTypesCleanedUpIndependently(IPcre2 api) {
         var code = new Pcre2Code(api, "test");
         var matchData = new Pcre2MatchData(code);
@@ -325,7 +304,7 @@ public class ResourceCleanupTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchDataCleanupDoesNotAffectCode(IPcre2 api) {
         var code = new Pcre2Code(api, "(hello)");
 

--- a/lib/src/testFixtures/java/org/pcre4j/test/BackendProvider.java
+++ b/lib/src/testFixtures/java/org/pcre4j/test/BackendProvider.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j.test;
+
+import org.junit.jupiter.params.provider.Arguments;
+import org.pcre4j.api.IPcre2;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.stream.Stream;
+
+/**
+ * Test fixture utility that provides {@link IPcre2} backend instances for parameterized tests.
+ *
+ * <p>This class centralizes backend discovery and instantiation logic shared across test classes in multiple modules.
+ * Backends are loaded reflectively to avoid compile-time coupling with specific backend implementations.</p>
+ *
+ * <p>Usage in test classes:</p>
+ * <pre>{@code
+ * @ParameterizedTest
+ * @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+ * void testSomething(IPcre2 api) {
+ *     // test code using api
+ * }
+ * }</pre>
+ */
+public final class BackendProvider {
+
+    private static final String JNA_BACKEND = "org.pcre4j.jna.Pcre2";
+    private static final String FFM_BACKEND = "org.pcre4j.ffm.Pcre2";
+
+    private BackendProvider() {
+    }
+
+    /**
+     * Reflectively instantiates an {@link IPcre2} backend by class name.
+     *
+     * @param className the fully qualified class name of the backend
+     * @return the backend instance
+     * @throws RuntimeException if the backend class is not found or cannot be instantiated
+     */
+    public static IPcre2 loadBackend(String className) {
+        try {
+            return (IPcre2) Class.forName(className).getDeclaredConstructor().newInstance();
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Backend " + className + " not found on classpath", e);
+        } catch (InvocationTargetException | InstantiationException | IllegalAccessException
+                 | NoSuchMethodException e) {
+            throw new RuntimeException("Failed to instantiate backend " + className, e);
+        }
+    }
+
+    /**
+     * Provides JNA and FFM backend instances as JUnit 5 parameterized test arguments.
+     *
+     * <p>Use with {@code @MethodSource("org.pcre4j.test.BackendProvider#parameters")}.</p>
+     *
+     * @return a stream of arguments, each containing an {@link IPcre2} backend instance
+     */
+    public static Stream<Arguments> parameters() {
+        return Stream.of(
+                Arguments.of(loadBackend(JNA_BACKEND)),
+                Arguments.of(loadBackend(FFM_BACKEND))
+        );
+    }
+}

--- a/regex/build.gradle.kts
+++ b/regex/build.gradle.kts
@@ -28,6 +28,7 @@ repositories {
 dependencies {
     api(project(":api"))
     api(project(":lib"))
+    testImplementation(testFixtures(project(":lib")))
     testImplementation(project(":jna"))
     testImplementation(project(":ffm"))
     testImplementation(libs.junit.jupiter)

--- a/regex/src/test/java/org/pcre4j/regex/MatchLimitTests.java
+++ b/regex/src/test/java/org/pcre4j/regex/MatchLimitTests.java
@@ -17,11 +17,8 @@ package org.pcre4j.regex;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
-
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -29,16 +26,6 @@ import static org.junit.jupiter.api.Assertions.*;
  * Tests for ReDoS protection via configurable match limits.
  */
 public class MatchLimitTests {
-
-    private static final IPcre2 JNA_PCRE2 = new org.pcre4j.jna.Pcre2();
-    private static final IPcre2 FFM_PCRE2 = new org.pcre4j.ffm.Pcre2();
-
-    private static Stream<Arguments> parameters() {
-        return Stream.of(
-                Arguments.of(JNA_PCRE2),
-                Arguments.of(FFM_PCRE2)
-        );
-    }
 
     private String savedJitProperty;
     private String savedMatchLimitProperty;
@@ -73,7 +60,7 @@ public class MatchLimitTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchLimitThrowsMatchLimitException(IPcre2 api) {
         // Set a very low match limit
         System.setProperty(Matcher.MATCH_LIMIT_PROPERTY, "100");
@@ -89,7 +76,7 @@ public class MatchLimitTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void depthLimitThrowsMatchLimitException(IPcre2 api) {
         // Depth limits are only enforced by the interpreter, not the JIT matcher
         System.setProperty("pcre2.regex.jit", "false");
@@ -107,7 +94,7 @@ public class MatchLimitTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void heapLimitThrowsMatchLimitException(IPcre2 api) {
         // Heap limits are only enforced by the interpreter, not the JIT matcher
         System.setProperty("pcre2.regex.jit", "false");
@@ -126,7 +113,7 @@ public class MatchLimitTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchLimitAppliesToMatches(IPcre2 api) {
         // Verify that match limit also applies to matches() method
         System.setProperty(Matcher.MATCH_LIMIT_PROPERTY, "100");
@@ -138,7 +125,7 @@ public class MatchLimitTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchLimitAppliesToLookingAt(IPcre2 api) {
         // Verify that match limit also applies to lookingAt() method
         System.setProperty(Matcher.MATCH_LIMIT_PROPERTY, "100");
@@ -150,7 +137,7 @@ public class MatchLimitTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void noLimitByDefaultAllowsNormalMatching(IPcre2 api) {
         // Without setting system properties, normal matching should work fine
         var pattern = Pattern.compile(api, "\\d+");
@@ -161,7 +148,7 @@ public class MatchLimitTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void highLimitAllowsNormalMatching(IPcre2 api) {
         // A high match limit should not interfere with normal patterns
         System.setProperty(Matcher.MATCH_LIMIT_PROPERTY, "10000000");
@@ -176,7 +163,7 @@ public class MatchLimitTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchLimitAppliesToUsePattern(IPcre2 api) {
         // Verify that match limits are reconfigured when usePattern() is called
         System.setProperty(Matcher.MATCH_LIMIT_PROPERTY, "100");

--- a/regex/src/test/java/org/pcre4j/regex/MatcherTests.java
+++ b/regex/src/test/java/org/pcre4j/regex/MatcherTests.java
@@ -15,11 +15,8 @@
 package org.pcre4j.regex;
 
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
-
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -31,18 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class MatcherTests {
 
-    private static final IPcre2 JNA_PCRE2 = new org.pcre4j.jna.Pcre2();
-    private static final IPcre2 FFM_PCRE2 = new org.pcre4j.ffm.Pcre2();
-
-    private static Stream<Arguments> parameters() {
-        return Stream.of(
-                Arguments.of(JNA_PCRE2),
-                Arguments.of(FFM_PCRE2)
-        );
-    }
-
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void unicodeOneByte(IPcre2 api) {
         var regex = "Å";
         var input = "Å";
@@ -64,7 +51,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void unicodeTwoBytes(IPcre2 api) {
         var regex = "Ǎ";
         var input = "Ǎ";
@@ -86,7 +73,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void unicodeThreeBytes(IPcre2 api) {
         var regex = "•";
         var input = "•";
@@ -108,7 +95,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void unicodeFourBytes(IPcre2 api) {
         var regex = "\uD83C\uDF0D";
         var input = "\uD83C\uDF0D";
@@ -130,7 +117,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void unicode(IPcre2 api) {
         var regex = "ÅǍ•\uD83C\uDF0D!";
         var input = "ÅǍ•\uD83C\uDF0D!";
@@ -152,7 +139,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void unicodeRegion(IPcre2 api) {
         var regex = "\uD83C\uDF0D";
         var input = "ÅǍ•\uD83C\uDF0D!";
@@ -177,7 +164,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchesTrue(IPcre2 api) {
         var regex = "42";
         var input = "42";
@@ -199,7 +186,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchesFalse(IPcre2 api) {
         var regex = "42";
         var input = "42!";
@@ -227,7 +214,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchesTrueInRegion(IPcre2 api) {
         var regex = "42";
         var input = "[42]";
@@ -252,7 +239,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void matchesFalseRegion(IPcre2 api) {
         var regex = "42";
         var input = "[42!]";
@@ -283,7 +270,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void lookingAtTrue(IPcre2 api) {
         var regex = "42";
         var input = "42!";
@@ -305,7 +292,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void lookingAtFalse(IPcre2 api) {
         var regex = "42";
         var input = "!42";
@@ -333,7 +320,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void lookingAtTrueInRegion(IPcre2 api) {
         var regex = "42";
         var input = "[42!]";
@@ -358,7 +345,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void lookingAtFalseRegion(IPcre2 api) {
         var regex = "42";
         var input = "[!42]";
@@ -389,7 +376,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void findTrue(IPcre2 api) {
         var regex = "42";
         var input = "42!";
@@ -411,7 +398,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void findFalse(IPcre2 api) {
         var regex = "42!";
         var input = "42";
@@ -439,7 +426,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void findTrueInRegion(IPcre2 api) {
         var regex = "42";
         var input = "[42]";
@@ -463,7 +450,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void findFalseInRegion(IPcre2 api) {
         var regex = "42!";
         var input = "[42]";
@@ -493,7 +480,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void findTrueAtOffset(IPcre2 api) {
         var regex = "42";
         var input = "!!42";
@@ -515,7 +502,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void findFalseAtOffset(IPcre2 api) {
         var regex = "42";
         var input = "!!test";
@@ -543,7 +530,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void findMultiple(IPcre2 api) {
         var regex = "42";
         var input = "42!42";
@@ -578,7 +565,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void findMultipleWithinRegion(IPcre2 api) {
         var regex = "42";
         var input = "42!42!42!42";
@@ -616,7 +603,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void findMultipleOutsideRegion(IPcre2 api) {
         var regex = "42";
         var input = "42!__!__!42";
@@ -647,7 +634,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void captureGroups(IPcre2 api) {
         var regex = "(?<four>4)(.*)(?<two>2)";
         var input = "4test2";
@@ -675,7 +662,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void emptyGroup(IPcre2 api) {
         var regex = "!*";
         var input = "42";
@@ -699,7 +686,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void singleUnmatchedGroup(IPcre2 api) {
         var regex = "(42)?";
         var input = "test";
@@ -723,7 +710,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void unmatchedGroups(IPcre2 api) {
         var regex = "42((?<exclamation>!)|(?<question>\\?))";
         var input = "42!";
@@ -751,7 +738,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void positiveLookaround(IPcre2 api) {
         var regex = "(?<=(?<lWrapper>\\W))?(\\d+)(?=(?<rWrapper>\\W))?";
         var input = "(42)";
@@ -779,7 +766,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void positiveUnmatchedLookaround(IPcre2 api) {
         var regex = "(?<=(?<lWrapper>\\W))?(\\d+)(?=(?<rWrapper>\\W))?";
         var input = "42]";
@@ -807,7 +794,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void emptyStringMatches(IPcre2 api) {
         var regex = "^$";
         var input = "";
@@ -818,7 +805,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void emptyStringFind(IPcre2 api) {
         var regex = "^$";
         var input = "";
@@ -837,7 +824,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void findAtEndOfString(IPcre2 api) {
         var regex = "$";
         var input = "abc";
@@ -849,7 +836,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void findExhaustedInRegion(IPcre2 api) {
         // Test find() behavior when iterating through all matches in a region
         var regex = "a";
@@ -875,7 +862,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void findWithZeroWidthMatchExhaustsRegion(IPcre2 api) {
         // Test that after a zero-width match at regionEnd, the next find() returns false
         // This exercises the start > regionEnd branch in find():
@@ -910,7 +897,7 @@ public class MatcherTests {
     // ========================================================================
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void quoteReplacement(IPcre2 api) {
         // Test basic string without special characters
         assertEquals(
@@ -944,7 +931,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void replaceAllBasic(IPcre2 api) {
         var regex = "world";
         var input = "hello world";
@@ -956,7 +943,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void replaceAllMultiple(IPcre2 api) {
         var regex = "o";
         var input = "hello world";
@@ -968,7 +955,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void replaceAllWithGroupReference(IPcre2 api) {
         var regex = "(\\w+) (\\w+)";
         var input = "hello world";
@@ -980,7 +967,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void replaceAllWithNamedGroupReference(IPcre2 api) {
         var regex = "(?<first>\\w+) (?<second>\\w+)";
         var input = "hello world";
@@ -992,7 +979,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void replaceAllNoMatch(IPcre2 api) {
         var regex = "xyz";
         var input = "hello world";
@@ -1004,7 +991,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void replaceAllEmptyReplacement(IPcre2 api) {
         var regex = "world";
         var input = "hello world";
@@ -1016,7 +1003,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void replaceAllUnicode(IPcre2 api) {
         var regex = "🌐";
         var input = "hello 🌐 world 🌐";
@@ -1028,7 +1015,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void replaceFirstBasic(IPcre2 api) {
         var regex = "o";
         var input = "hello world";
@@ -1040,7 +1027,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void replaceFirstWithGroupReference(IPcre2 api) {
         var regex = "(\\w+) (\\w+)";
         var input = "hello world, foo bar";
@@ -1052,7 +1039,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void replaceFirstNoMatch(IPcre2 api) {
         var regex = "xyz";
         var input = "hello world";
@@ -1064,7 +1051,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void replaceAllWithFunction(IPcre2 api) {
         var regex = "\\d+";
         var input = "a1b22c333";
@@ -1079,7 +1066,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void replaceFirstWithFunction(IPcre2 api) {
         var regex = "\\d+";
         var input = "a1b22c333";
@@ -1094,7 +1081,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void replaceFirstWithFunctionNoMatch(IPcre2 api) {
         var regex = "xyz";
         var input = "hello world";
@@ -1108,7 +1095,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void appendReplacementStringBuffer(IPcre2 api) {
         var regex = "(\\w+)";
         var input = "one two three";
@@ -1129,7 +1116,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void appendReplacementStringBuilder(IPcre2 api) {
         var regex = "(\\w+)";
         var input = "one two three";
@@ -1150,7 +1137,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void appendReplacementWithNamedGroup(IPcre2 api) {
         var regex = "(?<word>\\w+)";
         var input = "one two three";
@@ -1171,7 +1158,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void appendReplacementEscapedCharacters(IPcre2 api) {
         var regex = "\\d+";
         var input = "test123value";
@@ -1193,7 +1180,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void appendReplacementLiteralText(IPcre2 api) {
         var regex = "world";
         var input = "hello world!";
@@ -1214,7 +1201,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void appendTailOnly(IPcre2 api) {
         var regex = "xyz";
         var input = "hello world";
@@ -1232,7 +1219,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void appendReplacementNoMatch(IPcre2 api) {
         var regex = "\\d+";
         var input = "hello world";
@@ -1245,7 +1232,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void appendReplacementMultipleGroups(IPcre2 api) {
         var regex = "(\\w)(\\w)(\\w)";
         var input = "abc def ghi";
@@ -1266,7 +1253,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void appendReplacementGroupZero(IPcre2 api) {
         var regex = "\\w+";
         var input = "hello world";
@@ -1287,7 +1274,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void appendReplacementUnicode(IPcre2 api) {
         var regex = "🌐";
         var input = "hello 🌐 world 🌐!";
@@ -1312,7 +1299,7 @@ public class MatcherTests {
     // ========================================================================
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void resultsBasic(IPcre2 api) {
         var regex = "\\d+";
         var input = "a1b22c333d";
@@ -1331,7 +1318,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void resultsNoMatches(IPcre2 api) {
         var regex = "xyz";
         var input = "hello world";
@@ -1346,7 +1333,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void resultsSingleMatch(IPcre2 api) {
         var regex = "world";
         var input = "hello world!";
@@ -1364,7 +1351,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void resultsWithGroups(IPcre2 api) {
         var regex = "(\\w)(\\d)";
         var input = "a1 b2 c3";
@@ -1384,7 +1371,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void resultsImmutableSnapshots(IPcre2 api) {
         var regex = "\\w+";
         var input = "one two three";
@@ -1409,7 +1396,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void resultsDoesNotReset(IPcre2 api) {
         var regex = "\\w+";
         var input = "one two three";
@@ -1433,7 +1420,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void resultsZeroWidthMatches(IPcre2 api) {
         var regex = "(?=\\d)";  // Zero-width positive lookahead for digit
         var input = "a1b2c3";
@@ -1453,7 +1440,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void resultsEmptyString(IPcre2 api) {
         var regex = ".*";
         var input = "";
@@ -1467,7 +1454,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void resultsUnicode(IPcre2 api) {
         var regex = "\\p{L}+";
         var input = "hello мир 世界";
@@ -1486,7 +1473,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void resultsStreamOperations(IPcre2 api) {
         var regex = "\\d+";
         var input = "a1b22c333d4444";
@@ -1506,7 +1493,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void resultsCount(IPcre2 api) {
         var regex = "a";
         var input = "abracadabra";
@@ -1525,7 +1512,7 @@ public class MatcherTests {
     // ========================================================================
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hasAnchoringBoundsDefault(IPcre2 api) {
         var regex = "test";
         var input = "test";
@@ -1538,7 +1525,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void useAnchoringBoundsReturnsThis(IPcre2 api) {
         var regex = "test";
         var input = "test";
@@ -1550,7 +1537,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void useAnchoringBoundsFalse(IPcre2 api) {
         var regex = "test";
         var input = "test";
@@ -1565,7 +1552,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void useAnchoringBoundsTrue(IPcre2 api) {
         var regex = "test";
         var input = "test";
@@ -1581,7 +1568,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void anchoringBoundsCaretWithRegion(IPcre2 api) {
         // Test that ^ matches at region start with anchoring bounds enabled (default)
         var regex = "^test";
@@ -1600,7 +1587,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void anchoringBoundsCaretWithRegionDisabled(IPcre2 api) {
         // Test that ^ does NOT match at region start with anchoring bounds disabled
         var regex = "^test";
@@ -1617,7 +1604,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void anchoringBoundsDollarWithRegion(IPcre2 api) {
         // Test that $ matches at region end with anchoring bounds enabled (default)
         var regex = "test$";
@@ -1633,7 +1620,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void anchoringBoundsDollarWithRegionDisabled(IPcre2 api) {
         // Test that $ does NOT match at region end with anchoring bounds disabled
         var regex = "test$";
@@ -1649,7 +1636,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void anchoringBoundsLookingAtWithRegion(IPcre2 api) {
         // Test lookingAt() with ^ pattern in a region
         var regex = "^test";
@@ -1665,7 +1652,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void anchoringBoundsLookingAtWithRegionDisabled(IPcre2 api) {
         // Test lookingAt() with ^ pattern in a region with anchoring bounds disabled
         var regex = "^test";
@@ -1681,7 +1668,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void anchoringBoundsMatchesWithRegion(IPcre2 api) {
         // Test matches() with ^ and $ pattern in a region
         var regex = "^test$";
@@ -1697,7 +1684,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void anchoringBoundsMatchesWithRegionDisabled(IPcre2 api) {
         // Test matches() with ^ and $ pattern in a region with anchoring bounds disabled
         var regex = "^test$";
@@ -1713,7 +1700,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void anchoringBoundsPreservedAfterReset(IPcre2 api) {
         var regex = "test";
         var input = "test";
@@ -1732,7 +1719,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void anchoringBoundsPreservedAfterResetWithInput(IPcre2 api) {
         var regex = "test";
         var input = "test";
@@ -1751,7 +1738,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void anchoringBoundsWithFullInput(IPcre2 api) {
         // When region covers full input, anchoring bounds should have no effect
         var regex = "^test$";
@@ -1771,7 +1758,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void anchoringBoundsWordBoundaryWithRegion(IPcre2 api) {
         // Test that \b (word boundary) behavior with regions
         var regex = "\\bword\\b";
@@ -1787,7 +1774,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void anchoringBoundsWordBoundaryWithRegionDisabled(IPcre2 api) {
         // Test that \b (word boundary) behavior with regions and non-anchoring bounds.
         // Note: In Java, useAnchoringBounds(false) only affects ^ and $.
@@ -1812,7 +1799,7 @@ public class MatcherTests {
     // ========================================================================
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hasTransparentBoundsDefault(IPcre2 api) {
         var regex = "test";
         var input = "test";
@@ -1825,7 +1812,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void useTransparentBoundsReturnsThis(IPcre2 api) {
         var regex = "test";
         var input = "test";
@@ -1837,7 +1824,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void useTransparentBoundsTrue(IPcre2 api) {
         var regex = "test";
         var input = "test";
@@ -1852,7 +1839,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void useTransparentBoundsFalse(IPcre2 api) {
         var regex = "test";
         var input = "test";
@@ -1868,7 +1855,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsLookbehindCanSeeBeforeRegion(IPcre2 api) {
         // Test that lookbehind can see text before region start with transparent bounds enabled
         var regex = "(?<=foo)bar";
@@ -1888,7 +1875,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsLookbehindCannotSeeBeforeRegionWhenOpaque(IPcre2 api) {
         // Test that lookbehind cannot see text before region start with opaque bounds (default)
         var regex = "(?<=foo)bar";
@@ -1908,7 +1895,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsLookaheadCanSeeAfterRegion(IPcre2 api) {
         // Test that lookahead can see text after region end with transparent bounds enabled
         var regex = "bar(?=XXX)";
@@ -1928,7 +1915,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsLookaheadCannotSeeAfterRegionWhenOpaque(IPcre2 api) {
         // Test that lookahead cannot see text after region end with opaque bounds (default)
         var regex = "bar(?=XXX)";
@@ -1948,7 +1935,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsWordBoundaryCanSeeBeforeRegion(IPcre2 api) {
         // Test that \b (word boundary) can see text before region with transparent bounds
         var regex = "\\bword";
@@ -1969,7 +1956,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsWordBoundaryWithOpaqueRegion(IPcre2 api) {
         // Test that \b (word boundary) treats region start as word boundary with opaque bounds
         var regex = "\\bword";
@@ -1990,7 +1977,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsPreservedAfterReset(IPcre2 api) {
         var regex = "test";
         var input = "test";
@@ -2009,7 +1996,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsPreservedAfterResetWithInput(IPcre2 api) {
         var regex = "test";
         var input = "test";
@@ -2028,7 +2015,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsCombinedWithAnchoringBounds(IPcre2 api) {
         // Test that transparent bounds and anchoring bounds can be used together
         var regex = "(?<=foo)^bar$(?=XXX)";
@@ -2051,7 +2038,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsLookingAtWithLookbehind(IPcre2 api) {
         // Test lookingAt() with lookbehind and transparent bounds
         var regex = "(?<=foo)bar";
@@ -2067,7 +2054,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsMatchesWithLookaround(IPcre2 api) {
         // Test matches() with lookaround and transparent bounds
         var regex = "(?<=foo)bar(?=XXX)";
@@ -2083,7 +2070,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsNegativeLookbehind(IPcre2 api) {
         // Test negative lookbehind with transparent bounds
         var regex = "(?<!foo)bar";
@@ -2103,7 +2090,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsNegativeLookahead(IPcre2 api) {
         // Test negative lookahead with transparent bounds
         var regex = "bar(?!XXX)";
@@ -2123,7 +2110,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsWithFind(IPcre2 api) {
         // Test find() with transparent bounds
         var regex = "(?<=\\d)\\w+";
@@ -2144,7 +2131,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsUnicodeWithLookbehind(IPcre2 api) {
         // Test transparent bounds with Unicode and lookbehind
         var regex = "(?<=🌐)test";
@@ -2163,7 +2150,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsWithUsePattern(IPcre2 api) {
         // Test that usePattern() works correctly with transparent bounds
         // This exercises the anchoringBoundsCode = null path in usePattern()
@@ -2190,7 +2177,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsWithCaseInsensitive(IPcre2 api) {
         // Test transparent bounds with CASE_INSENSITIVE flag
         var regex = "(?<=FOO)bar";
@@ -2209,7 +2196,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsWithDotall(IPcre2 api) {
         // Test transparent bounds with DOTALL flag
         var regex = "(?<=foo).";
@@ -2228,7 +2215,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsWithMultiline(IPcre2 api) {
         // Test transparent bounds with MULTILINE flag
         // MULTILINE affects ^ behavior - should still work with transparent bounds
@@ -2247,7 +2234,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsMatchExtendsBeyondRegion(IPcre2 api) {
         // Test where greedy match would extend beyond region - should find shorter match
         var regex = "(?<=foo)\\w+";
@@ -2267,7 +2254,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsNoMatchWhenConstrainedToRegion(IPcre2 api) {
         // Test where match only exists beyond region - should not match
         var regex = "(?<=foo)XXX";
@@ -2286,7 +2273,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsWithAnchoringBoundsAndAnchors(IPcre2 api) {
         // Test transparent + anchoring bounds with ^ and $ in pattern
         var regex = "^bar$";
@@ -2307,7 +2294,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsMatchesConstrainedSubject(IPcre2 api) {
         // Test matches() with transparent bounds where match would extend beyond region
         var regex = "(?<=foo)\\w+(?=YYY)";
@@ -2326,7 +2313,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsWithComments(IPcre2 api) {
         // Test transparent bounds with COMMENTS flag
         var regex = "(?<=foo) bar  # match bar after foo";
@@ -2344,7 +2331,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsWithUnicodeCharacterClass(IPcre2 api) {
         // Test transparent bounds with UNICODE_CHARACTER_CLASS flag
         var regex = "(?<=foo)\\w+";
@@ -2363,7 +2350,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsWithUnixLines(IPcre2 api) {
         // Test transparent bounds with UNIX_LINES flag
         var regex = "(?<=foo)bar";
@@ -2381,7 +2368,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsCachedTransformedPattern(IPcre2 api) {
         // Test that the transformed pattern is cached and reused
         var regex = "^bar$";
@@ -2399,7 +2386,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsNoTransformationNeeded(IPcre2 api) {
         // Test pattern without ^ or $ (no transformation needed)
         var regex = "(?<=foo)bar(?=XXX)";
@@ -2418,7 +2405,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsAnchoringBoundsWithOnlyDollar(IPcre2 api) {
         // Test pattern with only $ (transformation removes $)
         var regex = "(?<=foo)bar$";
@@ -2437,7 +2424,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsAnchoringBoundsWithOnlyCaret(IPcre2 api) {
         // Test pattern with only ^ (transformation replaces ^ with \G)
         var regex = "^bar";
@@ -2456,7 +2443,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsEscapedAnchors(IPcre2 api) {
         // Test that escaped ^ and $ are not transformed
         var regex = "\\^bar\\$";
@@ -2475,7 +2462,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsAnchorsInCharacterClass(IPcre2 api) {
         // Test that ^ and $ inside character classes are not transformed
         var regex = "[^a]ar[$]";
@@ -2493,7 +2480,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsMatchDoesNotEndAtRegionEnd(IPcre2 api) {
         // Test where anchored match doesn't end exactly at regionEnd
         var regex = "^ba$";
@@ -2512,7 +2499,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsMultipleFlagsCombined(IPcre2 api) {
         // Test transparent bounds with multiple flags combined
         var regex = "(?<=FOO) bar  # comment";
@@ -2535,7 +2522,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsConstrainedMatchFailsAdvancesPosition(IPcre2 api) {
         // Test that when a match extends beyond regionEnd and the constrained match fails,
         // the search continues from the next position and eventually finds a valid match.
@@ -2556,7 +2543,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void opaqueBoundsWithRegionStartGreaterThanZero(IPcre2 api) {
         // Test opaque bounds (default) with regionStart > 0 to exercise getRegionSubject() branch
         var regex = "bar";
@@ -2578,7 +2565,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void opaqueBoundsLookbehindBlocked(IPcre2 api) {
         // Test that with opaque bounds (default), lookbehind cannot see before region
         // This uses regionStart > 0 to exercise the substring branch in getRegionSubject()
@@ -2599,7 +2586,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsWithLiteralFlag(IPcre2 api) {
         // Test transparent bounds with LITERAL flag - pattern treated as literal
         var regex = "^ba";  // With LITERAL, ^ and $ are literal characters, not anchors
@@ -2616,7 +2603,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void nonAnchoringBoundsWithMiddleRegion(IPcre2 api) {
         // Test non-anchoring bounds with region in middle of input
         // This exercises getMatchOptions() with both NOTBOL and NOTEOL
@@ -2638,7 +2625,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsSearchStartAdvancesOnConstraintFailure(IPcre2 api) {
         // Test the loop where searchStart advances after constrained match fails
         // Pattern: b+ (greedy) would match multiple b's
@@ -2664,7 +2651,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsAnchoringBoundsWithTransformFailedMatch(IPcre2 api) {
         // Test PATH 1 where transformed pattern matches but doesn't end at regionEnd,
         // then falls through to PATH 2 for normal matching
@@ -2685,7 +2672,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void nonAnchoringBoundsOnlyNotbol(IPcre2 api) {
         // Test non-anchoring bounds with only NOTBOL (regionStart > 0, regionEnd == input.length())
         var regex = "test";
@@ -2704,7 +2691,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void nonAnchoringBoundsOnlyNoteol(IPcre2 api) {
         // Test non-anchoring bounds with only NOTEOL (regionStart == 0, regionEnd < input.length())
         var regex = "test";
@@ -2723,7 +2710,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void opaqueBoundsRegionStartZero(IPcre2 api) {
         // Test opaque bounds with regionStart == 0 to exercise else branch in getRegionSubject()
         var regex = "test";
@@ -2744,7 +2731,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsWithDollarAnchorAtRegionEnd(IPcre2 api) {
         // Test transparent + anchoring bounds with pattern that has $ and match ends at regionEnd
         var regex = "^bar$";
@@ -2765,7 +2752,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsTransformedPatternNoMatch(IPcre2 api) {
         // Test PATH 1 where transformed pattern doesn't match, falls through to PATH 2
         var regex = "^xyz";  // Pattern with ^ that won't match at regionStart
@@ -2784,7 +2771,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsMatchExtendsAndConstrainedFails(IPcre2 api) {
         // Test PATH 3 where match extends beyond regionEnd and constrained match also fails
         // Pattern: "bbb" requires 3 b's, but region only has 2 b's
@@ -2805,7 +2792,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsSearchLoopExhaustsPositions(IPcre2 api) {
         // Test that search loop correctly terminates when all positions exhausted
         var regex = "xyz";  // Pattern that won't match anywhere in region
@@ -2823,7 +2810,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsWithDollarPatternNotEndingAtRegionEnd(IPcre2 api) {
         // Test pattern with $ where the match doesn't end at regionEnd
         // This exercises the path where originalHadDollar is true but lastMatchIndices[1] != regionEnd
@@ -2842,7 +2829,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsPatternWithOnlyDollarAnchor(IPcre2 api) {
         // Test transparent + anchoring bounds with pattern that has only $ (no ^)
         // This exercises patternContainsDollarAnchor returning true for patterns without ^
@@ -2861,7 +2848,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsGreedyQuantifierConstrainedMatch(IPcre2 api) {
         // Test greedy quantifier where transparent bounds sees more but constrained match works
         var regex = "a+";  // Greedy quantifier
@@ -2883,7 +2870,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsWithNestedCharacterClass(IPcre2 api) {
         // Test pattern with POSIX character class (nested brackets) containing $
         // This exercises the charClassDepth tracking in patternContainsDollarAnchor
@@ -2901,7 +2888,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsMatchStartsAfterRegionStart(IPcre2 api) {
         // Test transparent bounds where match doesn't start at regionStart
         // This ensures PATH 1 is skipped when searchStart != regionStart
@@ -2923,7 +2910,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void opaqueBoundsWithIndexAdjustment(IPcre2 api) {
         // Test that index adjustment works correctly for opaque bounds with regionStart > 0
         var regex = "(test)";  // Capturing group
@@ -2948,7 +2935,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsMultipleFinds(IPcre2 api) {
         // Test multiple find() calls with transparent bounds
         var regex = "a";
@@ -2978,7 +2965,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsEmptyRegion(IPcre2 api) {
         // Test transparent bounds with empty region
         var regex = "";  // Empty pattern matches empty string
@@ -2996,7 +2983,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsFullInputRegion(IPcre2 api) {
         // Test transparent bounds when region covers full input
         var regex = "(?<=X)test(?=Y)";
@@ -3015,7 +3002,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsAnchoringWithCaseInsensitiveFlag(IPcre2 api) {
         // Test transparent + anchoring bounds with CASE_INSENSITIVE flag
         // This exercises the CASELESS option in getOrCreateAnchoringBoundsCode()
@@ -3035,7 +3022,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsAnchoringWithDotallFlag(IPcre2 api) {
         // Test transparent + anchoring bounds with DOTALL flag
         // This exercises the DOTALL option in getOrCreateAnchoringBoundsCode()
@@ -3054,7 +3041,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsAnchoringWithUnicodeCharacterClassFlag(IPcre2 api) {
         // Test transparent + anchoring bounds with UNICODE_CHARACTER_CLASS flag
         // This exercises the UCP option in getOrCreateAnchoringBoundsCode()
@@ -3075,7 +3062,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsAnchoringWithCommentsFlag(IPcre2 api) {
         // Test transparent + anchoring bounds with COMMENTS flag
         // This exercises the EXTENDED option in getOrCreateAnchoringBoundsCode()
@@ -3094,7 +3081,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsAnchoringWithUnixLinesFlag(IPcre2 api) {
         // Test transparent + anchoring bounds with UNIX_LINES flag
         // This exercises the LF newline option in getOrCreateAnchoringBoundsCode()
@@ -3113,7 +3100,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsConstrainedMatchFailsAndAdvances(IPcre2 api) {
         // Test PATH 3 where match extends beyond regionEnd, constrained fails, and searchStart advances
         // Pattern "bb" would match at position 3 (matching "bb"), extending to position 5
@@ -3135,7 +3122,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void patternContainsDollarAnchorEscapedDollar(IPcre2 api) {
         // Test patternContainsDollarAnchor with escaped $ (should return false)
         // This exercises the escaped character handling path
@@ -3154,7 +3141,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void patternContainsDollarAnchorInCharClass(IPcre2 api) {
         // Test patternContainsDollarAnchor with $ inside character class (should return false)
         // This exercises the character class depth tracking
@@ -3172,7 +3159,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsLoopAdvancesMultipleTimes(IPcre2 api) {
         // Test that search loop can advance multiple times before finding a match
         // Pattern needs to fail at multiple positions before succeeding
@@ -3196,7 +3183,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void transparentBoundsWithAllFlagsAndAnchors(IPcre2 api) {
         // Test with multiple flags combined plus anchors
         int javaFlags = java.util.regex.Pattern.CASE_INSENSITIVE
@@ -3221,7 +3208,7 @@ public class MatcherTests {
     // hitEnd() and requireEnd() tests
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndBeforeMatchOperation(IPcre2 api) {
         // Before any match operation, hitEnd should return false
         var javaMatcher = java.util.regex.Pattern.compile("test").matcher("testing");
@@ -3232,7 +3219,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void requireEndBeforeMatchOperation(IPcre2 api) {
         // Before any match operation, requireEnd should return false
         var javaMatcher = java.util.regex.Pattern.compile("test").matcher("testing");
@@ -3243,7 +3230,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndAfterPartialMatch(IPcre2 api) {
         // Pattern "AAB" against input "AA" - no full match, but partial match exists
         var javaMatcher = java.util.regex.Pattern.compile("AAB").matcher("AA");
@@ -3258,7 +3245,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndAfterSuccessfulMatchAtEnd(IPcre2 api) {
         // Pattern "test" matches exactly at end of input - hitEnd is false in Java
         // because the literal pattern matched completely
@@ -3273,7 +3260,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndAfterSuccessfulMatchNotAtEnd(IPcre2 api) {
         // Pattern matches but not at the end - hitEnd should be false
         var javaMatcher = java.util.regex.Pattern.compile("test").matcher("test123");
@@ -3287,7 +3274,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndWithNoMatchNoPartial(IPcre2 api) {
         // Pattern cannot possibly match - hitEnd is still true in Java because
         // the search engine had to examine the entire input to determine no match
@@ -3302,7 +3289,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void requireEndWithDollarAnchor(IPcre2 api) {
         // Pattern with $ anchor matching at end - requireEnd should be true
         var javaMatcher = java.util.regex.Pattern.compile("test$").matcher("test");
@@ -3316,7 +3303,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void requireEndWithoutAnchor(IPcre2 api) {
         // Pattern without end anchor - requireEnd should be false even if match at end
         var javaMatcher = java.util.regex.Pattern.compile("test").matcher("test");
@@ -3330,7 +3317,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void requireEndWithBackslashZ(IPcre2 api) {
         // Pattern with \z anchor (absolute end) - requireEnd is FALSE in Java
         // because \z only matches at the absolute end, so more input cannot
@@ -3346,7 +3333,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void requireEndWithBackslashZUppercase(IPcre2 api) {
         // Pattern with \Z anchor (end before final newline) - requireEnd should be true
         var javaMatcher = java.util.regex.Pattern.compile("test\\Z").matcher("test");
@@ -3360,7 +3347,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndWithLookingAt(IPcre2 api) {
         // Test hitEnd with lookingAt
         var javaMatcher = java.util.regex.Pattern.compile("test").matcher("test");
@@ -3373,7 +3360,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndWithMatches(IPcre2 api) {
         // Test hitEnd with matches
         var javaMatcher = java.util.regex.Pattern.compile("test").matcher("test");
@@ -3386,7 +3373,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndPersistsAfterReset(IPcre2 api) {
         // In Java, hitEnd persists after reset() - it is NOT cleared
         var javaMatcher = java.util.regex.Pattern.compile("test$").matcher("test");
@@ -3408,7 +3395,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void requireEndPersistsAfterReset(IPcre2 api) {
         // In Java, requireEnd persists after reset() - it is NOT cleared
         var javaMatcher = java.util.regex.Pattern.compile("test$").matcher("test");
@@ -3430,7 +3417,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndWithGreedyQuantifier(IPcre2 api) {
         // Greedy quantifier at end - hitEnd should be true
         var javaMatcher = java.util.regex.Pattern.compile("a+").matcher("aaa");
@@ -3443,7 +3430,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndWithCharacterClass(IPcre2 api) {
         // Character class at end - hitEnd should be true
         var javaMatcher = java.util.regex.Pattern.compile("[a-z]+").matcher("abc");
@@ -3456,7 +3443,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndWithDot(IPcre2 api) {
         // Dot at end can match more - hitEnd should be true
         var javaMatcher = java.util.regex.Pattern.compile("a.").matcher("ab");
@@ -3469,7 +3456,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndAndRequireEndWithDollarNoMatch(IPcre2 api) {
         // Pattern ends with $ but doesn't match - requireEnd meaningless, hitEnd indicates partial
         var javaMatcher = java.util.regex.Pattern.compile("xyz$").matcher("abc");
@@ -3483,7 +3470,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndWithRegion(IPcre2 api) {
         // Test hitEnd with region
         var javaMatcher = java.util.regex.Pattern.compile("test").matcher("XXtestXX");
@@ -3499,7 +3486,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void requireEndWithDollarInCharacterClass(IPcre2 api) {
         // $ inside character class is literal, not anchor - requireEnd should be false
         var javaMatcher = java.util.regex.Pattern.compile("[$]").matcher("$");
@@ -3513,7 +3500,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndAfterMultipleFinds(IPcre2 api) {
         // Multiple finds - hitEnd should reflect the last find
         var javaMatcher = java.util.regex.Pattern.compile("a").matcher("aXa");
@@ -3537,7 +3524,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndWithCharacterClassNoQuantifier(IPcre2 api) {
         // Character class without quantifier at end - matches exactly one char, hitEnd should be false
         var javaMatcher = java.util.regex.Pattern.compile("[a-z]").matcher("a");
@@ -3551,7 +3538,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndWithWordEscape(IPcre2 api) {
         // \w at end without quantifier - matches exactly one char
         var javaMatcher = java.util.regex.Pattern.compile("\\w").matcher("a");
@@ -3564,7 +3551,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndWithDigitEscape(IPcre2 api) {
         // \d at end without quantifier
         var javaMatcher = java.util.regex.Pattern.compile("\\d").matcher("5");
@@ -3577,7 +3564,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndWithSpaceEscape(IPcre2 api) {
         // \s at end without quantifier
         var javaMatcher = java.util.regex.Pattern.compile("\\s").matcher(" ");
@@ -3590,7 +3577,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndWithLookingAtQuantifier(IPcre2 api) {
         // lookingAt with quantifier at end
         var javaMatcher = java.util.regex.Pattern.compile("a+").matcher("aaa");
@@ -3603,7 +3590,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndWithMatchesQuantifier(IPcre2 api) {
         // matches with quantifier
         var javaMatcher = java.util.regex.Pattern.compile("a+").matcher("aaa");
@@ -3616,7 +3603,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void requireEndWithMatchesDollar(IPcre2 api) {
         // matches() with $ - requireEnd should be true
         var javaMatcher = java.util.regex.Pattern.compile("test$").matcher("test");
@@ -3630,7 +3617,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void requireEndWithLookingAtDollar(IPcre2 api) {
         // lookingAt() with $ - requireEnd should be true when matched at end
         var javaMatcher = java.util.regex.Pattern.compile("test$").matcher("test");
@@ -3643,7 +3630,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void requireEndWithBraceQuantifier(IPcre2 api) {
         // Pattern with {n,} quantifier - hitEnd should be true
         var javaMatcher = java.util.regex.Pattern.compile("a{2,}").matcher("aaa");
@@ -3656,7 +3643,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void hitEndWithMatchNotAtEnd(IPcre2 api) {
         // Match found but not at end of input - hitEnd should be false
         var javaMatcher = java.util.regex.Pattern.compile("test").matcher("testXYZ");
@@ -3672,7 +3659,7 @@ public class MatcherTests {
     // Empty region anchor semantics tests (regression tests for issue #69)
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void emptyRegionAtEndWithAnchors_find(IPcre2 api) {
         // Regression test for issue #69: ^$ pattern should match empty region at end of input
         var regex = "^$";
@@ -3691,7 +3678,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void emptyRegionAtEndWithAnchors_matches(IPcre2 api) {
         // Regression test for issue #69: ^$ pattern should match empty region at end of input
         var regex = "^$";
@@ -3707,7 +3694,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void emptyRegionAtStartWithAnchors_find(IPcre2 api) {
         // Test ^$ pattern with empty region at start of input
         var regex = "^$";
@@ -3723,7 +3710,7 @@ public class MatcherTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void emptyRegionInMiddleWithAnchors_find(IPcre2 api) {
         // Test ^$ pattern with empty region in middle of input
         var regex = "^$";

--- a/regex/src/test/java/org/pcre4j/regex/PatternTests.java
+++ b/regex/src/test/java/org/pcre4j/regex/PatternTests.java
@@ -15,11 +15,8 @@
 package org.pcre4j.regex;
 
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
-
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -28,18 +25,8 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class PatternTests {
 
-    private static final IPcre2 JNA_PCRE2 = new org.pcre4j.jna.Pcre2();
-    private static final IPcre2 FFM_PCRE2 = new org.pcre4j.ffm.Pcre2();
-
-    private static Stream<Arguments> parameters() {
-        return Stream.of(
-                Arguments.of(JNA_PCRE2),
-                Arguments.of(FFM_PCRE2)
-        );
-    }
-
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void namedGroups(IPcre2 api) {
         var regex = "(?<number>42)";
         var javaPattern = java.util.regex.Pattern.compile(regex);
@@ -49,7 +36,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void split(IPcre2 api) {
         var regex = "\\D+";
         var input = "0, 1, 1, 2, 3, 5, 8, ..., 144, ...";
@@ -62,7 +49,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void unicodeSplit(IPcre2 api) {
         var regex = "\\D+";
         var input = "0 ⇾ 1 ⇾ 1 ⇾ 2 ⇾ 3 ⇾ 5 ⇾ 8 ⇾ … ⇾ 144 ⇾ …";
@@ -75,7 +62,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void withoutUnicodeCharacterClass(IPcre2 api) {
         var regex = "\\w";
         var input = "Ǎ";
@@ -86,7 +73,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void withUnicodeCharacterClass(IPcre2 api) {
         var regex = "\\w";
         var input = "Ǎ";
@@ -105,7 +92,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void withoutUnixNewline(IPcre2 api) {
         var regex = "^A$";
         var input = "A\u0085B";
@@ -124,7 +111,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void withUnixNewline(IPcre2 api) {
         var regex = "^A$";
         var input = "A\u0085B";
@@ -144,7 +131,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void quote(IPcre2 api) {
         var input = ".*+?^$|()[]\\{}";
         var inputWithSlashE = "abc\\Edef";
@@ -159,7 +146,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void commentsWhitespaceIgnored(IPcre2 api) {
         // Whitespace in pattern should be ignored with COMMENTS flag
         var regex = "a b c";
@@ -179,7 +166,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void commentsHashComments(IPcre2 api) {
         // Comments starting with # should be ignored until end of line
         var regex = "abc # this is a comment\ndef";
@@ -199,7 +186,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void commentsEscapedWhitespace(IPcre2 api) {
         // Escaped whitespace should be matched literally
         var regex = "a\\ b";
@@ -219,7 +206,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void commentsWhitespaceInCharacterClass(IPcre2 api) {
         // Escaped whitespace inside character class should be matched literally
         // Note: In PCRE2's EXTENDED mode, whitespace inside character classes is preserved,
@@ -242,7 +229,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void commentsEmbeddedFlag(IPcre2 api) {
         // Embedded (?x) flag should enable comments mode
         var regex = "(?x)a b c";
@@ -255,7 +242,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void unicodeCaseFlagValue(IPcre2 api) {
         // Verify UNICODE_CASE flag has the correct value (0x40)
         assertEquals(java.util.regex.Pattern.UNICODE_CASE, Pattern.UNICODE_CASE);
@@ -263,7 +250,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void unicodeCaseKelvinSign(IPcre2 api) {
         // Test Unicode case folding with Kelvin sign (U+212A)
         // In Unicode case folding, Kelvin sign matches k/K
@@ -304,7 +291,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void unicodeCaseLongS(IPcre2 api) {
         // Test Unicode case folding with Long S (U+017F)
         // In Unicode case folding, Long S (ſ) matches s/S
@@ -345,7 +332,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void unicodeCaseWithEmbeddedCaseInsensitiveFlag(IPcre2 api) {
         // Test that embedded (?i) flag with UTF mode provides Unicode case folding
         // In PCRE4J with UTF mode, Unicode case folding is always enabled
@@ -358,7 +345,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void unicodeCaseBasicCaseInsensitive(IPcre2 api) {
         // Test basic case-insensitive matching still works
         var regex = "hello";
@@ -379,7 +366,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void unicodeCaseFlagsMethod(IPcre2 api) {
         // Verify flags() method returns UNICODE_CASE when set
         var regex = "test";
@@ -391,7 +378,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void unicodeCaseAloneHasNoEffect(IPcre2 api) {
         // UNICODE_CASE without CASE_INSENSITIVE should not enable case-insensitive matching
         var regex = "k";
@@ -413,7 +400,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqFlagValue(IPcre2 api) {
         // Verify CANON_EQ flag has the correct value (0x80)
         assertEquals(java.util.regex.Pattern.CANON_EQ, Pattern.CANON_EQ);
@@ -421,7 +408,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqPrecomposedPatternMatchesDecomposedInput(IPcre2 api) {
         // Test canonical equivalence: precomposed pattern matches decomposed input
         // Pattern: é (U+00E9, precomposed)
@@ -444,7 +431,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqDecomposedPatternMatchesPrecomposedInput(IPcre2 api) {
         // Test canonical equivalence: decomposed pattern matches precomposed input
         // Pattern: a + combining ring above (U+0061 U+030A, decomposed)
@@ -467,7 +454,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqWithoutFlagNoMatch(IPcre2 api) {
         // Without CANON_EQ, precomposed and decomposed should NOT match
         var precomposedPattern = "\u00E9";  // é
@@ -481,7 +468,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqFindInMiddleOfString(IPcre2 api) {
         // Test find() with canonical equivalence
         var precomposedPattern = "caf\u00E9";  // café with precomposed é
@@ -504,7 +491,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqReplaceAll(IPcre2 api) {
         // Test replaceAll() with canonical equivalence
         var precomposedPattern = "caf\u00E9";
@@ -526,7 +513,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqReplaceFirst(IPcre2 api) {
         // Test replaceFirst() with canonical equivalence
         var precomposedPattern = "caf\u00E9";
@@ -546,7 +533,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqSplit(IPcre2 api) {
         // Test split() with canonical equivalence
         var precomposedPattern = "\u00E9";  // é
@@ -568,7 +555,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqWithCaseInsensitive(IPcre2 api) {
         // Test CANON_EQ combined with CASE_INSENSITIVE
         var upperPrecomposed = "\u00C9";  // É (uppercase)
@@ -589,7 +576,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqGroupCapture(IPcre2 api) {
         // Test that captured groups return correct text
         var groupPattern = "(caf\u00E9)";  // café in a capture group
@@ -613,7 +600,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqFlagsMethod(IPcre2 api) {
         // Verify flags() method returns CANON_EQ when set
         var regex = "test";
@@ -625,7 +612,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqAlternationPattern(IPcre2 api) {
         // Test CANON_EQ with alternation pattern (instead of character class)
         // Alternation works correctly with NFD normalization
@@ -662,7 +649,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqMultipleCombiningMarks(IPcre2 api) {
         // Test with multiple combining marks
         // ế (U+1EBF) = e with circumflex and acute
@@ -684,7 +671,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqWithRegion(IPcre2 api) {
         // Test CANON_EQ with region (non-zero regionStart)
         var pattern = "caf\u00E9";  // café with precomposed é
@@ -708,7 +695,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqWithRegionFind(IPcre2 api) {
         // Test CANON_EQ with region using find()
         var pattern = "\u00E9";  // é precomposed
@@ -734,7 +721,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqWithTransparentBounds(IPcre2 api) {
         // Test CANON_EQ with transparent bounds
         var pattern = "(?<=a)e\u0301";  // lookbehind for 'a' + decomposed é
@@ -759,7 +746,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqResetWithNewInput(IPcre2 api) {
         // Test that reset(CharSequence) properly reinitializes CANON_EQ support
         var pattern = "\u00E9";  // é precomposed
@@ -784,7 +771,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqMultipleFinds(IPcre2 api) {
         // Test multiple find() calls with CANON_EQ
         var pattern = "\u00E9";  // é
@@ -812,7 +799,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqLookingAt(IPcre2 api) {
         // Test lookingAt() with CANON_EQ
         var pattern = "caf\u00E9";  // café
@@ -834,7 +821,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqAtEndOfString(IPcre2 api) {
         // Test CANON_EQ when match is at end of string
         var pattern = "\u00E9$";  // é at end
@@ -857,7 +844,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqToMatchResult(IPcre2 api) {
         // Test toMatchResult() preserves correct indices with CANON_EQ
         var pattern = "caf\u00E9";
@@ -878,7 +865,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqAppendReplacement(IPcre2 api) {
         // Test appendReplacement with CANON_EQ
         var pattern = "\u00E9";  // é
@@ -900,7 +887,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqWithSurrogatePairs(IPcre2 api) {
         // Test CANON_EQ with surrogate pairs (characters outside BMP)
         // 𝄞 (U+1D11E, Musical Symbol G Clef) - doesn't decompose but tests surrogate handling
@@ -917,7 +904,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void canonEqMixedSurrogatesAndCombining(IPcre2 api) {
         // Test with both surrogate pairs and combining characters
         var pattern = "\uD834\uDD1E\u00E9";  // G clef + é (precomposed)
@@ -938,7 +925,7 @@ public class PatternTests {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void splitAsStream(IPcre2 api) {
         // Test splitAsStream against Java Pattern for multiple inputs and edge cases
         Object[][] cases = new Object[][]{


### PR DESCRIPTION
## Summary
- Add `BackendProvider` test fixture utility in `lib/src/testFixtures` that centralizes reflective backend discovery and JUnit 5 parameterized test argument provisioning
- Replace 12 identical copies of `loadBackend`/`parameters` boilerplate across 9 `lib` test classes and 3 `regex` test classes with references to the shared `BackendProvider#parameters`
- Add `testFixtures(project(":lib"))` dependency to `regex` module

Closes #276

## Test plan
- [x] `lib:compileTestJava` compiles successfully
- [x] `lib:test` passes all tests
- [x] `lib:checkstyleTest` passes
- [x] `regex:compileTestJava` compiles successfully
- [x] `regex:test` passes all tests
- [x] `regex:checkstyleTest` passes
- [x] CI validates full build

🤖 Generated with [Claude Code](https://claude.com/claude-code)