### PR TITLE
(chore) ci: set fail-fast: false in compatibility matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,7 @@ jobs:
     timeout-minutes: 30
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
         java-distribution: ${{ github.event_name == 'pull_request' && fromJson('["temurin"]') || fromJson('["temurin","zulu","adopt-hotspot","adopt-openj9","liberica","microsoft","corretto","semeru","oracle"]') }}


### PR DESCRIPTION
## Summary
- Set `fail-fast: false` in the compatibility matrix strategy so that all matrix combinations run to completion even if one fails, providing full visibility into which combinations pass or fail.

Closes #306

## Test plan
- [ ] CI pipeline runs all matrix jobs to completion regardless of individual failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)