### PR TITLE
(chore) test: add tests for Pcre4jUtils.isVersionAtLeast()

### DIFF
--- a/lib/src/test/java/org/pcre4j/Pcre4jUtilsExtendedTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre4jUtilsExtendedTests.java
@@ -54,18 +54,64 @@ public class Pcre4jUtilsExtendedTests {
 
     @ParameterizedTest
     @MethodSource("org.pcre4j.test.BackendProvider#parameters")
-    void isVersionAtLeast(IPcre2 api) {
-        // PCRE2 10.x should be present
-        assertTrue(Pcre4jUtils.isVersionAtLeast(api, 10, 0));
-        // Version 99.0 should not be reached
-        assertFalse(Pcre4jUtils.isVersionAtLeast(api, 99, 0));
+    void isVersionAtLeastExactVersion(IPcre2 api) {
+        var version = Pcre4jUtils.getVersion(api);
+        var versionPart = version.contains(" ") ? version.substring(0, version.indexOf(' ')) : version;
+        var parts = versionPart.split("\\.");
+        var actualMajor = Integer.parseInt(parts[0]);
+        var actualMinor = Integer.parseInt(parts[1]);
+
+        // Exact version match should return true
+        assertTrue(Pcre4jUtils.isVersionAtLeast(api, actualMajor, actualMinor));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void isVersionAtLeastLowerMajor(IPcre2 api) {
+        var version = Pcre4jUtils.getVersion(api);
+        var versionPart = version.contains(" ") ? version.substring(0, version.indexOf(' ')) : version;
+        var parts = versionPart.split("\\.");
+        var actualMajor = Integer.parseInt(parts[0]);
+
+        // Lower major version should return true
+        assertTrue(Pcre4jUtils.isVersionAtLeast(api, actualMajor - 1, 0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void isVersionAtLeastHigherMajor(IPcre2 api) {
+        var version = Pcre4jUtils.getVersion(api);
+        var versionPart = version.contains(" ") ? version.substring(0, version.indexOf(' ')) : version;
+        var parts = versionPart.split("\\.");
+        var actualMajor = Integer.parseInt(parts[0]);
+
+        // Higher major version should return false
+        assertFalse(Pcre4jUtils.isVersionAtLeast(api, actualMajor + 1, 0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void isVersionAtLeastSameMajorLowerMinor(IPcre2 api) {
+        var version = Pcre4jUtils.getVersion(api);
+        var versionPart = version.contains(" ") ? version.substring(0, version.indexOf(' ')) : version;
+        var parts = versionPart.split("\\.");
+        var actualMajor = Integer.parseInt(parts[0]);
+
+        // Same major, lower minor should return true
+        assertTrue(Pcre4jUtils.isVersionAtLeast(api, actualMajor, 0));
     }
 
     @ParameterizedTest
     @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void isVersionAtLeastSameMajorHigherMinor(IPcre2 api) {
-        // Should handle same major with higher minor correctly
-        assertTrue(Pcre4jUtils.isVersionAtLeast(api, 10, 0));
+        var version = Pcre4jUtils.getVersion(api);
+        var versionPart = version.contains(" ") ? version.substring(0, version.indexOf(' ')) : version;
+        var parts = versionPart.split("\\.");
+        var actualMajor = Integer.parseInt(parts[0]);
+        var actualMinor = Integer.parseInt(parts[1]);
+
+        // Same major, higher minor should return false
+        assertFalse(Pcre4jUtils.isVersionAtLeast(api, actualMajor, actualMinor + 1));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Summary
- Replaces weak `isVersionAtLeast()` tests with comprehensive tests that derive expected values from the actual PCRE2 version at runtime
- Covers all code paths: exact version match, lower/higher major version, same major with lower/higher minor version
- Null API argument validation test retained

## Test plan
- [x] All new tests pass locally (`./gradlew lib:test`)
- [x] Checkstyle passes (`./gradlew lib:checkstyleTest`)
- [ ] CI passes

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)