### PR TITLE
(chore) build: add SHA256 checksum to Gradle wrapper properties

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=b266d5ff6b90eada6dc3b20cb090e3731302e553a27c5d3e4df1f0d76beaff06
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true


### PR DESCRIPTION
## Summary
- Adds `distributionSha256Sum` property to `gradle/wrapper/gradle-wrapper.properties` for Gradle 9.3.1
- This ensures the integrity of the downloaded Gradle distribution is verified against its SHA256 checksum, mitigating supply-chain attacks

Closes #292

## Test plan
- [x] Verified SHA256 checksum matches the official Gradle 9.3.1 binary distribution (`b266d5ff6b90eada6dc3b20cb090e3731302e553a27c5d3e4df1f0d76beaff06`)
- [x] Verified project builds successfully with the checksum in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)