### PR TITLE
(chore) test: add tests for Matcher.toString() and Pattern.toString()

### DIFF
--- a/regex/src/test/java/org/pcre4j/regex/MatcherTests.java
+++ b/regex/src/test/java/org/pcre4j/regex/MatcherTests.java
@@ -3725,4 +3725,48 @@ public class MatcherTests {
         assertEquals(javaMatcher.find(), pcre4jMatcher.find());
     }
 
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void toStringBeforeMatch(IPcre2 api) {
+        var regex = "\\d+";
+        var input = "abc123def";
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        var result = pcre4jMatcher.toString();
+
+        assertTrue(result.startsWith("org.pcre4j.regex.Matcher["));
+        assertTrue(result.contains("pattern=" + regex));
+        assertTrue(result.contains("region=0," + input.length()));
+        assertTrue(result.contains("lastMatchIndices=null"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void toStringAfterMatch(IPcre2 api) {
+        var regex = "\\d+";
+        var input = "abc123def";
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+        pcre4jMatcher.find();
+
+        var result = pcre4jMatcher.toString();
+
+        assertTrue(result.startsWith("org.pcre4j.regex.Matcher["));
+        assertTrue(result.contains("pattern=" + regex));
+        assertTrue(result.contains("region=0," + input.length()));
+        assertTrue(result.contains("lastMatchIndices=[3, 6]"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void toStringWithRegion(IPcre2 api) {
+        var regex = "\\d+";
+        var input = "abc123def";
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+        pcre4jMatcher.region(3, 6);
+
+        var result = pcre4jMatcher.toString();
+
+        assertTrue(result.contains("region=3,6"));
+    }
+
 }

--- a/regex/src/test/java/org/pcre4j/regex/PatternTests.java
+++ b/regex/src/test/java/org/pcre4j/regex/PatternTests.java
@@ -27,6 +27,17 @@ public class PatternTests {
 
     @ParameterizedTest
     @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void toStringReturnsPattern(IPcre2 api) {
+        var regex = "\\d+";
+        var javaPattern = java.util.regex.Pattern.compile(regex);
+        var pcre4jPattern = Pattern.compile(api, regex);
+
+        assertEquals(javaPattern.toString(), pcre4jPattern.toString());
+        assertEquals(regex, pcre4jPattern.toString());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void namedGroups(IPcre2 api) {
         var regex = "(?<number>42)";
         var javaPattern = java.util.regex.Pattern.compile(regex);


### PR DESCRIPTION
## Summary
- Add `Pattern.toString()` test verifying it returns the regex string, matching `java.util.regex.Pattern` behavior
- Add `Matcher.toString()` tests covering: before match (null indices), after match (with indices), and with custom region

Closes #338

## Test plan
- [x] All new tests pass against both JNA and FFM backends
- [x] Checkstyle passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)