### PR TITLE
(chore) test: add assertions to configuration contract test

### DIFF
--- a/lib/src/testFixtures/java/org/pcre4j/test/Pcre2ConfigurationContractTest.java
+++ b/lib/src/testFixtures/java/org/pcre4j/test/Pcre2ConfigurationContractTest.java
@@ -17,6 +17,11 @@ package org.pcre4j.test;
 import org.junit.jupiter.api.Test;
 import org.pcre4j.Pcre4jUtils;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.api.Pcre2UtfWidth;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Contract tests for PCRE2 configuration and version queries.
@@ -33,21 +38,82 @@ public interface Pcre2ConfigurationContractTest<T extends IPcre2> {
     T getApi();
 
     @Test
-    default void config() {
-        var api = getApi();
-        Pcre4jUtils.getVersion(api);
-        Pcre4jUtils.getUnicodeVersion(api);
-        Pcre4jUtils.isUnicodeSupported(api);
-        Pcre4jUtils.getDefaultParenthesesNestingLimit(api);
-        Pcre4jUtils.getDefaultNewline(api);
-        Pcre4jUtils.isBackslashCDisabled(api);
-        Pcre4jUtils.getDefaultMatchLimit(api);
-        Pcre4jUtils.getInternalLinkSize(api);
-        Pcre4jUtils.getJitTarget(api);
-        Pcre4jUtils.isJitSupported(api);
-        Pcre4jUtils.getDefaultHeapLimit(api);
-        Pcre4jUtils.getDefaultDepthLimit(api);
-        Pcre4jUtils.getCompiledWidths(api);
-        Pcre4jUtils.getDefaultBsr(api);
+    default void getVersion() {
+        var version = Pcre4jUtils.getVersion(getApi());
+        assertNotNull(version);
+        assertFalse(version.isEmpty(), "version must not be empty");
+        assertTrue(version.matches("\\d+\\.\\d+.*"), "version must match 'major.minor...' format: " + version);
+    }
+
+    @Test
+    default void getUnicodeVersion() {
+        var unicodeVersion = Pcre4jUtils.getUnicodeVersion(getApi());
+        assertNotNull(unicodeVersion);
+        assertFalse(unicodeVersion.isEmpty(), "unicode version must not be empty");
+        assertTrue(
+                unicodeVersion.matches("\\d+\\.\\d+\\.\\d+"),
+                "unicode version must match 'major.minor.patch' format: " + unicodeVersion
+        );
+    }
+
+    @Test
+    default void getDefaultParenthesesNestingLimit() {
+        var limit = Pcre4jUtils.getDefaultParenthesesNestingLimit(getApi());
+        assertTrue(limit > 0, "parentheses nesting limit must be positive: " + limit);
+    }
+
+    @Test
+    default void getDefaultNewline() {
+        var newline = Pcre4jUtils.getDefaultNewline(getApi());
+        assertNotNull(newline);
+    }
+
+    @Test
+    default void getDefaultMatchLimit() {
+        var limit = Pcre4jUtils.getDefaultMatchLimit(getApi());
+        assertTrue(limit > 0, "match limit must be positive: " + limit);
+    }
+
+    @Test
+    default void getInternalLinkSize() {
+        var linkSize = Pcre4jUtils.getInternalLinkSize(getApi());
+        assertTrue(
+                linkSize == 2 || linkSize == 3 || linkSize == 4,
+                "internal link size must be 2, 3, or 4: " + linkSize
+        );
+    }
+
+    @Test
+    default void getJitTarget() {
+        var jitTarget = Pcre4jUtils.getJitTarget(getApi());
+        if (jitTarget != null) {
+            assertFalse(jitTarget.isEmpty(), "JIT target must not be empty when present");
+        }
+    }
+
+    @Test
+    default void getDefaultHeapLimit() {
+        var limit = Pcre4jUtils.getDefaultHeapLimit(getApi());
+        assertTrue(limit >= 0, "heap limit must be non-negative: " + limit);
+    }
+
+    @Test
+    default void getDefaultDepthLimit() {
+        var limit = Pcre4jUtils.getDefaultDepthLimit(getApi());
+        assertTrue(limit > 0, "depth limit must be positive: " + limit);
+    }
+
+    @Test
+    default void getCompiledWidths() {
+        var widths = Pcre4jUtils.getCompiledWidths(getApi());
+        assertNotNull(widths);
+        assertFalse(widths.isEmpty(), "compiled widths must not be empty");
+        assertTrue(widths.contains(Pcre2UtfWidth.UTF8), "compiled widths must include UTF-8");
+    }
+
+    @Test
+    default void getDefaultBsr() {
+        var bsr = Pcre4jUtils.getDefaultBsr(getApi());
+        assertNotNull(bsr);
     }
 }


### PR DESCRIPTION
## Summary
- Split the single `config()` test into individual focused test methods, each verifying one PCRE2 configuration query
- Add contract-based assertions that validate return values are sensible (format, range, non-null) without depending on specific PCRE2 build configuration
- Removed `isUnicodeSupported()` and `isBackslashCDisabled()` standalone tests as boolean returns are inherently valid; `isJitSupported()` kept implicitly via `getJitTarget()` null-vs-non-empty logic

Fixes #283

## Test plan
- [x] `jna:test` passes — configuration contract tests run through JNA backend
- [x] `ffm:test` passes — configuration contract tests run through FFM backend
- [x] `lib:checkstyleTestFixtures` passes — code style compliant

🤖 Generated with [Claude Code](https://claude.com/claude-code)