### PR TITLE
(fix) build: replace hardcoded ':' with File.pathSeparator for Windows support

### DIFF
--- a/ffm/build.gradle.kts
+++ b/ffm/build.gradle.kts
@@ -127,7 +127,7 @@ tasks.test {
         "java.library.path", listOf(
             providers.systemProperty("pcre2.library.path").orNull,
             providers.systemProperty("java.library.path").orNull
-        ).joinToString(":")
+        ).joinToString(File.pathSeparator)
     )
 
     val pcre2LibraryName = providers.systemProperty("pcre2.library.name").orNull
@@ -206,7 +206,7 @@ val testJava22 by tasks.registering(Test::class) {
         "java.library.path", listOf(
             providers.systemProperty("pcre2.library.path").orNull,
             providers.systemProperty("java.library.path").orNull
-        ).joinToString(":")
+        ).joinToString(File.pathSeparator)
     )
 
     val pcre2LibraryName = providers.systemProperty("pcre2.library.name").orNull

--- a/jna/build.gradle.kts
+++ b/jna/build.gradle.kts
@@ -65,7 +65,7 @@ tasks.withType<Test> {
         "jna.library.path", listOf(
             providers.systemProperty("pcre2.library.path").orNull,
             providers.systemProperty("jna.library.path").orNull
-        ).joinToString(":")
+        ).joinToString(File.pathSeparator)
     )
 
     val pcre2LibraryName = providers.systemProperty("pcre2.library.name").orNull

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -68,14 +68,14 @@ tasks.test {
         "jna.library.path", listOf(
             providers.systemProperty("pcre2.library.path").orNull,
             providers.systemProperty("jna.library.path").orNull
-        ).joinToString(":")
+        ).joinToString(File.pathSeparator)
     )
 
     systemProperty(
         "java.library.path", listOf(
             providers.systemProperty("pcre2.library.path").orNull,
             providers.systemProperty("java.library.path").orNull
-        ).joinToString(":")
+        ).joinToString(File.pathSeparator)
     )
 
     val pcre2LibraryName = providers.systemProperty("pcre2.library.name").orNull

--- a/regex/build.gradle.kts
+++ b/regex/build.gradle.kts
@@ -67,14 +67,14 @@ tasks.test {
         "jna.library.path", listOf(
             providers.systemProperty("pcre2.library.path").orNull,
             providers.systemProperty("jna.library.path").orNull
-        ).joinToString(":")
+        ).joinToString(File.pathSeparator)
     )
 
     systemProperty(
         "java.library.path", listOf(
             providers.systemProperty("pcre2.library.path").orNull,
             providers.systemProperty("java.library.path").orNull
-        ).joinToString(":")
+        ).joinToString(File.pathSeparator)
     )
 
     val pcre2LibraryName = providers.systemProperty("pcre2.library.name").orNull


### PR DESCRIPTION
## Summary
- Replace hardcoded `":"` path separator with `File.pathSeparator` in all module `build.gradle.kts` files for cross-platform compatibility
- Affects `jna.library.path` and `java.library.path` system property construction in test tasks across `lib`, `jna`, `ffm`, and `regex` modules (7 instances total)
- On Windows, the path separator is `;` not `:`, so hardcoded `":"` would break native library discovery during tests

## Test plan
- [x] Verified all 7 instances replaced across 4 build files
- [x] Full build passes (excluding pre-existing regex test failures on main)
- [ ] CI validates cross-platform build

Fixes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)