### PR TITLE
(chore) lib: make setCompileExtraOptions use EnumSet consistently

### DIFF
--- a/lib/src/main/java/org/pcre4j/Pcre2CompileContext.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2CompileContext.java
@@ -17,6 +17,7 @@ package org.pcre4j;
 import org.pcre4j.api.IPcre2;
 
 import java.lang.ref.Cleaner;
+import java.util.EnumSet;
 
 public class Pcre2CompileContext {
 
@@ -170,17 +171,14 @@ public class Pcre2CompileContext {
      *
      * @param extraOptions the extra compile options to set
      */
-    public void setCompileExtraOptions(Pcre2CompileExtraOption... extraOptions) {
+    public void setCompileExtraOptions(EnumSet<Pcre2CompileExtraOption> extraOptions) {
         if (extraOptions == null) {
             throw new IllegalArgumentException("extraOptions cannot be null");
         }
-        var extraOptionsValue = 0;
-        for (var extraOption : extraOptions) {
-            if (extraOption == null) {
-                throw new IllegalArgumentException("extraOptions cannot contain null");
-            }
-            extraOptionsValue |= extraOption.value();
-        }
+        final var extraOptionsValue = extraOptions
+                .stream()
+                .mapToInt(Pcre2CompileExtraOption::value)
+                .sum();
         final var result = api.setCompileExtraOptions(handle, extraOptionsValue);
         if (result != 0) {
             final var errorMessage = Pcre4jUtils.getErrorMessage(api, result);

--- a/lib/src/main/java/org/pcre4j/Pcre2CompileExtraOption.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2CompileExtraOption.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 /**
  * Extra compile options for PCRE2 patterns.
  * <p>
- * These options are set via {@link Pcre2CompileContext#setCompileExtraOptions(Pcre2CompileExtraOption...)} and provide
+ * These options are set via {@link Pcre2CompileContext#setCompileExtraOptions(java.util.EnumSet)} and provide
  * additional control over pattern compilation beyond the standard compile options.
  */
 public enum Pcre2CompileExtraOption {

--- a/lib/src/test/java/org/pcre4j/Pcre2ContextTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2ContextTests.java
@@ -122,7 +122,8 @@ public class Pcre2ContextTests {
     @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void compileContextSetCompileExtraOptions(IPcre2 api) {
         var ctx = new Pcre2CompileContext(api, null);
-        assertDoesNotThrow(() -> ctx.setCompileExtraOptions(Pcre2CompileExtraOption.BAD_ESCAPE_IS_LITERAL));
+        assertDoesNotThrow(() ->
+                ctx.setCompileExtraOptions(EnumSet.of(Pcre2CompileExtraOption.BAD_ESCAPE_IS_LITERAL)));
     }
 
     @ParameterizedTest
@@ -130,15 +131,7 @@ public class Pcre2ContextTests {
     void compileContextSetCompileExtraOptionsNullThrows(IPcre2 api) {
         var ctx = new Pcre2CompileContext(api, null);
         assertThrows(IllegalArgumentException.class, () ->
-                ctx.setCompileExtraOptions((Pcre2CompileExtraOption[]) null));
-    }
-
-    @ParameterizedTest
-    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
-    void compileContextSetCompileExtraOptionsNullElementThrows(IPcre2 api) {
-        var ctx = new Pcre2CompileContext(api, null);
-        assertThrows(IllegalArgumentException.class, () ->
-                ctx.setCompileExtraOptions(Pcre2CompileExtraOption.BAD_ESCAPE_IS_LITERAL, null));
+                ctx.setCompileExtraOptions(null));
     }
 
     @ParameterizedTest

--- a/lib/src/testFixtures/java/org/pcre4j/test/Pcre2CompileContextContractTest.java
+++ b/lib/src/testFixtures/java/org/pcre4j/test/Pcre2CompileContextContractTest.java
@@ -287,21 +287,14 @@ public interface Pcre2CompileContextContractTest<T extends IPcre2> {
     default void setCompileExtraOptionsNullThrows() {
         final var compileContext = new Pcre2CompileContext(getApi(), null);
         assertThrows(IllegalArgumentException.class,
-                () -> compileContext.setCompileExtraOptions((Pcre2CompileExtraOption[]) null));
-    }
-
-    @Test
-    default void setCompileExtraOptionsNullElementThrows() {
-        final var compileContext = new Pcre2CompileContext(getApi(), null);
-        assertThrows(IllegalArgumentException.class,
-                () -> compileContext.setCompileExtraOptions(Pcre2CompileExtraOption.MATCH_WORD, null));
+                () -> compileContext.setCompileExtraOptions(null));
     }
 
     @Test
     default void setCompileExtraOptionsEmpty() {
         final var compileContext = new Pcre2CompileContext(getApi(), null);
-        // Should not throw with empty varargs
-        compileContext.setCompileExtraOptions();
+        // Should not throw with empty EnumSet
+        compileContext.setCompileExtraOptions(EnumSet.noneOf(Pcre2CompileExtraOption.class));
 
         // Pattern should still compile and match
         final var code = new Pcre2Code(
@@ -332,7 +325,7 @@ public interface Pcre2CompileContextContractTest<T extends IPcre2> {
                 "Skipping test: ASCII_BSD requires PCRE2 10.43+");
 
         final var compileContext = new Pcre2CompileContext(api, null);
-        compileContext.setCompileExtraOptions(Pcre2CompileExtraOption.ASCII_BSD);
+        compileContext.setCompileExtraOptions(EnumSet.of(Pcre2CompileExtraOption.ASCII_BSD));
 
         // With ASCII_BSD, \d should only match ASCII digits even with UCP+UTF
         final var code = new Pcre2Code(
@@ -368,7 +361,7 @@ public interface Pcre2CompileContextContractTest<T extends IPcre2> {
     @Test
     default void setCompileExtraOptionsMatchWord() {
         final var compileContext = new Pcre2CompileContext(getApi(), null);
-        compileContext.setCompileExtraOptions(Pcre2CompileExtraOption.MATCH_WORD);
+        compileContext.setCompileExtraOptions(EnumSet.of(Pcre2CompileExtraOption.MATCH_WORD));
 
         // With MATCH_WORD, pattern should only match whole words
         final var code = new Pcre2Code(
@@ -404,7 +397,7 @@ public interface Pcre2CompileContextContractTest<T extends IPcre2> {
     @Test
     default void setCompileExtraOptionsMatchLine() {
         final var compileContext = new Pcre2CompileContext(getApi(), null);
-        compileContext.setCompileExtraOptions(Pcre2CompileExtraOption.MATCH_LINE);
+        compileContext.setCompileExtraOptions(EnumSet.of(Pcre2CompileExtraOption.MATCH_LINE));
 
         // With MATCH_LINE, pattern should only match whole lines
         final var code = new Pcre2Code(
@@ -446,11 +439,11 @@ public interface Pcre2CompileContextContractTest<T extends IPcre2> {
 
         final var compileContext = new Pcre2CompileContext(api, null);
         // Set multiple extra options at once
-        compileContext.setCompileExtraOptions(
+        compileContext.setCompileExtraOptions(EnumSet.of(
                 Pcre2CompileExtraOption.ASCII_BSD,
                 Pcre2CompileExtraOption.ASCII_BSS,
                 Pcre2CompileExtraOption.ASCII_BSW
-        );
+        ));
 
         // With all ASCII options, \w should only match ASCII word characters even with UCP+UTF
         final var code = new Pcre2Code(


### PR DESCRIPTION
## Summary
- Change `Pcre2CompileContext.setCompileExtraOptions()` from varargs (`Pcre2CompileExtraOption...`) to `EnumSet<Pcre2CompileExtraOption>` to be consistent with all other option-accepting methods in the codebase (`match()`, `substitute()`, `Pcre2Code` constructors, etc.)
- Remove the now-unnecessary null-element check test (EnumSet cannot contain null by design)
- Update all test call sites to use `EnumSet.of()` / `EnumSet.noneOf()`

Closes #310

## Test plan
- [x] All `lib`, `jna`, and `ffm` module tests pass
- [x] Checkstyle passes
- [x] Contract tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)