### PR TITLE
(chore) test: add positive tests for pattern embedded limit retrieval

### DIFF
--- a/lib/src/test/java/org/pcre4j/Pcre2CodePatternInfoTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodePatternInfoTests.java
@@ -308,6 +308,33 @@ public class Pcre2CodePatternInfoTests {
         assertTrue(foundSecond, "Name table should contain 'second' mapped to group 2");
     }
 
+    // --- matchLimit ---
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void matchLimitFromPattern(IPcre2 api) {
+        var code = new Pcre2Code(api, "(*LIMIT_MATCH=5000)test");
+        assertEquals(5000, code.matchLimit());
+    }
+
+    // --- depthLimit ---
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void depthLimitFromPattern(IPcre2 api) {
+        var code = new Pcre2Code(api, "(*LIMIT_DEPTH=3000)test");
+        assertEquals(3000, code.depthLimit());
+    }
+
+    // --- heapLimit ---
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void heapLimitFromPattern(IPcre2 api) {
+        var code = new Pcre2Code(api, "(*LIMIT_HEAP=8000)test");
+        assertEquals(8000, code.heapLimit());
+    }
+
     // --- size ---
 
     @ParameterizedTest


### PR DESCRIPTION
## Summary
* Add positive tests for `matchLimit()`, `depthLimit()`, and `heapLimit()` pattern info methods in `Pcre2CodePatternInfoTests`
* Tests verify that embedded limits (`(*LIMIT_MATCH=N)`, `(*LIMIT_DEPTH=N)`, `(*LIMIT_HEAP=N)`) are correctly retrievable from compiled patterns

## Test plan
- [x] New tests pass locally against both JNA and FFM backends
- [x] Checkstyle passes
- [ ] CI passes

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)