### PR TITLE
(chore) ci: configure Dependabot commit message prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "(chore) deps:"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "(chore) ci:"


### PR DESCRIPTION
## Summary
* Configure Dependabot commit message prefixes to match the project's `(type) scope:` convention
* Gradle dependency updates use `(chore) deps:` prefix
* GitHub Actions updates use `(chore) ci:` prefix

Fixes #325

## Test plan
- [ ] Verify Dependabot YAML is valid
- [ ] Next Dependabot PR should use the configured prefix format

🤖 Generated with [Claude Code](https://claude.com/claude-code)