### PR TITLE
(chore) repo: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for the entire repository
+* @alexey-pelykh


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` file assigning `@alexey-pelykh` as default owner for the entire repository
- Ensures automatic review requests on pull requests

Closes #322

## Test plan
- [ ] Verify CODEOWNERS syntax is valid (GitHub will show warnings on PR if not)
- [ ] Verify PR auto-assigns reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)