### PR TITLE
(docs) readme: simplify java.util.regex compatibility tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,86 +183,21 @@ See the exposed PCRE2 API functions list [here](./PCRE2_API.md).
 ## `java.util.regex` API Compatibility
 
 The `regex` module provides a complete implementation of the `java.util.regex` API backed by PCRE2.
-
-### `Pattern`
-
-| Method | Supported |
-|--------|-----------|
-| `compile(String)` | ✅ |
-| `compile(String, int)` | ✅ |
-| `matches(String, CharSequence)` | ✅ |
-| `quote(String)` | ✅ |
-| `asPredicate()` | ✅ |
-| `asMatchPredicate()` | ✅ |
-| `flags()` | ✅ |
-| `matcher(CharSequence)` | ✅ |
-| `namedGroups()` | ✅ |
-| `pattern()` | ✅ |
-| `split(CharSequence)` | ✅ |
-| `split(CharSequence, int)` | ✅ |
-| `splitAsStream(CharSequence)` | ✅ |
-| `splitWithDelimiters(CharSequence, int)` | ✅ |
-| `toString()` | ✅ |
+All `Pattern` and `Matcher` methods are supported.
 
 ### `Pattern` Flags
 
-| Flag | Supported | Notes |
-|------|-----------|-------|
-| `CASE_INSENSITIVE` | ✅ | Via `PCRE2_CASELESS` |
-| `COMMENTS` | ✅ | Via `PCRE2_EXTENDED` |
-| `DOTALL` | ✅ | Via `PCRE2_DOTALL` |
-| `LITERAL` | ✅ | Via `PCRE2_LITERAL` |
-| `MULTILINE` | ✅ | Via `PCRE2_MULTILINE` |
-| `UNICODE_CHARACTER_CLASS` | ✅ | Via `PCRE2_UCP` |
-| `UNICODE_CASE` | ✅ | PCRE2 with UTF mode already performs Unicode-aware case folding |
-| `UNIX_LINES` | ✅ | Via `PCRE2_NEWLINE_LF` |
-| `CANON_EQ` | ✅ | Via NFD normalization; see `Pattern.CANON_EQ` Javadoc for limitations |
-
-### `Matcher`
-
-| Method | Supported |
-|--------|-----------|
-| `appendReplacement(StringBuffer, String)` | ✅ |
-| `appendReplacement(StringBuilder, String)` | ✅ |
-| `appendTail(StringBuffer)` | ✅ |
-| `appendTail(StringBuilder)` | ✅ |
-| `end()` | ✅ |
-| `end(int)` | ✅ |
-| `end(String)` | ✅ |
-| `find()` | ✅ |
-| `find(int)` | ✅ |
-| `group()` | ✅ |
-| `group(int)` | ✅ |
-| `group(String)` | ✅ |
-| `groupCount()` | ✅ |
-| `hasAnchoringBounds()` | ✅ |
-| `hasMatch()` | ✅ |
-| `hasTransparentBounds()` | ✅ |
-| `hitEnd()` | ✅ |
-| `lookingAt()` | ✅ |
-| `matches()` | ✅ |
-| `namedGroups()` | ✅ |
-| `pattern()` | ✅ |
-| `quoteReplacement(String)` | ✅ |
-| `region(int, int)` | ✅ |
-| `regionEnd()` | ✅ |
-| `regionStart()` | ✅ |
-| `replaceAll(String)` | ✅ |
-| `replaceAll(Function)` | ✅ |
-| `replaceFirst(String)` | ✅ |
-| `replaceFirst(Function)` | ✅ |
-| `requireEnd()` | ✅ |
-| `reset()` | ✅ |
-| `reset(CharSequence)` | ✅ |
-| `results()` | ✅ |
-| `start()` | ✅ |
-| `start(int)` | ✅ |
-| `start(String)` | ✅ |
-| `toMatchResult()` | ✅ |
-| `toString()` | ✅ |
-| `useAnchoringBounds(boolean)` | ✅ |
-| `usePattern(Pattern)` | ✅ |
-| `useTransparentBounds(boolean)` | ✅ |
+| Flag | PCRE2 Mapping | Notes |
+|------|---------------|-------|
+| `CASE_INSENSITIVE` | `PCRE2_CASELESS` | |
+| `COMMENTS` | `PCRE2_EXTENDED` | |
+| `DOTALL` | `PCRE2_DOTALL` | |
+| `LITERAL` | `PCRE2_LITERAL` | |
+| `MULTILINE` | `PCRE2_MULTILINE` | |
+| `UNICODE_CHARACTER_CLASS` | `PCRE2_UCP` | |
+| `UNICODE_CASE` | — | PCRE2 with UTF mode already performs Unicode-aware case folding |
+| `UNIX_LINES` | `PCRE2_NEWLINE_LF` | |
+| `CANON_EQ` | — | Via NFD normalization; see `Pattern.CANON_EQ` Javadoc for limitations |
 
 ## Security: ReDoS Protection
 


### PR DESCRIPTION
## Summary
- Replace verbose all-checkmark `Pattern` and `Matcher` method tables with a concise statement that all methods are supported
- Retain the `Pattern` Flags table with a renamed "PCRE2 Mapping" column for its reference value, using "—" for flags without direct PCRE2 equivalents
- Net reduction of 65 lines from the README

Closes #321

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm no information loss (all flags and notes preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)