### PR TITLE
(chore) build: use Gradle -all distribution for IDE support

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=b266d5ff6b90eada6dc3b20cb090e3731302e553a27c5d3e4df1f0d76beaff06
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionSha256Sum=17f277867f6914d61b1aa02efab1ba7bb439ad652ca485cd8ca6842fccec6e43
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Switch Gradle wrapper from `-bin` to `-all` distribution to include Gradle source code
- Update SHA-256 checksum for the `-all` distribution
- The `-all` distribution enables better IDE support (source navigation, code completion for Gradle APIs)

Closes #328

## Test plan
- [ ] CI passes (Gradle wrapper validation, build, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)