### PR TITLE
(docs) docs: surface DCO requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,12 @@ The `ffm` module is packaged as a Multi-Release JAR supporting both:
 
 > **Note:** Automatic library discovery can be disabled by setting `-Dpcre2.library.discovery=false`.
 
+## Contributing
+
+Contributions are welcome! Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
+
+All commits must be signed off to certify the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). Use `git commit -s` to add the required `Signed-off-by` line.
+
 ## Javadoc
 
 Please see [the Javadoc Index](https://alexey-pelykh.com/pcre4j/javadoc/) for the detailed API documentation.


### PR DESCRIPTION
## Summary
* Add a "Contributing" section to README.md that surfaces the DCO sign-off requirement and links to CONTRIBUTING.md for full guidelines

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify links to CONTRIBUTING.md and developercertificate.org resolve

Fixes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)