### PR TITLE
(chore) build: document --enable-preview flag application pattern

### DIFF
--- a/ffm/build.gradle.kts
+++ b/ffm/build.gradle.kts
@@ -67,6 +67,14 @@ dependencies {
 // ============================================================
 // Java version configuration - Java 21 as base (with preview)
 // ============================================================
+// The Foreign Function & Memory (FFM) API was a preview feature in Java 21
+// and became GA in Java 22. Since this module targets Java 21 as the base,
+// --enable-preview is required for:
+//   - compileJava / compileTestJava: compiler must accept preview API usage
+//   - test JVM args: runtime must enable preview features
+//   - javadoc: must recognize preview API references
+// The java22 source set targets Java 22+ where FFM is GA, so no preview
+// flag is needed there.
 java {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -60,6 +60,11 @@ java {
     withJavadocJar()
 }
 
+// --enable-preview on test tasks only: lib's own code does not use preview
+// features, but tests load the FFM backend (which uses the preview FFM API
+// on Java 21) at runtime. The flag is needed for:
+//   - compileTestJava: test code may reference FFM-backed types
+//   - test JVM args: JVM must enable preview features for FFM backend loading
 tasks.test {
     useJUnitPlatform()
     jvmArgs("--enable-preview")

--- a/regex/build.gradle.kts
+++ b/regex/build.gradle.kts
@@ -59,6 +59,11 @@ java {
     withJavadocJar()
 }
 
+// --enable-preview on test tasks only: regex's own code does not use preview
+// features, but tests load the FFM backend (which uses the preview FFM API
+// on Java 21) at runtime. The flag is needed for:
+//   - compileTestJava: test code may reference FFM-backed types
+//   - test JVM args: JVM must enable preview features for FFM backend loading
 tasks.test {
     useJUnitPlatform()
     jvmArgs("--enable-preview")


### PR DESCRIPTION
## Summary
* Add explanatory comments to `ffm/build.gradle.kts` documenting why `--enable-preview` is required on compile, test, and javadoc tasks (FFM API was preview in Java 21, GA in Java 22)
* Add explanatory comments to `lib/build.gradle.kts` and `regex/build.gradle.kts` documenting why `--enable-preview` is needed on test tasks only (tests load the FFM backend at runtime)

Closes #356

## Test plan
- [ ] Verify build succeeds (comments only, no behavioral changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)