### PR TITLE
(chore) build: standardize test task configuration style

### DIFF
--- a/jna/build.gradle.kts
+++ b/jna/build.gradle.kts
@@ -58,7 +58,7 @@ java {
     withJavadocJar()
 }
 
-tasks.withType<Test> {
+tasks.test {
     useJUnitPlatform()
 
     systemProperty(


### PR DESCRIPTION
## Summary

* Standardize `jna` module test task configuration from `tasks.withType<Test>` to `tasks.test` for consistency with all other modules (`api`, `lib`, `ffm`, `regex`)

Fixes #341

## Test plan

- [ ] CI build passes (no behavior change — `jna` has only the standard `test` task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)