### PR TITLE
(docs) readme: add Prerequisites section

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ upstream dependencies as transitive, so your dependency manager pulls them autom
 A backend (`jna` or `ffm`) is always required at runtime but is intentionally not a transitive
 dependency of `regex` or `lib`, letting consumers choose which native access mechanism to use.
 
+## Prerequisites
+
+- **Java 21 or later**
+- **PCRE2 native library** installed on your system:
+  - **Ubuntu/Debian**: `sudo apt install libpcre2-8-0`
+  - **macOS** (Homebrew): `brew install pcre2`
+  - **Windows**: Download the PCRE2 DLL and add its location to `PATH`
+
+The library is located automatically via `pcre2-config`, `pkg-config`, or well-known platform
+paths. You can also set the path explicitly with `-Dpcre2.library.path=/path/to/lib`.
+
 ## Usage
 
 The PCRE4J library provides several APIs to interact with the PCRE library:


### PR DESCRIPTION
## Summary
- Add a Prerequisites section to README.md listing Java 21+ and PCRE2 native library requirements
- Include platform-specific PCRE2 installation instructions (Ubuntu/Debian, macOS, Windows)
- Note automatic library discovery and explicit path configuration

Closes #311

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm installation commands are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)