### PR TITLE
(chore) ci: extract Checkstyle to separate lint job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,39 @@ jobs:
 
           echo "All commits have valid DCO sign-off."
 
+  lint:
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4
+
+      - name: Set up temurin-jdk-21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Cache Gradle packages
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-${{ runner.os }}
+
+      - name: Checkstyle
+        run: ./gradlew checkstyleMain checkstyleTest
+
   compatibility:
     permissions:
       contents: read
@@ -181,6 +214,7 @@ jobs:
     timeout-minutes: 30
 
     needs:
+      - lint
       - compatibility-all
 
     env:
@@ -217,9 +251,6 @@ jobs:
             ~/.gradle/wrapper
           key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: gradle-${{ runner.os }}
-
-      - name: Checkstyle
-        run: ./gradlew checkstyleMain checkstyleTest
 
       - name: Build PCRE2
         uses: ./.github/actions/build-pcre2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Use the [feature request template](https://github.com/alexey-pelykh/pcre4j/issue
 
 The `main` branch has the following protection rules:
 
-- **Required status checks**: The `package` CI job must pass before merging (this transitively requires all `compatibility` matrix jobs to pass as well)
+- **Required status checks**: The `package` CI job must pass before merging (this transitively requires `lint` and all `compatibility` matrix jobs to pass as well)
 - **Branch must be up to date**: PRs must be up to date with `main` before merging
 - **Required reviews**: At least 1 approving review is required
 - **Stale review dismissal**: Approvals are dismissed when new commits are pushed


### PR DESCRIPTION
## Summary
- Extract Checkstyle from the `package` job into a dedicated `lint` job that runs in parallel with `compatibility` tests
- The `package` job now depends on both `lint` and `compatibility-all`, preserving the transitive gate
- Provides faster lint feedback without waiting for the full test matrix to complete

Closes #300

## Test plan
- [ ] Verify `lint` job runs successfully in CI
- [ ] Verify `package` job still depends on `lint` (fails if lint fails)
- [ ] Verify `compatibility` and `lint` run in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)