### PR TITLE
(chore) docs: reduce hardcoded version strings in README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,6 @@ gh release create <version> --title <version> --generate-notes
 1. Update `CHANGELOG.md`: move Unreleased items into a new version section with the release date
 2. `gh release create <version> --title <version> --generate-notes` creates tag + GitHub Release (using tag as title)
 3. Tag push triggers `.github/workflows/release.yaml` for Maven Central publish via JReleaser
-4. Update README.md version references, commit, push
 
 **Note**: `skipRelease: true` in jreleaser.yml exists because the GitHub Release is already created by `gh release create` before JReleaser runs.
 

--- a/README.md
+++ b/README.md
@@ -59,21 +59,26 @@ The PCRE4J library provides several APIs to interact with the PCRE library:
 
 ### Quick Start with `java.util.regex`-compatible API
 
-Add the following dependencies to your `pom.xml` file:
+Add the following dependencies to your `pom.xml` file (replace `${pcre4j.version}` with the
+[latest release version](https://mvnrepository.com/artifact/org.pcre4j/lib)):
 
 ```xml
+<properties>
+    <pcre4j.version><!-- latest version --></pcre4j.version>
+</properties>
+
 <dependencies>
     <dependency>
         <groupId>org.pcre4j</groupId>
         <artifactId>regex</artifactId>
-        <version>0.7.0</version>
+        <version>${pcre4j.version}</version>
     </dependency>
     <dependency>
         <groupId>org.pcre4j</groupId>
         <!-- TODO: Select one of the following artifacts corresponding to the backend you want to use -->
         <artifactId>jna</artifactId>
         <!-- <artifactId>ffm</artifactId> -->
-        <version>0.7.0</version>
+        <version>${pcre4j.version}</version>
     </dependency>
 </dependencies>
 ```
@@ -111,21 +116,26 @@ can set the `pcre2.regex.jit` system property with the value `false` to the JVM.
 
 ### Advanced Usage via PCRE4J API
 
-Add the following dependencies to your `pom.xml` file:
+Add the following dependencies to your `pom.xml` file (replace `${pcre4j.version}` with the
+[latest release version](https://mvnrepository.com/artifact/org.pcre4j/lib)):
 
 ```xml
+<properties>
+    <pcre4j.version><!-- latest version --></pcre4j.version>
+</properties>
+
 <dependencies>
     <dependency>
         <groupId>org.pcre4j</groupId>
         <artifactId>lib</artifactId>
-        <version>0.7.0</version>
+        <version>${pcre4j.version}</version>
     </dependency>
     <dependency>
         <groupId>org.pcre4j</groupId>
         <!-- TODO: Select one of the following artifacts corresponding to the backend you want to use -->
         <artifactId>jna</artifactId>
         <!-- <artifactId>ffm</artifactId> -->
-        <version>0.7.0</version>
+        <version>${pcre4j.version}</version>
     </dependency>
 </dependencies>
 ```
@@ -174,16 +184,21 @@ public class Usage {
 
 ### Low-Level Usage
 
-Add the following dependencies to your `pom.xml` file:
+Add the following dependencies to your `pom.xml` file (replace `${pcre4j.version}` with the
+[latest release version](https://mvnrepository.com/artifact/org.pcre4j/lib)):
 
 ```xml
+<properties>
+    <pcre4j.version><!-- latest version --></pcre4j.version>
+</properties>
+
 <dependencies>
     <dependency>
         <groupId>org.pcre4j</groupId>
         <!-- TODO: Select one of the following artifacts corresponding to the backend you want to use -->
         <artifactId>jna</artifactId>
         <!-- <artifactId>ffm</artifactId> -->
-        <version>0.7.0</version>
+        <version>${pcre4j.version}</version>
     </dependency>
 </dependencies>
 ```


### PR DESCRIPTION
## Summary

- Replace 5 hardcoded `0.7.0` version strings in README Maven dependency examples with a `${pcre4j.version}` property placeholder
- Each dependency section now links to Maven Central for finding the latest release version
- Remove the now-unnecessary "Update README.md version references" step from the release workflow in CLAUDE.md

Closes #305

## Test plan

- [x] Verify no hardcoded version strings remain in README.md
- [x] Verify `checkstyleMain checkstyleTest` passes
- [ ] Visual review of rendered README on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)