### PR TITLE
(chore) build: use human-readable names in POM metadata

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -79,7 +79,7 @@ publishing {
             artifactId = project.name
 
             pom {
-                name = "org.pcre4j:${project.name}"
+                name = "PCRE4J Backend API"
                 description = "PCRE4J Backend API"
             }
         }

--- a/ffm/build.gradle.kts
+++ b/ffm/build.gradle.kts
@@ -274,7 +274,7 @@ publishing {
             artifactId = project.name
 
             pom {
-                name = "org.pcre4j:${project.name}"
+                name = "PCRE4J FFM Backend"
                 description = "PCRE4J FFM Backend"
             }
         }

--- a/jna/build.gradle.kts
+++ b/jna/build.gradle.kts
@@ -101,7 +101,7 @@ publishing {
             artifactId = project.name
 
             pom {
-                name = "org.pcre4j:${project.name}"
+                name = "PCRE4J JNA Backend"
                 description = "PCRE4J JNA Backend"
             }
         }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -115,7 +115,7 @@ publishing {
             artifactId = project.name
 
             pom {
-                name = "org.pcre4j:${project.name}"
+                name = "PCRE4J Library"
                 description = "PCRE4J Library"
             }
         }

--- a/regex/build.gradle.kts
+++ b/regex/build.gradle.kts
@@ -114,8 +114,8 @@ publishing {
             artifactId = project.name
 
             pom {
-                name = "org.pcre4j:${project.name}"
-                description = "PCRE4J java.util.regex-alike API"
+                name = "PCRE4J Regex"
+                description = "PCRE4J java.util.regex-compatible API"
             }
         }
     }


### PR DESCRIPTION
## Summary

- Replace Maven coordinate format (`org.pcre4j:module`) with descriptive human-readable names in POM `<name>` elements across all five published modules
- Update regex module description from "java.util.regex-alike API" to "java.util.regex-compatible API"

| Module | Before | After |
|--------|--------|-------|
| api | `org.pcre4j:api` | `PCRE4J Backend API` |
| lib | `org.pcre4j:lib` | `PCRE4J Library` |
| jna | `org.pcre4j:jna` | `PCRE4J JNA Backend` |
| ffm | `org.pcre4j:ffm` | `PCRE4J FFM Backend` |
| regex | `org.pcre4j:regex` | `PCRE4J Regex` |

Fixes #342

## Test plan

- [x] `generatePomFileForMavenJavaPublication` succeeds and generated POMs contain human-readable names
- [x] `checkstyleMain` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)