### PR TITLE
(chore) test: deduplicate JNA/FFM loading tests

### DIFF
--- a/ffm/src/test/java/org/pcre4j/ffm/Pcre2LoadingTests.java
+++ b/ffm/src/test/java/org/pcre4j/ffm/Pcre2LoadingTests.java
@@ -14,12 +14,7 @@
  */
 package org.pcre4j.ffm;
 
-import org.junit.jupiter.api.Test;
-import org.pcre4j.api.Pcre2LibraryFinder;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.pcre4j.test.Pcre2LoadingContractTest;
 
 /**
  * Tests for FFM backend native library loading failure modes.
@@ -27,48 +22,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>Verifies that the FFM {@link Pcre2} backend produces clear, actionable errors when the PCRE2 native library
  * cannot be loaded.</p>
  */
-class Pcre2LoadingTests {
+class Pcre2LoadingTests implements Pcre2LoadingContractTest {
 
-    @Test
-    void loadNonExistentLibraryByName_throwsUnsatisfiedLinkError() {
-        System.setProperty(Pcre2LibraryFinder.DISCOVERY_PROPERTY, "false");
-        try {
-            var error = assertThrows(
-                    UnsatisfiedLinkError.class,
-                    () -> new Pcre2("nonexistent-pcre2-library-xyz", "_8")
-            );
-            assertNotNull(error.getMessage(), "Error message must not be null");
-            assertTrue(
-                    error.getMessage().contains("nonexistent-pcre2-library-xyz"),
-                    "Error message should mention the library name, got: " + error.getMessage()
-            );
-        } finally {
-            System.clearProperty(Pcre2LibraryFinder.DISCOVERY_PROPERTY);
-        }
-    }
-
-    @Test
-    void loadLibraryFromNonExistentPath_throwsUnsatisfiedLinkError() {
-        var error = assertThrows(
-                UnsatisfiedLinkError.class,
-                () -> new Pcre2("/nonexistent/path/to/libpcre2-8.so", "_8")
-        );
-        assertNotNull(error.getMessage(), "Error message must not be null");
-    }
-
-    @Test
-    void loadNullLibraryName_throwsIllegalArgumentException() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> new Pcre2(null, "_8")
-        );
-    }
-
-    @Test
-    void loadNullSuffix_throwsIllegalArgumentException() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> new Pcre2("pcre2-8", null)
-        );
+    @Override
+    public void createBackend(String library, String suffix) {
+        new Pcre2(library, suffix);
     }
 }

--- a/jna/src/test/java/org/pcre4j/jna/Pcre2LoadingTests.java
+++ b/jna/src/test/java/org/pcre4j/jna/Pcre2LoadingTests.java
@@ -14,12 +14,7 @@
  */
 package org.pcre4j.jna;
 
-import org.junit.jupiter.api.Test;
-import org.pcre4j.api.Pcre2LibraryFinder;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.pcre4j.test.Pcre2LoadingContractTest;
 
 /**
  * Tests for JNA backend native library loading failure modes.
@@ -27,48 +22,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>Verifies that the JNA {@link Pcre2} backend produces clear, actionable errors when the PCRE2 native library
  * cannot be loaded.</p>
  */
-class Pcre2LoadingTests {
+class Pcre2LoadingTests implements Pcre2LoadingContractTest {
 
-    @Test
-    void loadNonExistentLibraryByName_throwsUnsatisfiedLinkError() {
-        System.setProperty(Pcre2LibraryFinder.DISCOVERY_PROPERTY, "false");
-        try {
-            var error = assertThrows(
-                    UnsatisfiedLinkError.class,
-                    () -> new Pcre2("nonexistent-pcre2-library-xyz", "_8")
-            );
-            assertNotNull(error.getMessage(), "Error message must not be null");
-            assertTrue(
-                    error.getMessage().contains("nonexistent-pcre2-library-xyz"),
-                    "Error message should mention the library name, got: " + error.getMessage()
-            );
-        } finally {
-            System.clearProperty(Pcre2LibraryFinder.DISCOVERY_PROPERTY);
-        }
-    }
-
-    @Test
-    void loadLibraryFromNonExistentPath_throwsUnsatisfiedLinkError() {
-        var error = assertThrows(
-                UnsatisfiedLinkError.class,
-                () -> new Pcre2("/nonexistent/path/to/libpcre2-8.so", "_8")
-        );
-        assertNotNull(error.getMessage(), "Error message must not be null");
-    }
-
-    @Test
-    void loadNullLibraryName_throwsIllegalArgumentException() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> new Pcre2(null, "_8")
-        );
-    }
-
-    @Test
-    void loadNullSuffix_throwsIllegalArgumentException() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> new Pcre2("pcre2-8", null)
-        );
+    @Override
+    public void createBackend(String library, String suffix) {
+        new Pcre2(library, suffix);
     }
 }

--- a/lib/src/testFixtures/java/org/pcre4j/test/Pcre2LoadingContractTest.java
+++ b/lib/src/testFixtures/java/org/pcre4j/test/Pcre2LoadingContractTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j.test;
+
+import org.junit.jupiter.api.Test;
+import org.pcre4j.api.Pcre2LibraryFinder;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Contract tests for PCRE2 backend native library loading failure modes.
+ *
+ * <p>Verifies that backend implementations produce clear, actionable errors when the PCRE2 native library
+ * cannot be loaded.</p>
+ */
+public interface Pcre2LoadingContractTest {
+
+    /**
+     * Creates a new backend instance with the specified library name and function suffix.
+     *
+     * @param library the library name or path
+     * @param suffix the function suffix
+     */
+    void createBackend(String library, String suffix);
+
+    @Test
+    default void loadNonExistentLibraryByName_throwsUnsatisfiedLinkError() {
+        System.setProperty(Pcre2LibraryFinder.DISCOVERY_PROPERTY, "false");
+        try {
+            var error = assertThrows(
+                    UnsatisfiedLinkError.class,
+                    () -> createBackend("nonexistent-pcre2-library-xyz", "_8")
+            );
+            assertNotNull(error.getMessage(), "Error message must not be null");
+            assertTrue(
+                    error.getMessage().contains("nonexistent-pcre2-library-xyz"),
+                    "Error message should mention the library name, got: " + error.getMessage()
+            );
+        } finally {
+            System.clearProperty(Pcre2LibraryFinder.DISCOVERY_PROPERTY);
+        }
+    }
+
+    @Test
+    default void loadLibraryFromNonExistentPath_throwsUnsatisfiedLinkError() {
+        var error = assertThrows(
+                UnsatisfiedLinkError.class,
+                () -> createBackend("/nonexistent/path/to/libpcre2-8.so", "_8")
+        );
+        assertNotNull(error.getMessage(), "Error message must not be null");
+    }
+
+    @Test
+    default void loadNullLibraryName_throwsIllegalArgumentException() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> createBackend(null, "_8")
+        );
+    }
+
+    @Test
+    default void loadNullSuffix_throwsIllegalArgumentException() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> createBackend("pcre2-8", null)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Extract shared loading failure-mode tests into a `Pcre2LoadingContractTest` contract interface in `lib` testFixtures
- JNA and FFM `Pcre2LoadingTests` now implement the contract and provide only the backend-specific `createBackend` factory method
- Follows the existing contract test pattern used by `Pcre2ConfigurationContractTest`, `Pcre2MatchingContractTest`, etc.

Closes #329

## Test plan
- [x] `jna:test --tests '*Pcre2LoadingTests*'` passes (4 tests)
- [x] `ffm:test --tests '*Pcre2LoadingTests*'` passes (4 tests)
- [x] Checkstyle passes for all affected modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)