### PR TITLE
(chore) lib: consolidate six Cleaner instances into shared singleton

### DIFF
--- a/lib/src/main/java/org/pcre4j/Pcre2Code.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2Code.java
@@ -27,8 +27,6 @@ import java.util.EnumSet;
  */
 public class Pcre2Code {
 
-    private static final Cleaner cleaner = Cleaner.create();
-
     /**
      * The compiled pattern handle
      */
@@ -155,7 +153,7 @@ public class Pcre2Code {
 
         this.api = api;
         this.handle = handle;
-        this.cleanable = cleaner.register(this, new Clean(api, handle));
+        this.cleanable = Pcre4jCleaner.INSTANCE.register(this, new Clean(api, handle));
     }
 
     /**

--- a/lib/src/main/java/org/pcre4j/Pcre2CompileContext.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2CompileContext.java
@@ -21,8 +21,6 @@ import java.util.EnumSet;
 
 public class Pcre2CompileContext {
 
-    private static final Cleaner cleaner = Cleaner.create();
-
     /**
      * The compile context handle
      */
@@ -67,7 +65,7 @@ public class Pcre2CompileContext {
 
         this.api = api;
         this.handle = handle;
-        this.cleanable = cleaner.register(this, new Pcre2CompileContext.Clean(api, handle));
+        this.cleanable = Pcre4jCleaner.INSTANCE.register(this, new Pcre2CompileContext.Clean(api, handle));
     }
 
     /**

--- a/lib/src/main/java/org/pcre4j/Pcre2GeneralContext.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2GeneralContext.java
@@ -20,7 +20,6 @@ import java.lang.ref.Cleaner;
 
 public class Pcre2GeneralContext {
 
-    private static final Cleaner cleaner = Cleaner.create();
     /**
      * The general context handle
      */
@@ -59,7 +58,7 @@ public class Pcre2GeneralContext {
 
         this.api = api;
         this.handle = handle;
-        this.cleanable = cleaner.register(this, new Pcre2GeneralContext.Clean(api, handle));
+        this.cleanable = Pcre4jCleaner.INSTANCE.register(this, new Pcre2GeneralContext.Clean(api, handle));
     }
 
     /**

--- a/lib/src/main/java/org/pcre4j/Pcre2JitStack.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2JitStack.java
@@ -20,8 +20,6 @@ import java.lang.ref.Cleaner;
 
 public class Pcre2JitStack {
 
-    private static final Cleaner cleaner = Cleaner.create();
-
     /**
      * The JIT stack handle
      */
@@ -72,7 +70,7 @@ public class Pcre2JitStack {
 
         this.api = api;
         this.handle = handle;
-        this.cleanable = cleaner.register(this, new Pcre2JitStack.Clean(api, handle));
+        this.cleanable = Pcre4jCleaner.INSTANCE.register(this, new Pcre2JitStack.Clean(api, handle));
     }
 
     /**

--- a/lib/src/main/java/org/pcre4j/Pcre2MatchContext.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2MatchContext.java
@@ -20,8 +20,6 @@ import java.lang.ref.Cleaner;
 
 public class Pcre2MatchContext {
 
-    private static final Cleaner cleaner = Cleaner.create();
-
     /**
      * The match context handle
      */
@@ -66,7 +64,7 @@ public class Pcre2MatchContext {
 
         this.api = api;
         this.handle = handle;
-        this.cleanable = cleaner.register(this, new Pcre2MatchContext.Clean(api, handle));
+        this.cleanable = Pcre4jCleaner.INSTANCE.register(this, new Pcre2MatchContext.Clean(api, handle));
     }
 
     /**

--- a/lib/src/main/java/org/pcre4j/Pcre2MatchData.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2MatchData.java
@@ -24,7 +24,6 @@ import java.nio.ByteBuffer;
  */
 public class Pcre2MatchData {
 
-    private static final Cleaner cleaner = Cleaner.create();
     /**
      * The match data handle
      */
@@ -70,7 +69,7 @@ public class Pcre2MatchData {
 
         this.api = api;
         this.handle = handle;
-        this.cleanable = cleaner.register(this, new Pcre2MatchData.Clean(api, handle));
+        this.cleanable = Pcre4jCleaner.INSTANCE.register(this, new Pcre2MatchData.Clean(api, handle));
     }
 
     /**
@@ -93,7 +92,7 @@ public class Pcre2MatchData {
 
         this.api = code.api;
         this.handle = handle;
-        this.cleanable = cleaner.register(this, new Pcre2MatchData.Clean(api, handle));
+        this.cleanable = Pcre4jCleaner.INSTANCE.register(this, new Pcre2MatchData.Clean(api, handle));
     }
 
     /**

--- a/lib/src/main/java/org/pcre4j/Pcre4jCleaner.java
+++ b/lib/src/main/java/org/pcre4j/Pcre4jCleaner.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j;
+
+import java.lang.ref.Cleaner;
+
+/**
+ * Shared {@link Cleaner} instance for all PCRE4J native resource wrappers.
+ * <p>
+ * Using a single shared cleaner reduces daemon thread overhead from one thread per wrapper class to a single thread
+ * for the entire library.
+ */
+/* package-private */ final class Pcre4jCleaner {
+
+    /**
+     * The shared {@link Cleaner} instance.
+     */
+    static final Cleaner INSTANCE = Cleaner.create();
+
+    private Pcre4jCleaner() {
+    }
+
+}


### PR DESCRIPTION
## Summary

- Introduce package-private `Pcre4jCleaner` with a single shared `Cleaner` instance
- Replace per-class `Cleaner.create()` calls in `Pcre2Code`, `Pcre2MatchData`, `Pcre2GeneralContext`, `Pcre2CompileContext`, `Pcre2MatchContext`, and `Pcre2JitStack` with `Pcre4jCleaner.INSTANCE`
- Reduces daemon thread count from 6 to 1 per JVM, following JDK documentation recommendation

## Test plan

- [x] All existing tests pass (`./gradlew test`)
- [x] Checkstyle passes (`./gradlew checkstyleMain checkstyleTest`)
- [ ] CI passes on all platforms

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)