### PR TITLE
(chore) build: remove redundant sourceSets declarations

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -36,12 +36,6 @@ configurations {
     }
 }
 
-sourceSets {
-    main {
-        java.srcDir("src/main/java")
-    }
-}
-
 java {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21

--- a/ffm/build.gradle.kts
+++ b/ffm/build.gradle.kts
@@ -39,12 +39,6 @@ configurations {
     }
 }
 
-sourceSets {
-    main {
-        java.srcDir("src/main/java")
-    }
-}
-
 // ============================================================
 // MRJAR: Java 22+ source set for finalized FFM API
 // ============================================================

--- a/jna/build.gradle.kts
+++ b/jna/build.gradle.kts
@@ -40,12 +40,6 @@ configurations {
     }
 }
 
-sourceSets {
-    main {
-        java.srcDir("src/main/java")
-    }
-}
-
 java {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -42,12 +42,6 @@ configurations {
     }
 }
 
-sourceSets {
-    main {
-        java.srcDir("src/main/java")
-    }
-}
-
 java {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21

--- a/regex/build.gradle.kts
+++ b/regex/build.gradle.kts
@@ -41,12 +41,6 @@ configurations {
     }
 }
 
-sourceSets {
-    main {
-        java.srcDir("src/main/java")
-    }
-}
-
 java {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21


### PR DESCRIPTION
## Summary
- Remove the redundant `sourceSets { main { java.srcDir("src/main/java") } }` blocks from all five module build scripts (`api`, `lib`, `jna`, `ffm`, `regex`)
- These blocks merely re-declare the default source directory that Gradle's `java-library` plugin already provides
- Non-default `sourceSets` usages in the `ffm` module (MRJAR `java22` and `testJava22Classes` source sets) are preserved

## Test plan
- [x] Full `./gradlew build` passes with all tests green

Fixes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)