### PR TITLE
(chore) api: rename valueOf(int) to avoid Enum.valueOf(String) shadowing

### DIFF
--- a/api/src/main/java/org/pcre4j/api/Pcre2UtfWidth.java
+++ b/api/src/main/java/org/pcre4j/api/Pcre2UtfWidth.java
@@ -117,7 +117,7 @@ public enum Pcre2UtfWidth {
      * @param value the integer value
      * @return the enum entry
      */
-    public static Optional<Pcre2UtfWidth> valueOf(int value) {
+    public static Optional<Pcre2UtfWidth> fromValue(int value) {
         return Arrays.stream(values())
                 .filter(entry -> entry.value == value)
                 .findFirst();


### PR DESCRIPTION
## Summary
- Rename `Pcre2UtfWidth.valueOf(int)` to `fromValue(int)` to avoid shadowing the inherited `Enum.valueOf(String)` method, which can cause confusion with auto-complete and reflection tools

## Test plan
- [x] Full `./gradlew build` passes (no callers of `Pcre2UtfWidth.valueOf(int)` existed to update)
- [ ] CI passes

Fixes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)