### PR TITLE
(chore) build: use JUnit BOM for version alignment

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -26,6 +26,7 @@ repositories {
 }
 
 dependencies {
+    testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly(libs.junit.platform.launcher)
 }

--- a/ffm/build.gradle.kts
+++ b/ffm/build.gradle.kts
@@ -27,6 +27,7 @@ repositories {
 
 dependencies {
     api(project(":api"))
+    testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testImplementation(project(":lib"))
     testImplementation(testFixtures(project(":lib")))
@@ -169,6 +170,7 @@ configurations["testJava22ClassesRuntimeOnly"].extendsFrom(configurations.testRu
 
 dependencies {
     // Java 22 test classes need to see the main JAR (for MRJAR resolution)
+    "testJava22ClassesImplementation"(platform(libs.junit.bom))
     "testJava22ClassesImplementation"(project(":api"))
     "testJava22ClassesImplementation"(project(":lib"))
     "testJava22ClassesImplementation"(testFixtures(project(":lib")))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
 jna = "5.18.1"
-junit-jupiter = "5.14.2"
-junit-platform = "1.14.2"
+junit = "5.14.2"
 jreleaser = "1.22.0"
 
 [libraries]
 jna-platform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }
-junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 
 [plugins]
 jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }

--- a/jna/build.gradle.kts
+++ b/jna/build.gradle.kts
@@ -28,6 +28,7 @@ repositories {
 dependencies {
     api(project(":api"))
     implementation(libs.jna.platform)
+    testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testImplementation(project(":lib"))
     testImplementation(testFixtures(project(":lib")))

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -28,10 +28,12 @@ repositories {
 
 dependencies {
     api(project(":api"))
+    testFixturesApi(platform(libs.junit.bom))
     testFixturesApi(libs.junit.jupiter)
     // Runtime-only: lib tests discover backends reflectively to avoid compile-time coupling
     testRuntimeOnly(project(":jna"))
     testRuntimeOnly(project(":ffm"))
+    testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly(libs.junit.platform.launcher)
 }

--- a/regex/build.gradle.kts
+++ b/regex/build.gradle.kts
@@ -28,6 +28,7 @@ repositories {
 dependencies {
     api(project(":api"))
     api(project(":lib"))
+    testImplementation(platform(libs.junit.bom))
     testImplementation(testFixtures(project(":lib")))
     testImplementation(project(":jna"))
     testImplementation(project(":ffm"))


### PR DESCRIPTION
## Summary
- Replace separate `junit-jupiter` and `junit-platform` version entries in the version catalog with a single JUnit BOM (`org.junit:junit-bom`)
- Add `platform(libs.junit.bom)` to all modules that use JUnit dependencies (api, lib, jna, ffm, regex)
- JUnit module versions are now aligned through the BOM rather than manually coordinated individual version references

Closes #295

## Test plan
- [x] Full build passes (`./gradlew build`)
- [x] All module tests pass (api, lib, jna, ffm, regex)
- [x] Checkstyle passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)