### PR TITLE
(chore) ci: align release workflow PCRE2 with CI source build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,9 @@ jobs:
 
     timeout-minutes: 30
 
+    env:
+      PCRE2_VERSION: '10.47'
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -52,11 +55,13 @@ jobs:
       - name: Checkstyle
         run: ./gradlew checkstyleMain checkstyleTest
 
-      - name: Install PCRE
-        run: sudo apt-get install -y libpcre2-8-0
+      - name: Build PCRE2
+        uses: ./.github/actions/build-pcre2
+        with:
+          version: ${{ env.PCRE2_VERSION }}
 
       - name: Build artifacts
-        run: ./gradlew build jacocoAggregatedTestReport -Dpcre2.library.path=/usr/lib/x86_64-linux-gnu
+        run: ./gradlew build jacocoAggregatedTestReport -Dpcre2.library.path=/opt/pcre2/lib
 
       - name: Stage artifacts
         run: ./gradlew publishAllPublicationsToStagingDeployRepository -Ppcre4j.version=${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- Replace `apt-get install -y libpcre2-8-0` in the release workflow with the `build-pcre2` composite action already used by CI
- Pin PCRE2 version to 10.47 with SHA256 verification, matching CI's `package` job
- Update library path from `/usr/lib/x86_64-linux-gnu` to `/opt/pcre2/lib`

Fixes #369

## Test plan
- [ ] CI passes on this PR (validates the workflow YAML syntax and composite action reference)
- [ ] Verify the release workflow `package` job structure matches CI's `package` job pattern for PCRE2 setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)