### PR TITLE
(chore) api: extract readBytes() into INativeMemoryAccess interface

### DIFF
--- a/api/src/main/java/org/pcre4j/api/INativeMemoryAccess.java
+++ b/api/src/main/java/org/pcre4j/api/INativeMemoryAccess.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j.api;
+
+/**
+ * Interface for native memory access operations.
+ * <p>
+ * This interface is separate from {@link IPcre2} because native memory access is a utility concern,
+ * not part of the PCRE2 API contract. Backend implementations (JNA, FFM) provide their own native
+ * memory reading capabilities alongside their PCRE2 API implementations.
+ */
+public interface INativeMemoryAccess {
+
+    /**
+     * Read bytes from a native memory pointer.
+     *
+     * @param pointer the native memory pointer
+     * @param length  the number of bytes to read
+     * @return the bytes read from the pointer
+     */
+    byte[] readBytes(long pointer, int length);
+}

--- a/api/src/main/java/org/pcre4j/api/IPcre2.java
+++ b/api/src/main/java/org/pcre4j/api/IPcre2.java
@@ -1824,14 +1824,4 @@ public interface IPcre2 {
      */
     int serializeGetNumberOfCodes(byte[] bytes);
 
-    /**
-     * Read bytes from a native memory pointer.
-     * <p>
-     * This is a utility method used internally to read string data from native memory.
-     *
-     * @param pointer the native memory pointer
-     * @param length  the number of bytes to read
-     * @return the bytes read from the pointer
-     */
-    byte[] readBytes(long pointer, int length);
 }

--- a/ffm/src/main/java/org/pcre4j/ffm/Pcre2.java
+++ b/ffm/src/main/java/org/pcre4j/ffm/Pcre2.java
@@ -14,6 +14,7 @@
  */
 package org.pcre4j.ffm;
 
+import org.pcre4j.api.INativeMemoryAccess;
 import org.pcre4j.api.IPcre2;
 import org.pcre4j.api.Pcre2LibraryFinder;
 import org.pcre4j.api.Pcre2UtfWidth;
@@ -28,7 +29,7 @@ import java.nio.ByteBuffer;
 /**
  * A PCRE2 API using the Foreign Function {@literal &} Memory API.
  */
-public class Pcre2 implements IPcre2 {
+public class Pcre2 implements IPcre2, INativeMemoryAccess {
 
     private static final Linker LINKER = Linker.nativeLinker();
     private static final SymbolLookup SYMBOL_LOOKUP = SymbolLookup.loaderLookup();

--- a/jna/src/main/java/org/pcre4j/jna/Pcre2.java
+++ b/jna/src/main/java/org/pcre4j/jna/Pcre2.java
@@ -22,6 +22,7 @@ import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.LongByReference;
 import com.sun.jna.ptr.PointerByReference;
+import org.pcre4j.api.INativeMemoryAccess;
 import org.pcre4j.api.IPcre2;
 import org.pcre4j.api.Pcre2LibraryFinder;
 import org.pcre4j.api.Pcre2UtfWidth;
@@ -35,7 +36,7 @@ import java.util.Map;
 /**
  * A PCRE2 API using the JNA.
  */
-public class Pcre2 implements IPcre2 {
+public class Pcre2 implements IPcre2, INativeMemoryAccess {
 
     /**
      * The PCRE2 library loaded by JNA.

--- a/lib/src/main/java/org/pcre4j/Pcre2Code.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2Code.java
@@ -14,6 +14,7 @@
  */
 package org.pcre4j;
 
+import org.pcre4j.api.INativeMemoryAccess;
 import org.pcre4j.api.IPcre2;
 
 import java.lang.ref.Cleaner;
@@ -534,7 +535,7 @@ public class Pcre2Code {
         // Each entry starts with a 2-byte group number (big-endian)
         for (int i = 0; i < numEntries; i++) {
             final var entryStart = first[0] + ((long) i * entrySize);
-            final var bytes = api.readBytes(entryStart, 2);
+            final var bytes = ((INativeMemoryAccess) api).readBytes(entryStart, 2);
             // Group number is stored as big-endian 16-bit value
             groupNumbers[i] = ((bytes[0] & 0xFF) << 8) | (bytes[1] & 0xFF);
         }

--- a/lib/src/main/java/org/pcre4j/Pcre2MatchData.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2MatchData.java
@@ -14,6 +14,7 @@
  */
 package org.pcre4j;
 
+import org.pcre4j.api.INativeMemoryAccess;
 import org.pcre4j.api.IPcre2;
 
 import java.lang.ref.Cleaner;
@@ -175,7 +176,7 @@ public class Pcre2MatchData {
 
         if (result == 0) {
             try {
-                return api.readBytes(bufferptr[0], (int) bufflen[0]);
+                return ((INativeMemoryAccess) api).readBytes(bufferptr[0], (int) bufflen[0]);
             } finally {
                 api.substringFree(bufferptr[0]);
             }
@@ -229,7 +230,7 @@ public class Pcre2MatchData {
 
         if (result == 0) {
             try {
-                return api.readBytes(bufferptr[0], (int) bufflen[0]);
+                return ((INativeMemoryAccess) api).readBytes(bufferptr[0], (int) bufflen[0]);
             } finally {
                 api.substringFree(bufferptr[0]);
             }

--- a/lib/src/testFixtures/java/org/pcre4j/test/Pcre2SerializationContractTest.java
+++ b/lib/src/testFixtures/java/org/pcre4j/test/Pcre2SerializationContractTest.java
@@ -15,6 +15,7 @@
 package org.pcre4j.test;
 
 import org.junit.jupiter.api.Test;
+import org.pcre4j.api.INativeMemoryAccess;
 import org.pcre4j.api.IPcre2;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -54,7 +55,7 @@ public interface Pcre2SerializationContractTest<T extends IPcre2> {
         assertTrue(serializedSize[0] > 0, "serializedSize should be positive");
 
         // Read the serialized data to verify it's accessible
-        final var bytes = api.readBytes(serializedBytes[0], (int) serializedSize[0]);
+        final var bytes = ((INativeMemoryAccess) api).readBytes(serializedBytes[0], (int) serializedSize[0]);
         assertEquals(serializedSize[0], bytes.length, "Read bytes should match serialized size");
 
         api.serializeFree(serializedBytes[0]);
@@ -137,7 +138,7 @@ public interface Pcre2SerializationContractTest<T extends IPcre2> {
         assertEquals(1, encodeResult, "serializeEncode should return 1 for single pattern");
 
         // Read the serialized data
-        final var bytes = api.readBytes(serializedBytes[0], (int) serializedSize[0]);
+        final var bytes = ((INativeMemoryAccess) api).readBytes(serializedBytes[0], (int) serializedSize[0]);
         assertEquals(serializedSize[0], bytes.length, "Read bytes should match serialized size");
 
         // Decode the pattern
@@ -172,7 +173,7 @@ public interface Pcre2SerializationContractTest<T extends IPcre2> {
         final var encodeResult2 = api.serializeEncode(codes12, 2, serializedBytes2, serializedSize2, 0);
         assertEquals(2, encodeResult2, "serializeEncode should return 2 for two patterns");
 
-        final var bytes2 = api.readBytes(serializedBytes2[0], (int) serializedSize2[0]);
+        final var bytes2 = ((INativeMemoryAccess) api).readBytes(serializedBytes2[0], (int) serializedSize2[0]);
 
         final var decodedCodes2 = new long[2];
         final var decodeResult2 = api.serializeDecode(decodedCodes2, 2, bytes2, 0);
@@ -207,7 +208,7 @@ public interface Pcre2SerializationContractTest<T extends IPcre2> {
         final var encodeResult3 = api.serializeEncode(new long[]{code3}, 1, serializedBytes3, serializedSize3, 0);
         assertEquals(1, encodeResult3, "serializeEncode should return 1");
 
-        final var bytes3 = api.readBytes(serializedBytes3[0], (int) serializedSize3[0]);
+        final var bytes3 = ((INativeMemoryAccess) api).readBytes(serializedBytes3[0], (int) serializedSize3[0]);
 
         final var decodedCodes3 = new long[1];
         final var decodeResult3 = api.serializeDecode(decodedCodes3, 1, bytes3, 0);
@@ -313,7 +314,7 @@ public interface Pcre2SerializationContractTest<T extends IPcre2> {
         final var encodeResult = api.serializeEncode(new long[]{code}, 1, serializedBytes, serializedSize, 0);
         assertEquals(1, encodeResult, "serializeEncode should return 1 for single pattern");
 
-        final var bytes = api.readBytes(serializedBytes[0], (int) serializedSize[0]);
+        final var bytes = ((INativeMemoryAccess) api).readBytes(serializedBytes[0], (int) serializedSize[0]);
         final var count = api.serializeGetNumberOfCodes(bytes);
         assertEquals(1, count, "serializeGetNumberOfCodes should return 1 for single pattern");
 
@@ -337,7 +338,7 @@ public interface Pcre2SerializationContractTest<T extends IPcre2> {
                 new long[]{code1, code2, code3}, 3, serializedBytes2, serializedSize2, 0);
         assertEquals(3, encodeResult2, "serializeEncode should return 3 for three patterns");
 
-        final var bytes2 = api.readBytes(serializedBytes2[0], (int) serializedSize2[0]);
+        final var bytes2 = ((INativeMemoryAccess) api).readBytes(serializedBytes2[0], (int) serializedSize2[0]);
         final var count2 = api.serializeGetNumberOfCodes(bytes2);
         assertEquals(3, count2, "serializeGetNumberOfCodes should return 3 for three patterns");
 


### PR DESCRIPTION
## Summary
- Extracts `readBytes()` from `IPcre2` interface into a dedicated `INativeMemoryAccess` interface in the `api` module
- Both JNA and FFM backends implement `INativeMemoryAccess` alongside `IPcre2`
- Updates all callers in `lib` module (`Pcre2Code`, `Pcre2MatchData`) and test fixtures to use the new interface via cast

This keeps `IPcre2` purely as the PCRE2 API backend contract, separating the native memory access utility concern.

Closes #366

## Test plan
- [x] Full build passes (`./gradlew build`)
- [x] All existing JNA and FFM tests pass (no behavior change)
- [ ] CI validates across compatibility matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)