### PR TITLE
(docs) api: add security warning to serializeDecode API

### DIFF
--- a/api/src/main/java/org/pcre4j/api/IPcre2.java
+++ b/api/src/main/java/org/pcre4j/api/IPcre2.java
@@ -1776,6 +1776,11 @@ public interface IPcre2 {
      * The memory for the decoded patterns is obtained using the general context's memory management
      * functions (or {@code malloc()} if no context is provided). Each decoded pattern must be freed
      * separately using {@link #codeFree}.
+     * <p>
+     * <b>Security warning:</b> The serialized data is only subject to simple consistency checking, not complete
+     * validation. This function is intended for use with trusted data from within the same application. Do not
+     * deserialize data from untrusted or external sources, as corrupted or malicious input may cause undefined
+     * behavior, including reading beyond the end of the provided byte stream.
      *
      * @param codes          an array to receive the decoded compiled pattern handles
      * @param numberOfCodes  the number of slots available in the codes array (must be positive)


### PR DESCRIPTION
## Summary
- Add a security warning to the `serializeDecode` JavaDoc in `IPcre2` interface, noting that serialized data undergoes only simple consistency checking and must not come from untrusted sources

Fixes #286

## Test plan
- [x] Checkstyle passes (`api:checkstyleMain`)
- [x] Javadoc generates without new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)