### PR TITLE
(chore) build: standardize DuplicatesStrategy across modules

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -63,10 +63,6 @@ tasks.jacocoTestReport {
     }
 }
 
-tasks.named<Jar>("sourcesJar") {
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
-}
-
 publishing {
     publications {
         create<MavenPublication>("mavenJava") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,6 +82,12 @@ tasks.named("check") {
 // Shared POM metadata for all published modules
 // ==========================================================================
 subprojects {
+    tasks.withType<Jar>().configureEach {
+        if (name == "sourcesJar") {
+            duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        }
+    }
+
     pluginManager.withPlugin("maven-publish") {
         configure<PublishingExtension> {
             publications.withType<MavenPublication> {

--- a/ffm/build.gradle.kts
+++ b/ffm/build.gradle.kts
@@ -245,7 +245,6 @@ tasks.jacocoTestReport {
 // Sources JAR includes both source sets
 // ============================================================
 tasks.named<Jar>("sourcesJar") {
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     // Include Java 22-specific ArenaHelper.java
     from(java22.allSource) {
         into("META-INF/versions/22")

--- a/jna/build.gradle.kts
+++ b/jna/build.gradle.kts
@@ -85,10 +85,6 @@ tasks.jacocoTestReport {
     }
 }
 
-tasks.named<Jar>("sourcesJar") {
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
-}
-
 publishing {
     publications {
         create<MavenPublication>("mavenJava") {

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -105,10 +105,6 @@ tasks.jacocoTestReport {
     }
 }
 
-tasks.named<Jar>("sourcesJar") {
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
-}
-
 publishing {
     publications {
         create<MavenPublication>("mavenJava") {

--- a/regex/build.gradle.kts
+++ b/regex/build.gradle.kts
@@ -103,10 +103,6 @@ tasks.jacocoTestReport {
     }
 }
 
-tasks.named<Jar>("sourcesJar") {
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
-}
-
 publishing {
     publications {
         create<MavenPublication>("mavenJava") {


### PR DESCRIPTION
## Summary
- Centralize `DuplicatesStrategy.EXCLUDE` for `sourcesJar` tasks in the root `build.gradle.kts` subprojects block
- Remove per-module `duplicatesStrategy` settings from `api`, `lib`, `jna`, `ffm`, and `regex` modules
- Standardize on `EXCLUDE` (previously `api`, `lib`, `jna`, `regex` used `INCLUDE` while `ffm` used `EXCLUDE`)

Closes #308

## Test plan
- [x] Full `./gradlew build` passes across all modules
- [x] Sources JARs are generated correctly for all modules including FFM MRJAR

🤖 Generated with [Claude Code](https://claude.com/claude-code)