### PR TITLE
(chore) build: generate JaCoCo coverage for FFM testJava22 task

### DIFF
--- a/ffm/build.gradle.kts
+++ b/ffm/build.gradle.kts
@@ -232,8 +232,34 @@ tasks.check {
 // ============================================================
 // JaCoCo configuration
 // ============================================================
+
+// Report for Java 22+ tests
+val jacocoTestJava22Report by tasks.registering(JacocoReport::class) {
+    dependsOn(testJava22)
+
+    executionData(testJava22.get())
+
+    // Use only Java 22 compiled classes (Pcre2 + ArenaHelper) to avoid duplicate class errors
+    classDirectories.setFrom(java22.output.classesDirs)
+    sourceDirectories.setFrom(
+        java22.java.srcDirs + sourceSets.main.get().java.srcDirs
+    )
+
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+testJava22 {
+    finalizedBy(jacocoTestJava22Report)
+}
+
+// Report for Java 21 tests (includes testJava22 execution data for aggregation)
 tasks.jacocoTestReport {
-    dependsOn(tasks.test)
+    dependsOn(tasks.test, testJava22)
+
+    executionData(testJava22.get())
 
     reports {
         xml.required = true


### PR DESCRIPTION
## Summary

- Add a `jacocoTestJava22Report` task that generates JaCoCo coverage reports from the `testJava22` execution data, using only Java 22 compiled classes to avoid duplicate class errors with the MRJAR setup
- Wire `testJava22` to finalize with `jacocoTestJava22Report` for automatic report generation
- Include `testJava22` execution data in the existing `jacocoTestReport` for aggregated coverage

Fixes #323

## Test plan

- [x] `./gradlew :ffm:testJava22` produces `testJava22.exec` execution data
- [x] `./gradlew :ffm:jacocoTestJava22Report` generates XML and HTML reports
- [x] `./gradlew :ffm:jacocoTestReport` loads both `test.exec` and `testJava22.exec`
- [x] `./gradlew build jacocoAggregatedTestReport` succeeds with all coverage included

🤖 Generated with [Claude Code](https://claude.com/claude-code)