### PR TITLE
(chore) ci: add lib and regex modules to compatibility matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,11 +168,11 @@ jobs:
 
       - name: Test (Java 21 with preview)
         if: ${{ matrix.os == 'ubuntu-24.04' && matrix.java-version == 21 }}
-        run: ./gradlew ffm:test jna:test -Dpcre2.library.path=/opt/pcre2/lib
+        run: ./gradlew lib:test regex:test ffm:test jna:test -Dpcre2.library.path=/opt/pcre2/lib
 
       - name: Test (Java 22+ with MRJAR)
         if: ${{ matrix.os == 'ubuntu-24.04' && matrix.java-version >= 22 }}
-        run: ./gradlew ffm:testJava22 jna:test -Dpcre2.library.path=/opt/pcre2/lib -PtestJavaVersion=${{ matrix.java-version }}
+        run: ./gradlew lib:test regex:test ffm:testJava22 jna:test -Dpcre2.library.path=/opt/pcre2/lib -PtestJavaVersion=${{ matrix.java-version }}
 
   compatibility-all:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
- Adds `lib` and `regex` modules to the CI compatibility matrix so they are tested across Java versions and PCRE2 versions alongside `jna` and `ffm`

Closes #315

## Test plan
- [ ] CI passes with the updated matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)