### PR TITLE
(fix) Guard extraMultipleAsciiRestrictions test for PCRE2 < 10.43

### DIFF
--- a/lib/src/test/java/org/pcre4j/Pcre2EnumFlagCombinationTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2EnumFlagCombinationTests.java
@@ -23,6 +23,7 @@ import java.util.EnumSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Behavioral tests for enum flag combinations.
@@ -585,6 +586,10 @@ public class Pcre2EnumFlagCombinationTests {
     @ParameterizedTest
     @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void extraMultipleAsciiRestrictions(IPcre2 api) {
+        // ASCII_BSD and ASCII_BSW were added in PCRE2 10.43
+        assumeTrue(Pcre4jUtils.isVersionAtLeast(api, 10, 43),
+                "Skipping test: ASCII_BSD and ASCII_BSW require PCRE2 10.43+");
+
         var ctx = new Pcre2CompileContext(api, null);
         ctx.setCompileExtraOptions(EnumSet.of(
                 Pcre2CompileExtraOption.ASCII_BSD,


### PR DESCRIPTION
## Summary
- Add `assumeTrue(Pcre4jUtils.isVersionAtLeast(api, 10, 43))` version guard to `extraMultipleAsciiRestrictions` test
- The test uses `PCRE2_EXTRA_ASCII_BSD` / `PCRE2_EXTRA_ASCII_BSW` flags introduced in PCRE2 10.43, causing compile errors on PCRE2 10.42

Fixes #484

## Test plan
- [ ] Verify test passes on PCRE2 10.43+ (test executes normally)
- [ ] Verify test is skipped on PCRE2 10.42 (assumption causes skip, no compile error)
- [ ] Verify CI compatibility matrix jobs for 10.42 no longer fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)