### PR TITLE
(fix) Exclude OpenJ9/Semeru from Java 21 FFM tests and document as known issue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,8 +167,13 @@ jobs:
           version: ${{ matrix.pcre2-version }}
 
       - name: Test (Java 21 with preview)
-        if: ${{ matrix.os == 'ubuntu-24.04' && matrix.java-version == 21 }}
+        if: ${{ matrix.os == 'ubuntu-24.04' && matrix.java-version == 21 && matrix.java-distribution != 'adopt-openj9' && matrix.java-distribution != 'semeru' }}
         run: ./gradlew lib:test regex:test ffm:test jna:test -Dpcre2.library.path=/opt/pcre2/lib
+
+      # OpenJ9/Semeru Java 21 crashes in FFM preview due to a JVM bug (memory corruption assertion)
+      - name: Test (Java 21 without FFM)
+        if: ${{ matrix.os == 'ubuntu-24.04' && matrix.java-version == 21 && (matrix.java-distribution == 'adopt-openj9' || matrix.java-distribution == 'semeru') }}
+        run: ./gradlew lib:test regex:test jna:test -Dpcre2.library.path=/opt/pcre2/lib
 
       - name: Test (Java 22+ with MRJAR)
         if: ${{ matrix.os == 'ubuntu-24.04' && matrix.java-version >= 22 }}

--- a/README.md
+++ b/README.md
@@ -393,6 +393,10 @@ The `ffm` module is packaged as a Multi-Release JAR supporting both:
 - **Java 21**: Requires `--enable-preview` flag (FFM was a preview feature)
 - **Java 22+**: No special flags required (FFM is finalized)
 
+> **Note:** The `ffm` backend is incompatible with OpenJ9-based JVMs (including IBM Semeru) on Java
+> 21 due to a JVM bug in the preview FFM implementation that causes memory corruption assertions.
+> OpenJ9 Java 22+, where FFM is finalized, works correctly. Use the `jna` backend on OpenJ9 Java 21.
+
 > **Note:** Automatic library discovery can be disabled by setting `-Dpcre2.library.discovery=false`.
 
 ## Contributing


### PR DESCRIPTION
## Summary
- Split the Java 21 CI test step to skip FFM tests for `adopt-openj9` and `semeru` distributions, which crash with a JVM-level memory corruption assertion in their preview FFM implementation
- Other tests (lib, regex, JNA) continue to run for these distributions on Java 21
- Document the OpenJ9 Java 21 FFM incompatibility in the README backend section

## Test plan
- [ ] CI passes: OpenJ9/Semeru Java 21 jobs run without FFM tests (no crash)
- [ ] CI passes: All other Java 21 matrix jobs still run FFM tests
- [ ] CI passes: OpenJ9/Semeru Java 22+ jobs continue to run FFM tests (unaffected)

Fixes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)