### PR TITLE
(docs) lib: document global singleton pattern and multi-classloader implications

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,32 @@ The PCRE4J library provides several APIs to interact with the PCRE library:
 - The PCRE4J API via `org.pcre4j.Pcre2Code` and related classes
 - The `libpcre2` direct API via backends that implement `org.pcre4j.api.IPcre2`
 
+### Library Initialization
+
+The `regex` and `lib` convenience APIs use a global backend held by `Pcre4j`. Call
+`Pcre4j.setup()` once — typically in a static initializer — before any other PCRE4J usage:
+
+```java
+import org.pcre4j.Pcre4j;
+import org.pcre4j.jna.Pcre2;   // or org.pcre4j.ffm.Pcre2
+
+static {
+    Pcre4j.setup(new Pcre2());
+}
+```
+
+`setup()` may be called again to replace the backend; existing compiled patterns are unaffected
+because each `Pcre2Code` instance captures the backend it was created with.
+
+Every convenience constructor and factory method (e.g. `Pcre2Code(String)`,
+`Pattern.compile(String)`) has an explicit-API overload that accepts an `IPcre2` parameter
+directly, bypassing the global singleton entirely.
+
+> **Multi-classloader note:** `Pcre4j` stores the backend in a `static` field, so each
+> classloader that loads PCRE4J gets its own independent singleton. In application servers or
+> plugin frameworks, either place the PCRE4J JARs in a shared classloader, or use the
+> explicit-API overloads to avoid relying on the global state.
+
 ### Quick Start with `java.util.regex`-compatible API
 
 Add the following dependencies (replace `${pcre4j.version}` / `pcre4jVersion` with the

--- a/lib/src/main/java/org/pcre4j/Pcre4j.java
+++ b/lib/src/main/java/org/pcre4j/Pcre4j.java
@@ -18,6 +18,54 @@ import org.pcre4j.api.IPcre2;
 import org.pcre4j.api.Pcre2UtfWidth;
 
 
+/**
+ * Global singleton that holds the active {@link IPcre2} backend instance.
+ *
+ * <h2>Initialization</h2>
+ *
+ * <p>Applications must call {@link #setup(IPcre2)} once before using any PCRE4J convenience API
+ * that relies on the global backend (e.g.&nbsp;{@link Pcre2Code#Pcre2Code(String)},
+ * {@code org.pcre4j.regex.Pattern.compile(String)}). A static initializer in the application's
+ * entry point is the recommended approach:</p>
+ *
+ * <pre>{@code
+ * static {
+ *     Pcre4j.setup(new org.pcre4j.jna.Pcre2());   // or org.pcre4j.ffm.Pcre2
+ * }
+ * }</pre>
+ *
+ * <p>Calling {@link #api()} before {@link #setup(IPcre2)} throws
+ * {@link IllegalStateException}.</p>
+ *
+ * <h2>Thread Safety</h2>
+ *
+ * <p>Both {@link #setup(IPcre2)} and {@link #api()} are synchronized and safe to call from any
+ * thread. The backend reference may be replaced by calling {@link #setup(IPcre2)} again; existing
+ * {@link Pcre2Code} instances are unaffected because each instance captures the {@link IPcre2}
+ * reference at construction time.</p>
+ *
+ * <h2>Multi-Classloader Environments</h2>
+ *
+ * <p>The singleton is held in a {@code static} field of this class. In environments where the same
+ * JAR is loaded by multiple classloaders (application servers, OSGi, plugin frameworks), each
+ * classloader creates its own copy of the {@code Pcre4j} class and therefore its own independent
+ * singleton. This means:</p>
+ *
+ * <ul>
+ *   <li>Each classloader must call {@link #setup(IPcre2)} independently.</li>
+ *   <li>{@link Pcre2Code} and other objects created under one classloader cannot be mixed with a
+ *       backend set up under a different classloader.</li>
+ * </ul>
+ *
+ * <p>To avoid classloader isolation issues, place the PCRE4J JARs in a shared classloader (e.g.
+ * the server-level classpath) so that all applications share a single {@code Pcre4j} class
+ * definition and a single {@link #setup(IPcre2)} call.</p>
+ *
+ * <p>Alternatively, use the explicit-API overloads (e.g.
+ * {@link Pcre2Code#Pcre2Code(IPcre2, String)},
+ * {@code org.pcre4j.regex.Pattern.compile(IPcre2, String)}) to bypass the global singleton
+ * entirely.</p>
+ */
 public final class Pcre4j {
 
     private static final Object lock = new Object();
@@ -27,9 +75,13 @@ public final class Pcre4j {
     }
 
     /**
-     * Set up the PCRE4J library.
+     * Set up the PCRE4J library by installing the given backend as the global default.
      *
-     * @param api the API to use
+     * <p>May be called more than once; subsequent calls replace the active backend. Existing
+     * {@link Pcre2Code} instances retain the backend they were compiled with.</p>
+     *
+     * @param api the PCRE2 backend to use; must not be {@code null} and must support UTF-8
+     * @throws IllegalArgumentException if {@code api} is {@code null} or does not support UTF-8
      */
     public static void setup(IPcre2 api) {
         if (api == null) {
@@ -47,9 +99,10 @@ public final class Pcre4j {
     }
 
     /**
-     * Get the API.
+     * Return the global {@link IPcre2} backend previously installed via {@link #setup(IPcre2)}.
      *
-     * @return the API
+     * @return the active backend instance
+     * @throws IllegalStateException if {@link #setup(IPcre2)} has not been called yet
      */
     public static IPcre2 api() {
         synchronized (lock) {


### PR DESCRIPTION
## Summary

- Added comprehensive Javadoc to `Pcre4j` class covering initialization, thread safety, and multi-classloader behavior
- Enhanced `setup()` and `api()` method Javadoc with parameter constraints and cross-references
- Added a "Library Initialization" section to the README explaining the singleton pattern, replaceability, explicit-API overloads, and multi-classloader considerations

Closes #362

## Test plan

- [x] `checkstyleMain` passes
- [ ] CI build passes (documentation-only changes, no behavioral changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)