### PR TITLE
(chore) regex: document Pattern resource lifecycle (not AutoCloseable)

### DIFF
--- a/regex/src/main/java/org/pcre4j/regex/Matcher.java
+++ b/regex/src/main/java/org/pcre4j/regex/Matcher.java
@@ -28,7 +28,17 @@ import java.util.stream.Stream;
 
 /**
  * Performs match operations on a character sequence by interpreting a {@link Pattern} using the PCRE library yet aims
- * to have a {@link java.util.regex.Matcher}-alike API
+ * to have a {@link java.util.regex.Matcher}-alike API.
+ *
+ * <h2>Resource Lifecycle</h2>
+ *
+ * <p>Each {@code Matcher} instance holds native PCRE2 resources (a match context and, when JIT
+ * compilation is active, a JIT stack). Like {@link java.util.regex.Matcher}, this class does
+ * <strong>not</strong> implement {@link AutoCloseable}. The native resources are automatically
+ * released by a {@link java.lang.ref.Cleaner} when the {@code Matcher} becomes unreachable.</p>
+ *
+ * <p>A {@code Matcher} is created via {@link Pattern#matcher(CharSequence)} and is not safe for
+ * use by multiple concurrent threads.</p>
  */
 public class Matcher implements java.util.regex.MatchResult {
 

--- a/regex/src/main/java/org/pcre4j/regex/Pattern.java
+++ b/regex/src/main/java/org/pcre4j/regex/Pattern.java
@@ -30,6 +30,21 @@ import java.util.stream.Stream;
 /**
  * A compiled representation of a regular expression that uses the PCRE library yet aims to have a
  * {@link java.util.regex.Pattern}-alike API.
+ *
+ * <h2>Resource Lifecycle</h2>
+ *
+ * <p>Each {@code Pattern} instance holds one or more native PCRE2 compiled pattern handles
+ * (via {@link Pcre2Code}). These native resources are <strong>not</strong> managed through
+ * {@link AutoCloseable}; instead, they are automatically released by a {@link java.lang.ref.Cleaner}
+ * when the {@code Pattern} becomes unreachable. This mirrors the lifecycle model of
+ * {@link java.util.regex.Pattern}, which also does not implement {@link AutoCloseable}.</p>
+ *
+ * <p>Patterns are designed to be compiled once and reused across many {@link Matcher} instances.
+ * There is no {@code close()} method and no need for try-with-resources.</p>
+ *
+ * <p><strong>Note:</strong> Because native memory is reclaimed during garbage collection rather
+ * than deterministically, applications that compile a very large number of short-lived patterns
+ * may observe higher native memory usage until the garbage collector runs.</p>
  */
 public class Pattern {
 


### PR DESCRIPTION
## Summary

- Add JavaDoc resource lifecycle documentation to `Pattern` explaining that native PCRE2 handles are released via `java.lang.ref.Cleaner` (not `AutoCloseable`), mirroring `java.util.regex.Pattern` behavior
- Add corresponding resource lifecycle documentation to `Matcher` covering its match context and JIT stack resources
- Note for users about native memory behavior when compiling many short-lived patterns

Closes #351

## Test plan

- [x] `checkstyleMain` passes — no line length or formatting violations
- [ ] CI passes (docs-only change, no behavioral changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)