### PR TITLE
(docs) lib: add class-level JavaDoc to undocumented public classes

### DIFF
--- a/lib/src/main/java/org/pcre4j/Pcre2CompileContext.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2CompileContext.java
@@ -19,6 +19,9 @@ import org.pcre4j.api.IPcre2;
 import java.lang.ref.Cleaner;
 import java.util.EnumSet;
 
+/**
+ * A compile context for controlling pattern compilation settings.
+ */
 public class Pcre2CompileContext {
 
     /**

--- a/lib/src/main/java/org/pcre4j/Pcre2CompileError.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2CompileError.java
@@ -14,6 +14,9 @@
  */
 package org.pcre4j;
 
+/**
+ * An error that occurs when a pattern fails to compile.
+ */
 public class Pcre2CompileError extends IllegalArgumentException {
 
     /**

--- a/lib/src/main/java/org/pcre4j/Pcre2CompileOption.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2CompileOption.java
@@ -19,6 +19,9 @@ import org.pcre4j.api.IPcre2;
 import java.util.Arrays;
 import java.util.Optional;
 
+/**
+ * Compile options for {@link Pcre2Code}
+ */
 public enum Pcre2CompileOption {
     /**
      * Force pattern anchoring

--- a/lib/src/main/java/org/pcre4j/Pcre2GeneralContext.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2GeneralContext.java
@@ -18,6 +18,9 @@ import org.pcre4j.api.IPcre2;
 
 import java.lang.ref.Cleaner;
 
+/**
+ * A general context for custom memory management functions.
+ */
 public class Pcre2GeneralContext {
 
     /**

--- a/lib/src/main/java/org/pcre4j/Pcre2JitOption.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2JitOption.java
@@ -19,6 +19,9 @@ import org.pcre4j.api.IPcre2;
 import java.util.Arrays;
 import java.util.Optional;
 
+/**
+ * JIT compilation options for {@link Pcre2JitCode}
+ */
 public enum Pcre2JitOption {
     /**
      * Compile code for full matching

--- a/lib/src/main/java/org/pcre4j/Pcre2JitStack.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2JitStack.java
@@ -18,6 +18,9 @@ import org.pcre4j.api.IPcre2;
 
 import java.lang.ref.Cleaner;
 
+/**
+ * A custom stack for JIT-compiled pattern matching.
+ */
 public class Pcre2JitStack {
 
     /**

--- a/lib/src/main/java/org/pcre4j/Pcre2MatchContext.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2MatchContext.java
@@ -18,6 +18,9 @@ import org.pcre4j.api.IPcre2;
 
 import java.lang.ref.Cleaner;
 
+/**
+ * A match context for controlling pattern matching settings.
+ */
 public class Pcre2MatchContext {
 
     /**

--- a/lib/src/main/java/org/pcre4j/Pcre2Newline.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2Newline.java
@@ -19,6 +19,9 @@ import org.pcre4j.api.IPcre2;
 import java.util.Arrays;
 import java.util.Optional;
 
+/**
+ * The newline convention.
+ */
 public enum Pcre2Newline {
     /**
      * Carriage return only (\r)

--- a/lib/src/main/java/org/pcre4j/Pcre2PatternInfo.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2PatternInfo.java
@@ -19,6 +19,9 @@ import org.pcre4j.api.IPcre2;
 import java.util.Arrays;
 import java.util.Optional;
 
+/**
+ * Pattern information codes for {@link Pcre2Code} introspection.
+ */
 public enum Pcre2PatternInfo {
     /**
      * Final options after compiling

--- a/lib/src/main/java/org/pcre4j/Pcre2PatternInfoSizeError.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2PatternInfoSizeError.java
@@ -14,6 +14,9 @@
  */
 package org.pcre4j;
 
+/**
+ * An error indicating an unexpected data size for a {@link Pcre2PatternInfo} query.
+ */
 public class Pcre2PatternInfoSizeError extends RuntimeException {
 
     public Pcre2PatternInfoSizeError(Pcre2PatternInfo info, long size) {

--- a/lib/src/main/java/org/pcre4j/Pcre4jUtils.java
+++ b/lib/src/main/java/org/pcre4j/Pcre4jUtils.java
@@ -24,6 +24,9 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Static utility methods for PCRE2 configuration queries, error message retrieval, and match result processing.
+ */
 public final class Pcre4jUtils {
 
     /**


### PR DESCRIPTION
## Summary
- Add class-level JavaDoc comments to 11 public classes and enums in the `lib` module that were missing them: `Pcre2CompileContext`, `Pcre2CompileError`, `Pcre2CompileOption`, `Pcre2GeneralContext`, `Pcre2JitOption`, `Pcre2JitStack`, `Pcre2MatchContext`, `Pcre2Newline`, `Pcre2PatternInfo`, `Pcre2PatternInfoSizeError`, and `Pcre4jUtils`
- Follows the existing JavaDoc style established by documented classes in the same module

## Test plan
- [x] `checkstyleMain` passes
- [x] `javadoc` generates without new warnings
- [x] Full `build` passes with all tests green

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)