### PR TITLE
(feat) ci: add SAST and dependency vulnerability scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,15 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "(chore) deps:"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "(chore) ci:"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 8 * * 1' # Weekly Monday 08:00 UTC
+
+permissions: {}
+
+jobs:
+
+  analyze:
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+      security-events: write
+
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v4
+
+      - name: Set up temurin-jdk-21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@f5c2471be782132e47a6e6f9c725e56730d6e9a3 # v3
+        with:
+          languages: java-kotlin
+          build-mode: autobuild
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@f5c2471be782132e47a6e6f9c725e56730d6e9a3 # v3
+        with:
+          category: "/language:java-kotlin"


### PR DESCRIPTION
## Summary

- Add CodeQL SAST workflow for Java/Kotlin static analysis (runs on push to main, PRs, and weekly schedule)
- Enhance Dependabot configuration with PR limits (`open-pull-requests-limit: 5`) and `dependencies` labels
- All actions SHA-pinned consistent with existing CI conventions

Fixes #294

## Test plan

- [ ] CodeQL workflow runs successfully on this PR
- [ ] Dependabot config is valid (no syntax errors in YAML)
- [ ] Existing CI jobs remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)