### PR TITLE
(docs) arch: create Architecture Decision Records for key decisions

### DIFF
--- a/docs/adr/0002-backend-strategy-pattern-with-global-singleton.md
+++ b/docs/adr/0002-backend-strategy-pattern-with-global-singleton.md
@@ -1,0 +1,47 @@
+# ADR-0002: Backend Strategy Pattern with Global Singleton
+
+## Status
+
+Accepted
+
+## Context
+
+PCRE4J needs to support multiple native library backends (JNA and FFM) through a single API. The
+`IPcre2` interface in the `api` module defines the backend contract — a set of ~60 methods that map
+directly to PCRE2 C functions, operating on opaque `long` handles for native resources.
+
+Applications need a way to select which backend to use. Two competing concerns arise:
+
+1. **Convenience**: Most applications use a single backend throughout their lifecycle. Requiring
+   an `IPcre2` parameter on every API call adds unnecessary boilerplate.
+2. **Flexibility**: Some environments (tests, multi-classloader containers) need to work with
+   multiple backends simultaneously or swap them at runtime.
+
+## Decision
+
+We use a **global singleton with explicit-API escape hatches**:
+
+- `Pcre4j` holds a single `IPcre2` instance, set once via `Pcre4j.setup(IPcre2)` and retrieved via
+  `Pcre4j.api()`. Both methods are synchronized.
+- Convenience constructors (e.g. `Pcre2Code(String)`, `Pattern.compile(String)`) delegate to
+  `Pcre4j.api()` internally.
+- Every convenience constructor has an explicit-API overload that accepts an `IPcre2` parameter
+  directly (e.g. `Pcre2Code(IPcre2, String)`, `Pattern.compile(IPcre2, String)`), bypassing the
+  global singleton entirely.
+- Each `Pcre2Code` (and other wrapper objects) captures the `IPcre2` reference at construction
+  time, so replacing the global backend later does not affect existing instances.
+
+The singleton validates at setup time that the backend supports UTF-8 via
+`Pcre4jUtils.getCompiledWidths()`.
+
+## Consequences
+
+- Applications call `Pcre4j.setup(new org.pcre4j.jna.Pcre2())` once at startup and then use the
+  convenience API without passing backend references.
+- Calling `Pcre4j.api()` before `setup()` throws `IllegalStateException`, making misconfiguration
+  obvious.
+- Tests and multi-backend scenarios use the explicit-API overloads and never depend on global state.
+- In multi-classloader environments (application servers, OSGi), each classloader gets its own
+  `Pcre4j` class and must call `setup()` independently.
+- The `api` module has no dependency on `lib` — backends implement `IPcre2` without knowing about
+  the singleton.

--- a/docs/adr/0003-cleaner-based-resource-management.md
+++ b/docs/adr/0003-cleaner-based-resource-management.md
@@ -1,0 +1,54 @@
+# ADR-0003: Cleaner-based Resource Management
+
+## Status
+
+Accepted
+
+## Context
+
+PCRE4J wraps native PCRE2 resources — compiled patterns (`pcre2_code`), match data blocks
+(`pcre2_match_data`), and various contexts (`pcre2_compile_context`, `pcre2_match_context`,
+`pcre2_general_context`, `pcre2_convert_context`). Each of these is allocated by PCRE2 and must be
+explicitly freed via the corresponding `*_free()` function. Failing to free them leaks native memory
+that the JVM garbage collector cannot reclaim.
+
+Java offers two standard patterns for deterministic resource cleanup:
+
+1. **`Closeable`/`AutoCloseable` with try-with-resources**: Caller explicitly manages lifecycle.
+   Straightforward, but forces every usage site into a try-with-resources block and makes it easy to
+   leak resources if the caller forgets to close.
+2. **`java.lang.ref.Cleaner`**: GC-driven cleanup. Resources are freed automatically when the
+   wrapper object becomes unreachable. No caller action required, but cleanup timing is
+   non-deterministic.
+
+## Decision
+
+We use `java.lang.ref.Cleaner` for all native resource wrappers. A single shared `Cleaner` instance
+(`Pcre4jCleaner.INSTANCE`) serves the entire library, reducing daemon thread overhead to one thread
+total.
+
+Each wrapper class (e.g. `Pcre2Code`, `Pcre2MatchData`, `Pcre2MatchContext`) follows the same
+pattern:
+
+1. The constructor allocates the native resource via `IPcre2` and stores the returned `long` handle.
+2. It registers a `Cleaner.Cleanable` with a static inner `Clean` record that captures only the
+   `IPcre2` reference and the `long` handle — never the wrapper object itself (to avoid preventing
+   GC).
+3. The `Clean` record implements `Runnable.run()` to call the appropriate `*_free()` method.
+
+The wrapper classes do **not** implement `Closeable` or `AutoCloseable`.
+
+## Consequences
+
+- Callers never need to manage native resource lifecycle explicitly — no try-with-resources blocks
+  required for PCRE4J objects.
+- The `regex` module's `Pattern` and `Matcher` classes can hold `Pcre2Code` and `Pcre2MatchData`
+  references with the same lifecycle semantics as `java.util.regex`, where patterns and matchers are
+  not closeable either.
+- Native memory cleanup is non-deterministic. Under heavy allocation without GC, native memory
+  pressure may build up before the cleaner runs. In practice, PCRE2 resource sizes are small enough
+  that this is not a concern.
+- All `Clean` records are static inner types that hold only primitive handles and the `IPcre2`
+  reference — they never capture a reference to the enclosing wrapper, ensuring the cleaner does not
+  prevent garbage collection.
+- A single daemon thread handles all cleanup, rather than one per wrapper class.

--- a/docs/adr/0004-multi-release-jar-for-ffm.md
+++ b/docs/adr/0004-multi-release-jar-for-ffm.md
@@ -1,0 +1,54 @@
+# ADR-0004: Multi-Release JAR for FFM Preview/GA
+
+## Status
+
+Accepted
+
+## Context
+
+The Foreign Function & Memory (FFM) API is the preferred approach for calling native code from Java
+without JNI. However, the FFM API went through breaking changes between Java versions:
+
+- **Java 21 (LTS)**: FFM is a third preview (JEP 442). Methods like `Arena.allocateArray()` and
+  `MemorySegment.getUtf8String()` are used for allocation and string handling. Code must be compiled
+  and run with `--enable-preview`.
+- **Java 22+**: FFM is finalized (JEP 454). The API changed: `Arena.allocate()` replaces
+  `allocateArray()`, `Arena.allocateFrom()` replaces `allocateArray()` for initialized data, and
+  `MemorySegment.getString()` replaces `getUtf8String()`.
+
+PCRE4J targets Java 21 as its minimum version (current LTS), but must also work correctly on
+Java 22+ without requiring `--enable-preview`.
+
+## Decision
+
+We use a **Multi-Release JAR** (JEP 238) for the `ffm` module:
+
+- **Base (Java 21)**: The main source set contains `Pcre2.java` (the full `IPcre2` implementation
+  using FFM `MethodHandle` invocations) and `ArenaHelper.java` (a thin adapter that wraps the
+  preview API methods). Compiled with `--enable-preview`.
+- **Java 22 overlay**: A separate `java22` source set at `src/main/java22/` contains only
+  `ArenaHelper.java`, rewritten to use the finalized FFM API. Compiled with a Java 22 toolchain
+  and no preview flags. Packaged into `META-INF/versions/22/` in the JAR.
+- **Shared logic**: `Pcre2.java` is identical across both versions. All version-specific API
+  differences are isolated in `ArenaHelper`, which provides static methods for allocation and
+  string operations. The Java 22 source set compiles against a copy of `Pcre2.java` from the main
+  source to satisfy compile-time references.
+
+The JAR manifest includes `Multi-Release: true`, and the JVM automatically selects the Java 22
+`ArenaHelper` when running on Java 22+.
+
+Testing runs on both Java versions:
+- The default `test` task runs with Java 21 and `--enable-preview`.
+- A separate `testJava22` task uses a Java 22 toolchain and runs against the packaged MRJAR to
+  verify that the Java 22 overlay is selected correctly.
+
+## Consequences
+
+- A single `pcre4j-ffm` artifact works on both Java 21 (preview) and Java 22+ (GA) without any
+  user configuration.
+- The API difference surface is small — five methods in `ArenaHelper` — making the MRJAR overlay
+  easy to maintain.
+- `Pcre2.java` is never duplicated; only the thin `ArenaHelper` adapter varies.
+- Users on Java 21 must add `--enable-preview` to their JVM flags; users on Java 22+ do not.
+- When Java 21 reaches end of life, the base source set can be updated to the GA API and the
+  `java22` overlay removed.

--- a/docs/adr/0005-contract-testing-via-shared-test-fixtures.md
+++ b/docs/adr/0005-contract-testing-via-shared-test-fixtures.md
@@ -1,0 +1,54 @@
+# ADR-0005: Contract Testing via Shared Test Fixtures
+
+## Status
+
+Accepted
+
+## Context
+
+PCRE4J has two backend implementations (JNA and FFM) that both implement the `IPcre2` interface.
+Every backend must behave identically — the same pattern compiled and matched through JNA must
+produce the same results as through FFM. Without shared tests, each backend would maintain its own
+copy of test cases, and behavioral differences would go undetected.
+
+The challenge is structural: `lib` defines the wrapper API and should own the contract tests, but
+`lib` has no compile-time dependency on the backends. The backends depend on `lib`, not the other
+way around.
+
+## Decision
+
+We use **Gradle test fixtures** (`java-test-fixtures` plugin) in the `lib` module to publish shared
+test infrastructure that both backend modules consume:
+
+- `lib/src/testFixtures/` contains:
+  - `BackendProvider` — a utility that reflectively loads `IPcre2` implementations by class name
+    (`org.pcre4j.jna.Pcre2`, `org.pcre4j.ffm.Pcre2`) and exposes them as JUnit 5
+    `@MethodSource` arguments.
+  - `Pcre2Tests` — an abstract base class that implements multiple contract test interfaces (e.g.
+    `Pcre2ConfigurationContractTest`, `Pcre2MatchingContractTest`, `Pcre2SubstitutionContractTest`,
+    and others). Each interface covers a specific PCRE2 functional area.
+  - Individual contract test interfaces containing the actual `@ParameterizedTest` methods.
+
+- Backend modules (`jna`, `ffm`) declare `testImplementation(testFixtures(project(":lib")))` and
+  extend `Pcre2Tests` with a concrete subclass that implements `createApi()` for their specific
+  backend.
+
+- `lib` itself declares `jna` and `ffm` as `testRuntimeOnly` dependencies so it can run the same
+  contract tests against both backends via `BackendProvider` (see ADR-0001 for the test-time
+  circular awareness this creates).
+
+Backend discovery is reflective (`Class.forName()`) so that `lib`'s test fixtures have no
+compile-time coupling to any backend implementation.
+
+## Consequences
+
+- A single set of contract tests verifies both backends identically. Adding a test to any contract
+  interface automatically runs it against JNA and FFM.
+- Adding a new backend requires: implementing `IPcre2`, extending `Pcre2Tests`, and registering the
+  class name in `BackendProvider`.
+- Backend class name changes cause runtime test failures rather than compile-time errors, due to
+  the reflective loading strategy.
+- Test fixtures are published as a separate artifact (`pcre4j-lib-test-fixtures`), making them
+  available to third-party backend implementations.
+- The contract test interfaces provide fine-grained test organization by PCRE2 functional area,
+  while `Pcre2Tests` composes them into a single runnable suite per backend.

--- a/docs/adr/0006-three-pattern-compilation-in-regex-module.md
+++ b/docs/adr/0006-three-pattern-compilation-in-regex-module.md
@@ -1,0 +1,54 @@
+# ADR-0006: Three-Pattern Compilation in Regex Module
+
+## Status
+
+Accepted
+
+## Context
+
+The `regex` module provides a `java.util.regex`-compatible API (`Pattern` and `Matcher`). The
+`java.util.regex.Matcher` class defines three matching operations with distinct semantics:
+
+- **`find()`**: Searches for the next occurrence of the pattern anywhere in the input.
+- **`matches()`**: Tests whether the entire input matches the pattern.
+- **`lookingAt()`**: Tests whether the input matches the pattern starting from the beginning.
+
+PCRE2 does not have direct equivalents for `matches()` and `lookingAt()`. It provides compile-time
+options `ANCHORED` (pattern must match at the start) and `ENDANCHORED` (match must extend to the
+end of the subject) that can be combined to achieve the same effect. However, these options must be
+set at pattern compile time, not at match time.
+
+When JIT compilation is enabled, PCRE2 compiles a pattern into optimized machine code for the
+specific combination of options it was compiled with. A pattern compiled without `ANCHORED` cannot
+benefit from JIT when used for anchored matching at match time — the JIT code path is bypassed
+entirely.
+
+## Decision
+
+The `Pattern` class maintains up to three independently compiled `Pcre2Code` instances:
+
+1. **`code`** (primary): Compiled during construction with the user-specified options. Used for
+   `find()` operations.
+2. **`matchingCode`**: Compiled lazily with the original options plus `ANCHORED` and `ENDANCHORED`.
+   Used for `matches()` operations. Only created when JIT is enabled.
+3. **`lookingAtCode`**: Compiled lazily with the original options plus `ANCHORED`. Used for
+   `lookingAt()` operations. Only created when JIT is enabled.
+
+Lazy compilation uses double-checked locking with `volatile` fields to ensure thread safety without
+synchronizing on every access.
+
+When JIT is not enabled, the specialized patterns are not created. Instead, `matches()` and
+`lookingAt()` pass the anchoring options at match time via `Pcre2MatchOption`, which is sufficient
+for the non-JIT interpreter path.
+
+## Consequences
+
+- `matches()` and `lookingAt()` achieve full JIT optimization by using patterns compiled with the
+  correct anchoring options upfront.
+- Memory overhead is deferred — the specialized patterns are only compiled when first needed.
+  Applications that only use `find()` never allocate the extra patterns.
+- Each `Pattern` instance may hold up to three native PCRE2 compiled patterns, tripling the native
+  memory cost in the worst case. In practice, the compiled pattern size is small relative to
+  application memory.
+- The lazy compilation pattern adds some code complexity but is a well-understood Java idiom.
+- Non-JIT mode avoids the extra compilations entirely by passing options at match time.

--- a/docs/adr/0007-redos-protection-via-match-limits.md
+++ b/docs/adr/0007-redos-protection-via-match-limits.md
@@ -1,0 +1,59 @@
+# ADR-0007: ReDoS Protection via Match Limits
+
+## Status
+
+Accepted
+
+## Context
+
+Regular Expression Denial of Service (ReDoS) occurs when a crafted input causes a regex engine to
+backtrack exponentially, consuming CPU time and memory. PCRE2 provides three resource limits that
+can be set on a match context to terminate runaway matches early:
+
+- **Match limit**: Caps the total number of calls to the internal `match()` function during
+  backtracking.
+- **Depth limit**: Caps the maximum recursion/backtracking depth.
+- **Heap limit**: Caps the amount of heap memory (in kibibytes) that PCRE2 may allocate during
+  a match.
+
+Without explicit limits, PCRE2 uses compile-time defaults that may be too generous for
+security-sensitive applications.
+
+## Decision
+
+Resource limits are exposed at two levels:
+
+**Mid-level API (`lib` module)**: `Pcre2MatchContext` provides `setMatchLimit(int)`,
+`setDepthLimit(int)`, and `setHeapLimit(int)` methods that delegate directly to the corresponding
+PCRE2 API calls. This gives callers fine-grained, per-match-context control over limits.
+
+**High-level API (`regex` module)**: The `Matcher` class reads default limits from system
+properties at match context creation time:
+
+- `pcre2.regex.match.limit` — maximum number of match function calls
+- `pcre2.regex.depth.limit` — maximum backtracking depth
+- `pcre2.regex.heap.limit` — maximum heap memory in kibibytes
+
+When any limit is exceeded, PCRE2 returns a specific error code. The `regex` module translates
+these into a `MatchLimitException` (a `RuntimeException`) that carries the PCRE2 error code,
+allowing callers to distinguish which limit was exceeded via `getErrorCode()`:
+
+- `IPcre2.ERROR_MATCHLIMIT`
+- `IPcre2.ERROR_DEPTHLIMIT`
+- `IPcre2.ERROR_HEAPLIMIT`
+
+System properties are optional. When not set, PCRE2's compiled-in defaults apply.
+
+## Consequences
+
+- Applications can protect against ReDoS at the JVM level by setting system properties, without
+  any code changes.
+- The mid-level API allows per-context limit tuning for applications that need different limits for
+  different patterns or use cases.
+- `MatchLimitException` is an unchecked exception, consistent with `java.util.regex`'s approach of
+  using unchecked exceptions for regex errors. Callers who need to handle limit violations can
+  catch it; others get a clear error message.
+- The system property approach means limits are set globally for the `regex` module. Applications
+  needing per-pattern limits should use the mid-level `Pcre2MatchContext` API directly.
+- When limits are set too aggressively, legitimate complex patterns may fail to match. The error
+  code in `MatchLimitException` helps diagnose which limit needs adjustment.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,18 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for the PCRE4J project.
+
+ADRs document significant architectural decisions, their context, and consequences. They follow the
+format: Status, Context, Decision, Consequences.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-test-time-circular-awareness-in-lib-module.md) | Test-Time Circular Awareness in lib Module | Accepted |
+| [0002](0002-backend-strategy-pattern-with-global-singleton.md) | Backend Strategy Pattern with Global Singleton | Accepted |
+| [0003](0003-cleaner-based-resource-management.md) | Cleaner-based Resource Management | Accepted |
+| [0004](0004-multi-release-jar-for-ffm.md) | Multi-Release JAR for FFM Preview/GA | Accepted |
+| [0005](0005-contract-testing-via-shared-test-fixtures.md) | Contract Testing via Shared Test Fixtures | Accepted |
+| [0006](0006-three-pattern-compilation-in-regex-module.md) | Three-Pattern Compilation in Regex Module | Accepted |
+| [0007](0007-redos-protection-via-match-limits.md) | ReDoS Protection via Match Limits | Accepted |


### PR DESCRIPTION
## Summary

- Create ADRs documenting six key architectural decisions: backend strategy pattern (ADR-0002), Cleaner-based resource management (ADR-0003), Multi-Release JAR for FFM (ADR-0004), contract testing via shared test fixtures (ADR-0005), three-pattern compilation in regex module (ADR-0006), and ReDoS protection via match limits (ADR-0007)
- Add ADR index (README.md) listing all seven ADRs including the pre-existing ADR-0001
- Each ADR follows the established format (Status, Context, Decision, Consequences) from ADR-0001

Fixes #365

## Test plan

- [x] Verify all ADR files are valid Markdown
- [x] Verify README.md links point to correct files
- [x] Verify no code changes (documentation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)