### PR TITLE
(feat) api: add JPMS module-info.java descriptors

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2024 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * PCRE4J Backend API — defines the contract that PCRE2 backend implementations must fulfill.
+ *
+ * <p>This module exports the {@link org.pcre4j.api.IPcre2} interface and supporting types
+ * used by both the JNA and FFM backends.</p>
+ */
+module org.pcre4j.api {
+    requires java.logging;
+
+    exports org.pcre4j.api;
+}

--- a/ffm/src/main/java/module-info.java
+++ b/ffm/src/main/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * PCRE4J FFM Backend — {@link org.pcre4j.api.IPcre2} implementation using the
+ * Foreign Function {@literal &} Memory API.
+ *
+ * <p>This module is packaged as a Multi-Release JAR: the base targets Java 21
+ * (FFM as a preview feature) while the Java 22+ overlay uses the finalized API.</p>
+ */
+module org.pcre4j.ffm {
+    requires org.pcre4j.api;
+
+    exports org.pcre4j.ffm;
+}

--- a/jna/src/main/java/module-info.java
+++ b/jna/src/main/java/module-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * PCRE4J JNA Backend — {@link org.pcre4j.api.IPcre2} implementation using Java Native Access.
+ */
+module org.pcre4j.jna {
+    requires org.pcre4j.api;
+    requires com.sun.jna;
+
+    exports org.pcre4j.jna;
+}

--- a/lib/src/main/java/module-info.java
+++ b/lib/src/main/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * PCRE4J Library — mid-level wrapper around the PCRE2 API providing compiled patterns,
+ * match data, contexts, and utility classes.
+ *
+ * <p>This module re-exports the {@code org.pcre4j.api} module so that consumers of
+ * {@code org.pcre4j} automatically have access to the backend contract types.</p>
+ */
+module org.pcre4j {
+    requires transitive org.pcre4j.api;
+
+    exports org.pcre4j;
+}

--- a/regex/src/main/java/module-info.java
+++ b/regex/src/main/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * PCRE4J Regex — a {@link java.util.regex.Pattern}-compatible API backed by PCRE2.
+ *
+ * <p>This module re-exports {@code org.pcre4j.api} and {@code org.pcre4j} so that consumers
+ * can access backend and wrapper types without additional dependency declarations.</p>
+ */
+module org.pcre4j.regex {
+    requires transitive org.pcre4j.api;
+    requires transitive org.pcre4j;
+
+    exports org.pcre4j.regex;
+}


### PR DESCRIPTION
## Summary

- Add `module-info.java` descriptors to all five modules (`api`, `lib`, `jna`, `ffm`, `regex`), enabling JPMS (Java Platform Module System) support
- Module names follow the established package naming: `org.pcre4j.api`, `org.pcre4j`, `org.pcre4j.jna`, `org.pcre4j.ffm`, `org.pcre4j.regex`
- Uses `requires transitive` where public API exposes types from dependencies (`lib` → `api`, `regex` → `api` + `lib`)

## Design Decisions

- **`org.pcre4j.api`**: Requires `java.logging` (used by `Pcre2LibraryFinder`)
- **`org.pcre4j`** (lib): `requires transitive org.pcre4j.api` since its public API exposes `IPcre2` types
- **`org.pcre4j.jna`**: `requires com.sun.jna` (JNA's declared automatic module name)
- **`org.pcre4j.ffm`**: No special requirements beyond `org.pcre4j.api` — `java.lang.foreign` is in `java.base`. The `module-info.java` is in the base source set only; MRJAR overlays do not need separate descriptors
- **`org.pcre4j.regex`**: `requires transitive` for both `api` and `lib` so consumers get full access

## Backwards Compatibility

Adding `module-info.java` is backwards-compatible — JARs with module descriptors work on both the classpath (as before) and the module path (new JPMS support).

## Test Plan

- [x] `./gradlew build` passes (all modules compile and tests pass)
- [x] `./gradlew checkstyleMain` passes
- [x] FFM MRJAR Java 22 compilation works
- [ ] CI passes

Fixes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)