### PR TITLE
(chore) test: cover remaining hard-to-reach error paths across all modules

### DIFF
--- a/lib/src/test/java/org/pcre4j/Pcre2ErrorClassTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2ErrorClassTests.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for error/exception class edge cases across the lib module.
+ */
+public class Pcre2ErrorClassTests {
+
+    // === Pcre2CompileError getPatternRegion edge cases ===
+
+    @Test
+    void compileErrorShortPatternNoEllipsis() {
+        // Pattern shorter than region size: no ellipsis on either side
+        var error = new Pcre2CompileError("ab", 1, "test error");
+        var message = error.getMessage();
+        assertTrue(message.contains("\"ab\""), "Short pattern should appear without ellipsis: " + message);
+    }
+
+    @Test
+    void compileErrorAtStartNoLeadingEllipsis() {
+        // Error at offset 0: no leading ellipsis, may have trailing ellipsis
+        var error = new Pcre2CompileError("abcdefghij", 0, "test error");
+        var message = error.getMessage();
+        // Region is pattern[0..3] = "abc", no leading ellipsis
+        assertTrue(
+                message.contains("\"abc\u2026\""),
+                "Start of long pattern should have trailing ellipsis only: " + message
+        );
+    }
+
+    @Test
+    void compileErrorAtEndNoTrailingEllipsis() {
+        // Error at the last character: no trailing ellipsis, may have leading ellipsis
+        var error = new Pcre2CompileError("abcdefghij", 9, "test error");
+        var message = error.getMessage();
+        // Region is pattern[6..10] = "ghij", with leading ellipsis
+        assertTrue(
+                message.contains("\"\u2026ghij\""),
+                "End of long pattern should have leading ellipsis only: " + message
+        );
+    }
+
+    @Test
+    void compileErrorMiddleBothEllipsis() {
+        // Error in the middle of a long pattern: both leading and trailing ellipsis
+        var error = new Pcre2CompileError("abcdefghijklmnop", 8, "test error");
+        var message = error.getMessage();
+        // Region is pattern[5..11] = "fghijk", with ellipsis on both sides
+        assertTrue(message.contains("\u2026"), "Middle of long pattern should have ellipsis: " + message);
+    }
+
+    @Test
+    void compileErrorEmptyPattern() {
+        // Edge case: empty pattern
+        var error = new Pcre2CompileError("", 0, "test error");
+        var message = error.getMessage();
+        assertTrue(message.contains("\"\""), "Empty pattern should produce empty quoted region: " + message);
+    }
+
+    @Test
+    void compileErrorSingleCharPattern() {
+        var error = new Pcre2CompileError("?", 0, "test error");
+        assertEquals("?", error.pattern());
+        assertEquals(0, error.offset());
+        assertEquals("test error", error.message());
+    }
+
+    @Test
+    void compileErrorExactlyRegionSizePattern() {
+        // Pattern of exactly 2*PATTERN_REGION_SIZE (6 chars) with error in the middle
+        var error = new Pcre2CompileError("abcdef", 3, "test error");
+        var message = error.getMessage();
+        // Region is [0..6] = entire pattern, no ellipsis
+        assertTrue(message.contains("\"abcdef\""), "Pattern at region size should have no ellipsis: " + message);
+    }
+
+    @Test
+    void compileErrorMessageFormat() {
+        var error = new Pcre2CompileError("test", 2, "some error");
+        assertEquals("Error in pattern at 2 \"test\": some error", error.getMessage());
+    }
+
+    // === Pcre2CompileError hierarchy and cause chain ===
+
+    @Test
+    void compileErrorIsIllegalArgumentException() {
+        var error = new Pcre2CompileError("test", 0, "error");
+        assertInstanceOf(IllegalArgumentException.class, error);
+    }
+
+    @Test
+    void compileErrorCauseIsNullWhenNotProvided() {
+        var error = new Pcre2CompileError("test", 0, "error");
+        assertNull(error.getCause());
+    }
+
+    @Test
+    void compileErrorCauseIsSetWhenProvided() {
+        var cause = new RuntimeException("underlying");
+        var error = new Pcre2CompileError("test", 0, "error", cause);
+        assertEquals(cause, error.getCause());
+    }
+
+    @Test
+    void compileErrorNullCauseMatchesSingleArgConstructor() {
+        var single = new Pcre2CompileError("test", 0, "error");
+        var nullCause = new Pcre2CompileError("test", 0, "error", null);
+        assertEquals(single.getMessage(), nullCause.getMessage());
+        assertNull(nullCause.getCause());
+    }
+
+    // === Pcre2SubstituteError edge cases ===
+
+    @Test
+    void substituteErrorIsRuntimeException() {
+        var error = new Pcre2SubstituteError("test");
+        assertInstanceOf(RuntimeException.class, error);
+    }
+
+    @Test
+    void substituteErrorCauseIsNullWhenNotProvided() {
+        var error = new Pcre2SubstituteError("test");
+        assertNull(error.getCause());
+    }
+
+    @Test
+    void substituteErrorNullCauseMatchesSingleArgConstructor() {
+        var single = new Pcre2SubstituteError("test");
+        var nullCause = new Pcre2SubstituteError("test", null);
+        assertEquals(single.getMessage(), nullCause.getMessage());
+        assertNull(nullCause.getCause());
+    }
+
+    @Test
+    void substituteErrorMessageIsSameWithAndWithoutCause() {
+        var without = new Pcre2SubstituteError("error msg");
+        var with = new Pcre2SubstituteError("error msg", new RuntimeException("cause"));
+        assertEquals(without.getMessage(), with.getMessage());
+    }
+
+    // === Pcre2NoSubstringError edge cases ===
+
+    @Test
+    void noSubstringErrorIsRuntimeException() {
+        var error = new Pcre2NoSubstringError("test");
+        assertInstanceOf(RuntimeException.class, error);
+    }
+
+    @Test
+    void noSubstringErrorCauseIsNullWhenNotProvided() {
+        var error = new Pcre2NoSubstringError("test");
+        assertNull(error.getCause());
+    }
+
+    @Test
+    void noSubstringErrorNullCauseMatchesSingleArgConstructor() {
+        var single = new Pcre2NoSubstringError("test");
+        var nullCause = new Pcre2NoSubstringError("test", null);
+        assertEquals(single.getMessage(), nullCause.getMessage());
+        assertNull(nullCause.getCause());
+    }
+
+    @Test
+    void noSubstringErrorMessageIsSameWithAndWithoutCause() {
+        var without = new Pcre2NoSubstringError("error msg");
+        var with = new Pcre2NoSubstringError("error msg", new RuntimeException("cause"));
+        assertEquals(without.getMessage(), with.getMessage());
+    }
+
+    // === Pcre2NoUniqueSubstringError edge cases ===
+
+    @Test
+    void noUniqueSubstringErrorIsRuntimeException() {
+        var error = new Pcre2NoUniqueSubstringError("test");
+        assertInstanceOf(RuntimeException.class, error);
+    }
+
+    @Test
+    void noUniqueSubstringErrorCauseIsNullWhenNotProvided() {
+        var error = new Pcre2NoUniqueSubstringError("test");
+        assertNull(error.getCause());
+    }
+
+    @Test
+    void noUniqueSubstringErrorNullCauseMatchesSingleArgConstructor() {
+        var single = new Pcre2NoUniqueSubstringError("test");
+        var nullCause = new Pcre2NoUniqueSubstringError("test", null);
+        assertEquals(single.getMessage(), nullCause.getMessage());
+        assertNull(nullCause.getCause());
+    }
+
+    @Test
+    void noUniqueSubstringErrorMessageIsSameWithAndWithoutCause() {
+        var without = new Pcre2NoUniqueSubstringError("error msg");
+        var with = new Pcre2NoUniqueSubstringError("error msg", new RuntimeException("cause"));
+        assertEquals(without.getMessage(), with.getMessage());
+    }
+}

--- a/regex/src/test/java/org/pcre4j/regex/MatcherResultsTests.java
+++ b/regex/src/test/java/org/pcre4j/regex/MatcherResultsTests.java
@@ -222,6 +222,52 @@ public class MatcherResultsTests {
 
     @ParameterizedTest
     @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void resultsAfterReset(IPcre2 api) {
+        var regex = "\\w+";
+        var input = "one two three";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        // Consume some matches
+        javaMatcher.find();
+        pcre4jMatcher.find();
+
+        // Reset and verify results() starts from beginning
+        javaMatcher.reset();
+        pcre4jMatcher.reset();
+
+        var javaResults = javaMatcher.results().toList();
+        var pcre4jResults = pcre4jMatcher.results().toList();
+
+        assertEquals(javaResults.size(), pcre4jResults.size());
+        assertEquals(3, pcre4jResults.size());
+        for (int i = 0; i < javaResults.size(); i++) {
+            assertEquals(javaResults.get(i).group(), pcre4jResults.get(i).group());
+            assertEquals(javaResults.get(i).start(), pcre4jResults.get(i).start());
+            assertEquals(javaResults.get(i).end(), pcre4jResults.get(i).end());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void resultsWithNamedGroups(IPcre2 api) {
+        var regex = "(?<word>\\w+)";
+        var input = "hello world";
+        var javaMatcher = java.util.regex.Pattern.compile(regex).matcher(input);
+        var pcre4jMatcher = Pattern.compile(api, regex).matcher(input);
+
+        var javaResults = javaMatcher.results().toList();
+        var pcre4jResults = pcre4jMatcher.results().toList();
+
+        assertEquals(javaResults.size(), pcre4jResults.size());
+        for (int i = 0; i < javaResults.size(); i++) {
+            assertEquals(javaResults.get(i).group(), pcre4jResults.get(i).group());
+            assertEquals(javaResults.get(i).group(1), pcre4jResults.get(i).group(1));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
     void resultsCount(IPcre2 api) {
         var regex = "a";
         var input = "abracadabra";

--- a/regex/src/test/java/org/pcre4j/regex/PatternSplitTests.java
+++ b/regex/src/test/java/org/pcre4j/regex/PatternSplitTests.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j.regex;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.pcre4j.api.IPcre2;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+/**
+ * Edge case tests for {@link Pattern#split(CharSequence)}, {@link Pattern#split(CharSequence, int)},
+ * and {@link Pattern#splitWithDelimiters(CharSequence, int)}.
+ */
+public class PatternSplitTests {
+
+    // --- limit=0 trailing empty strings removal ---
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void splitTrailingEmptyStringsRemovedWithDefaultLimit(IPcre2 api) {
+        // split() with default limit (0) should remove trailing empty strings
+        var javaPattern = java.util.regex.Pattern.compile(",");
+        var pcre4jPattern = Pattern.compile(api, ",");
+        var input = "a,b,c,,,";
+
+        assertArrayEquals(javaPattern.split(input), pcre4jPattern.split(input));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void splitTrailingEmptyStringsRemovedWithZeroLimit(IPcre2 api) {
+        // split(input, 0) should remove trailing empty strings
+        var javaPattern = java.util.regex.Pattern.compile(",");
+        var pcre4jPattern = Pattern.compile(api, ",");
+        var input = "a,b,c,,,";
+
+        assertArrayEquals(javaPattern.split(input, 0), pcre4jPattern.split(input, 0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void splitAllEmptyWithZeroLimit(IPcre2 api) {
+        // Input that results in all empty strings
+        var javaPattern = java.util.regex.Pattern.compile(",");
+        var pcre4jPattern = Pattern.compile(api, ",");
+        var input = ",,,";
+
+        assertArrayEquals(javaPattern.split(input, 0), pcre4jPattern.split(input, 0));
+    }
+
+    // --- Positive limit ---
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void splitPositiveLimitOne(IPcre2 api) {
+        // limit=1 returns the entire input as a single element
+        var javaPattern = java.util.regex.Pattern.compile(",");
+        var pcre4jPattern = Pattern.compile(api, ",");
+        var input = "a,b,c";
+
+        assertArrayEquals(javaPattern.split(input, 1), pcre4jPattern.split(input, 1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void splitPositiveLimitExceedsMatches(IPcre2 api) {
+        // limit greater than number of matches
+        var javaPattern = java.util.regex.Pattern.compile(",");
+        var pcre4jPattern = Pattern.compile(api, ",");
+        var input = "a,b,c";
+
+        assertArrayEquals(javaPattern.split(input, 10), pcre4jPattern.split(input, 10));
+    }
+
+    // --- Empty input and no-match ---
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void splitEmptyInput(IPcre2 api) {
+        var javaPattern = java.util.regex.Pattern.compile(",");
+        var pcre4jPattern = Pattern.compile(api, ",");
+
+        assertArrayEquals(javaPattern.split(""), pcre4jPattern.split(""));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void splitNoMatch(IPcre2 api) {
+        // No delimiter found — returns entire input
+        var javaPattern = java.util.regex.Pattern.compile(",");
+        var pcre4jPattern = Pattern.compile(api, ",");
+        var input = "abc";
+
+        assertArrayEquals(javaPattern.split(input), pcre4jPattern.split(input));
+    }
+
+    // --- splitWithDelimiters edge cases ---
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void splitWithDelimitersTrailingEmpties(IPcre2 api) {
+        var javaPattern = java.util.regex.Pattern.compile(",");
+        var pcre4jPattern = Pattern.compile(api, ",");
+        var input = "a,b,c,,,";
+
+        assertArrayEquals(
+                javaPattern.splitWithDelimiters(input, 0),
+                pcre4jPattern.splitWithDelimiters(input, 0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void splitWithDelimitersPositiveLimit(IPcre2 api) {
+        var javaPattern = java.util.regex.Pattern.compile(",");
+        var pcre4jPattern = Pattern.compile(api, ",");
+        var input = "a,b,c,d";
+
+        assertArrayEquals(
+                javaPattern.splitWithDelimiters(input, 3),
+                pcre4jPattern.splitWithDelimiters(input, 3)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void splitWithDelimitersNoMatch(IPcre2 api) {
+        var javaPattern = java.util.regex.Pattern.compile(",");
+        var pcre4jPattern = Pattern.compile(api, ",");
+        var input = "abc";
+
+        assertArrayEquals(
+                javaPattern.splitWithDelimiters(input, 0),
+                pcre4jPattern.splitWithDelimiters(input, 0)
+        );
+    }
+
+    // --- Regex-based delimiter edge cases ---
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void splitMultiCharDelimiter(IPcre2 api) {
+        var javaPattern = java.util.regex.Pattern.compile("\\s*,\\s*");
+        var pcre4jPattern = Pattern.compile(api, "\\s*,\\s*");
+        var input = "a , b , c";
+
+        assertArrayEquals(javaPattern.split(input), pcre4jPattern.split(input));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void splitDelimiterAtStartAndEnd(IPcre2 api) {
+        var javaPattern = java.util.regex.Pattern.compile(",");
+        var pcre4jPattern = Pattern.compile(api, ",");
+        var input = ",a,b,c,";
+
+        assertArrayEquals(javaPattern.split(input), pcre4jPattern.split(input));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void splitConsecutiveDelimiters(IPcre2 api) {
+        var javaPattern = java.util.regex.Pattern.compile(",");
+        var pcre4jPattern = Pattern.compile(api, ",");
+        var input = "a,,b,,c";
+
+        assertArrayEquals(javaPattern.split(input), pcre4jPattern.split(input));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void splitSingleCharInput(IPcre2 api) {
+        var javaPattern = java.util.regex.Pattern.compile(",");
+        var pcre4jPattern = Pattern.compile(api, ",");
+
+        assertArrayEquals(javaPattern.split(","), pcre4jPattern.split(","));
+    }
+
+    // --- splitAsStream edge cases ---
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void splitAsStreamTrailingEmpties(IPcre2 api) {
+        var javaPattern = java.util.regex.Pattern.compile(",");
+        var pcre4jPattern = Pattern.compile(api, ",");
+        var input = "a,b,c,,,";
+
+        assertArrayEquals(
+                javaPattern.splitAsStream(input).toArray(),
+                pcre4jPattern.splitAsStream(input).toArray()
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void splitAsStreamEmptyInput(IPcre2 api) {
+        var javaPattern = java.util.regex.Pattern.compile(",");
+        var pcre4jPattern = Pattern.compile(api, ",");
+
+        assertArrayEquals(
+                javaPattern.splitAsStream("").toArray(),
+                pcre4jPattern.splitAsStream("").toArray()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add `Pcre2ErrorClassTests` with `getPatternRegion` formatting edge cases (empty pattern, boundary offsets, ellipsis truncation), exception hierarchy checks, and cause chain tests for `Pcre2CompileError`, `Pcre2SubstituteError`, `Pcre2NoSubstringError`, `Pcre2NoUniqueSubstringError`
- Add `PatternSplitTests` with `limit=0` trailing empty string removal, positive limit, empty/no-match input, delimiter-at-boundaries, `splitWithDelimiters`, and `splitAsStream` edge cases
- Add `resultsAfterReset` and `resultsWithNamedGroups` tests to `MatcherResultsTests`

## Test plan

- [x] All new tests pass with both JNA and FFM backends
- [x] Checkstyle passes
- [x] Full build succeeds (`./gradlew build`)

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)