### PR TITLE
(chore) build: expand Checkstyle rules beyond line length

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -10,4 +10,59 @@
         <property name="ignorePattern"
                   value="^package.*|^import.*|href\s*=\s*&quot;[^&quot;]*&quot;|http://|https://|ftp://"/>
     </module>
+
+    <!-- File-level checks -->
+    <module name="NewlineAtEndOfFile"/>
+    <module name="FileTabCharacter"/>
+
+    <!-- Copyright header -->
+    <module name="RegexpHeader">
+        <property name="headerFile" value="${config_loc}/java-header.txt"/>
+        <property name="fileExtensions" value="java"/>
+    </module>
+
+    <!-- JNA backend methods mirror native C function names (pcre2_*) -->
+    <module name="SuppressionSingleFilter">
+        <property name="files" value="jna[/\\].*Pcre2\.java$"/>
+        <property name="checks" value="MethodName"/>
+    </module>
+
+    <!-- Test methods use descriptive underscore-separated naming (method_scenario_expected) -->
+    <module name="SuppressionSingleFilter">
+        <property name="files" value="[/\\]src[/\\](test|testFixtures)[/\\]"/>
+        <property name="checks" value="MethodName"/>
+    </module>
+
+    <module name="TreeWalker">
+        <!-- Import hygiene -->
+        <module name="AvoidStarImport"/>
+        <module name="RedundantImport"/>
+        <module name="UnusedImports"/>
+
+        <!-- Naming conventions -->
+        <module name="TypeName"/>
+        <module name="MethodName"/>
+        <module name="PackageName"/>
+
+        <!-- Whitespace -->
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+            <property name="allowEmptyLoops" value="true"/>
+            <property name="allowEmptyLambdas" value="true"/>
+            <property name="allowEmptyCatches" value="true"/>
+        </module>
+        <module name="NoWhitespaceBefore"/>
+        <module name="GenericWhitespace"/>
+
+        <!-- Indentation -->
+        <module name="Indentation">
+            <property name="basicOffset" value="4"/>
+            <property name="caseIndent" value="4"/>
+            <property name="throwsIndent" value="8"/>
+            <property name="lineWrappingIndentation" value="8"/>
+        </module>
+    </module>
 </module>

--- a/config/checkstyle/java-header.txt
+++ b/config/checkstyle/java-header.txt
@@ -1,0 +1,14 @@
+^/\*$
+^ \* Copyright \(C\) 20\d\d(-20\d\d)? Oleksii PELYKH$
+^ \*$
+^ \* This file is a part of the PCRE4J\. The PCRE4J is free software: you can redistribute it and/or modify it under the$
+^ \* terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the$
+^ \* License, or \(at your option\) any later version\.$
+^ \*$
+^ \* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied$
+^ \* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE\. See the GNU Lesser General Public License for more$
+^ \* details\.$
+^ \*$
+^ \* You should have received a copy of the GNU Lesser General Public License along with this program\. If not, see$
+^ \* <https://www\.gnu\.org/licenses/>\.$
+^ \*/$

--- a/ffm/src/main/java/org/pcre4j/ffm/Pcre2.java
+++ b/ffm/src/main/java/org/pcre4j/ffm/Pcre2.java
@@ -22,7 +22,12 @@ import org.pcre4j.api.Pcre2UtfWidth;
 import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.lang.foreign.*;
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.nio.ByteBuffer;
 

--- a/lib/src/test/java/org/pcre4j/Pcre2CodeSubstituteTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodeSubstituteTests.java
@@ -22,7 +22,6 @@ import java.util.EnumSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**

--- a/lib/src/test/java/org/pcre4j/Pcre2MatchDataTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2MatchDataTests.java
@@ -22,7 +22,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/lib/src/testFixtures/java/org/pcre4j/test/Pcre2UtfWidthContractTest.java
+++ b/lib/src/testFixtures/java/org/pcre4j/test/Pcre2UtfWidthContractTest.java
@@ -18,7 +18,8 @@ import org.junit.jupiter.api.Test;
 import org.pcre4j.api.IPcre2;
 import org.pcre4j.api.Pcre2UtfWidth;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**

--- a/regex/src/main/java/org/pcre4j/regex/Matcher.java
+++ b/regex/src/main/java/org/pcre4j/regex/Matcher.java
@@ -14,7 +14,17 @@
  */
 package org.pcre4j.regex;
 
-import org.pcre4j.*;
+import org.pcre4j.Pcre2Code;
+import org.pcre4j.Pcre2CompileContext;
+import org.pcre4j.Pcre2CompileError;
+import org.pcre4j.Pcre2CompileOption;
+import org.pcre4j.Pcre2JitStack;
+import org.pcre4j.Pcre2MatchContext;
+import org.pcre4j.Pcre2MatchData;
+import org.pcre4j.Pcre2MatchOption;
+import org.pcre4j.Pcre2Newline;
+import org.pcre4j.Pcre2SubstituteOption;
+import org.pcre4j.Pcre4jUtils;
 import org.pcre4j.api.IPcre2;
 
 import java.nio.charset.StandardCharsets;

--- a/regex/src/main/java/org/pcre4j/regex/Pattern.java
+++ b/regex/src/main/java/org/pcre4j/regex/Pattern.java
@@ -14,7 +14,15 @@
  */
 package org.pcre4j.regex;
 
-import org.pcre4j.*;
+import org.pcre4j.Pcre2Code;
+import org.pcre4j.Pcre2CompileContext;
+import org.pcre4j.Pcre2CompileError;
+import org.pcre4j.Pcre2CompileOption;
+import org.pcre4j.Pcre2JitCode;
+import org.pcre4j.Pcre2JitOption;
+import org.pcre4j.Pcre2Newline;
+import org.pcre4j.Pcre4j;
+import org.pcre4j.Pcre4jUtils;
 import org.pcre4j.api.IPcre2;
 
 import java.text.Normalizer;

--- a/regex/src/test/java/org/pcre4j/regex/MatchLimitTests.java
+++ b/regex/src/test/java/org/pcre4j/regex/MatchLimitTests.java
@@ -20,7 +20,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for ReDoS protection via configurable match limits.

--- a/regex/src/test/java/org/pcre4j/regex/PatternTests.java
+++ b/regex/src/test/java/org/pcre4j/regex/PatternTests.java
@@ -18,7 +18,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests to ensure API likeness of the {@link Pattern} to the {@link java.util.regex.Pattern}.


### PR DESCRIPTION
## Summary

- Expand Checkstyle configuration with file-level checks, import hygiene, naming conventions, whitespace rules, indentation enforcement, and LGPL copyright header verification
- Fix existing violations: replace star imports with explicit imports in 6 files, remove 2 unused imports
- Add suppression filters for JNA native method names (`pcre2_*`) and test method underscore naming convention

## Test plan

- [x] `./gradlew clean checkstyleMain checkstyleTest` passes with zero violations
- [x] `./gradlew clean build -Dpcre2.library.path=/opt/homebrew/lib` passes all tests
- [ ] CI passes

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)