### PR TITLE
(fix) build: exclude module-info.java from Checkstyle checks

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -4,6 +4,11 @@
         "https://checkstyle.sourceforge.io/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
+    <!-- module-info.java uses 'module' keyword that Checkstyle's parser cannot handle -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$"/>
+    </module>
+
     <module name="LineLength">
         <property name="fileExtensions" value="java"/>
         <property name="max" value="120"/>


### PR DESCRIPTION
## Summary
- Checkstyle's TreeWalker parser fails on `module-info.java` files with `no viable alternative at input 'module'`, breaking CI lint on main since `72eb317`
- Add `BeforeExecutionExclusionFileFilter` to skip `module-info.java` files from Checkstyle processing

## Test plan
- [x] `./gradlew checkstyleMain checkstyleTest` passes locally
- [ ] CI lint job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)