### PR TITLE
(docs) claude: document DCO sign-off requirement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ The FFM module is a Multi-Release JAR (MRJAR):
 See [CONTRIBUTING.md](CONTRIBUTING.md#commit-message-format) for the commit message format and type prefixes.
 
 - Reverts use Git default: `Revert "(type) original message"`
+- All commits **must** include a `Signed-off-by` trailer (DCO). Use `git commit -s` to add it automatically.
 
 ## Release Process
 


### PR DESCRIPTION
## Summary
- Document in CLAUDE.md that all commits must include a `Signed-off-by` trailer (DCO) and that `git commit -s` adds it automatically

## Test plan
- [x] Documentation-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)