### PR TITLE
(feat) test: add stress and thread-safety tests

### DIFF
--- a/lib/src/test/java/org/pcre4j/NativeMemoryStressTests.java
+++ b/lib/src/test/java/org/pcre4j/NativeMemoryStressTests.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.pcre4j.api.IPcre2;
+
+import java.lang.ref.Reference;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Stress tests for native memory management under load.
+ *
+ * <p>These tests verify that Cleaner-based resource management handles rapid creation and disposal of native
+ * objects without memory leaks or double-free errors.</p>
+ */
+@Tag("stress")
+public class NativeMemoryStressTests {
+
+    private static final int RAPID_CREATION_COUNT = 100_000;
+    private static final int THREAD_COUNT = Runtime.getRuntime().availableProcessors() * 2;
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void rapidPatternCreationAndGc(IPcre2 api) {
+        for (int i = 0; i < RAPID_CREATION_COUNT; i++) {
+            new Pcre2Code(api, "pattern" + (i % 1000));
+            if (i % 10_000 == 0) {
+                System.gc();
+            }
+        }
+
+        assertDoesNotThrow(() -> {
+            var code = new Pcre2Code(api, "final-pattern");
+            var matchData = new Pcre2MatchData(api, 1);
+            code.match("final-pattern", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null);
+        }, "Pattern creation should work after rapid creation/GC cycles");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void rapidMatchDataCreationAndGc(IPcre2 api) {
+        var code = new Pcre2Code(api, "(\\w+)");
+
+        for (int i = 0; i < RAPID_CREATION_COUNT; i++) {
+            var matchData = new Pcre2MatchData(code);
+            code.match("hello", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null);
+            if (i % 10_000 == 0) {
+                System.gc();
+            }
+        }
+
+        assertDoesNotThrow(() -> {
+            var matchData = new Pcre2MatchData(code);
+            code.match("hello", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null);
+        }, "MatchData creation should work after rapid creation/GC cycles");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void rapidContextCreationAndGc(IPcre2 api) {
+        for (int i = 0; i < RAPID_CREATION_COUNT / 10; i++) {
+            var generalCtx = new Pcre2GeneralContext(api);
+            new Pcre2CompileContext(api, generalCtx);
+            new Pcre2MatchContext(api, generalCtx);
+            if (i % 1_000 == 0) {
+                System.gc();
+            }
+        }
+
+        assertDoesNotThrow(() -> {
+            var generalCtx = new Pcre2GeneralContext(api);
+            new Pcre2CompileContext(api, generalCtx);
+            new Pcre2MatchContext(api, generalCtx);
+        }, "Context creation should work after rapid creation/GC cycles");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void concurrentPatternCreationAndDisposal(IPcre2 api) throws Exception {
+        var errors = Collections.synchronizedList(new ArrayList<Throwable>());
+        var latch = new CountDownLatch(1);
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var futures = new ArrayList<Future<?>>();
+            for (int t = 0; t < THREAD_COUNT; t++) {
+                final int threadIndex = t;
+                futures.add(executor.submit(() -> {
+                    try {
+                        latch.await();
+                        for (int i = 0; i < 10_000; i++) {
+                            var code = new Pcre2Code(
+                                    api, "thread" + threadIndex + "_pattern" + (i % 100)
+                            );
+                            var matchData = new Pcre2MatchData(api, 1);
+                            code.match(
+                                    "thread" + threadIndex + "_pattern42",
+                                    0,
+                                    EnumSet.noneOf(Pcre2MatchOption.class),
+                                    matchData,
+                                    null
+                            );
+                            Reference.reachabilityFence(matchData);
+                            Reference.reachabilityFence(code);
+                        }
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    }
+                }));
+            }
+
+            latch.countDown();
+            for (var future : futures) {
+                future.get(120, TimeUnit.SECONDS);
+            }
+        }
+
+        assertTrue(errors.isEmpty(), () -> "Concurrent pattern creation errors: " + errors.getFirst());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void concurrentMatchDataCreationAndDisposal(IPcre2 api) throws Exception {
+        var code = new Pcre2Code(api, "(\\w+)-(\\d+)");
+        var errors = Collections.synchronizedList(new ArrayList<Throwable>());
+        var latch = new CountDownLatch(1);
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var futures = new ArrayList<Future<?>>();
+            for (int t = 0; t < THREAD_COUNT; t++) {
+                futures.add(executor.submit(() -> {
+                    try {
+                        latch.await();
+                        for (int i = 0; i < 10_000; i++) {
+                            var matchData = new Pcre2MatchData(code);
+                            code.match(
+                                    "hello-42",
+                                    0,
+                                    EnumSet.noneOf(Pcre2MatchOption.class),
+                                    matchData,
+                                    null
+                            );
+                            Reference.reachabilityFence(matchData);
+                        }
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    }
+                }));
+            }
+
+            latch.countDown();
+            for (var future : futures) {
+                future.get(120, TimeUnit.SECONDS);
+            }
+        }
+
+        assertTrue(errors.isEmpty(), () -> "Concurrent match data creation errors: " + errors.getFirst());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void matchWhileGcRunsConcurrently(IPcre2 api) throws Exception {
+        var code = new Pcre2Code(api, "\\d+");
+        var errors = Collections.synchronizedList(new ArrayList<Throwable>());
+        var latch = new CountDownLatch(1);
+        var done = new java.util.concurrent.atomic.AtomicBoolean(false);
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var futures = new ArrayList<Future<?>>();
+
+            // GC pressure thread: rapidly creates and discards patterns to trigger cleanup
+            futures.add(executor.submit(() -> {
+                try {
+                    latch.await();
+                    while (!done.get()) {
+                        for (int i = 0; i < 100; i++) {
+                            new Pcre2Code(api, "disposable" + i);
+                        }
+                        System.gc();
+                        Thread.sleep(10);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } catch (Throwable e) {
+                    errors.add(e);
+                }
+            }));
+
+            // Matching threads: use the shared code while GC runs
+            for (int t = 0; t < THREAD_COUNT; t++) {
+                futures.add(executor.submit(() -> {
+                    try {
+                        latch.await();
+                        for (int i = 0; i < 10_000; i++) {
+                            var matchData = new Pcre2MatchData(api, 1);
+                            var result = code.match(
+                                    "abc123def",
+                                    0,
+                                    EnumSet.noneOf(Pcre2MatchOption.class),
+                                    matchData,
+                                    null
+                            );
+                            Reference.reachabilityFence(matchData);
+                            if (result < 1) {
+                                errors.add(new AssertionError(
+                                        "Expected match but got result=" + result
+                                ));
+                            }
+                        }
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    }
+                }));
+            }
+
+            latch.countDown();
+
+            // Wait for matching threads (skip the GC thread at index 0)
+            for (int i = 1; i < futures.size(); i++) {
+                futures.get(i).get(120, TimeUnit.SECONDS);
+            }
+            done.set(true);
+            futures.getFirst().get(10, TimeUnit.SECONDS);
+        }
+
+        assertTrue(errors.isEmpty(), () -> "Match-during-GC errors: " + errors.getFirst());
+    }
+}

--- a/lib/src/test/java/org/pcre4j/Pcre2CodeThreadSafetyTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodeThreadSafetyTests.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.pcre4j.api.IPcre2;
+
+import java.lang.ref.Reference;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Thread-safety tests for {@link Pcre2Code}.
+ *
+ * <p>Compiled PCRE2 patterns are immutable and safe to share across threads for matching. These tests verify that
+ * concurrent matching on a shared {@link Pcre2Code} instance produces correct results without corruption.</p>
+ *
+ * <p>Note: {@link Reference#reachabilityFence(Object)} calls are used to prevent the JVM from collecting
+ * {@link Pcre2MatchData} instances (and triggering their Cleaner to free native memory) before the native
+ * match call has returned.</p>
+ */
+@Tag("stress")
+public class Pcre2CodeThreadSafetyTests {
+
+    private static final int THREAD_COUNT = Runtime.getRuntime().availableProcessors() * 2;
+    private static final int ITERATIONS_PER_THREAD = 10_000;
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void concurrentMatchingOnSharedPattern(IPcre2 api) throws Exception {
+        var code = new Pcre2Code(api, "\\d+");
+        var errors = Collections.synchronizedList(new ArrayList<Throwable>());
+        var latch = new CountDownLatch(1);
+
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var futures = new ArrayList<Future<?>>();
+            for (int t = 0; t < THREAD_COUNT; t++) {
+                futures.add(executor.submit(() -> {
+                    try {
+                        latch.await();
+                        for (int i = 0; i < ITERATIONS_PER_THREAD; i++) {
+                            var matchData = new Pcre2MatchData(api, 1);
+                            var result = code.match(
+                                    "abc123def",
+                                    0,
+                                    EnumSet.noneOf(Pcre2MatchOption.class),
+                                    matchData,
+                                    null
+                            );
+                            Reference.reachabilityFence(matchData);
+                            if (result < 1) {
+                                errors.add(new AssertionError(
+                                        "Expected match but got result=" + result
+                                ));
+                            }
+                        }
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    }
+                }));
+            }
+
+            latch.countDown();
+            for (var future : futures) {
+                future.get(60, TimeUnit.SECONDS);
+            }
+        }
+
+        assertTrue(errors.isEmpty(), () -> "Concurrent matching errors: " + errors.getFirst());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void concurrentMatchingWithCaptures(IPcre2 api) throws Exception {
+        var code = new Pcre2Code(api, "(\\w+)@(\\w+\\.\\w+)");
+        var errors = Collections.synchronizedList(new ArrayList<Throwable>());
+        var latch = new CountDownLatch(1);
+        var subjects = List.of(
+                "user@example.com",
+                "admin@test.org",
+                "info@domain.net",
+                "hello@world.io"
+        );
+
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var futures = new ArrayList<Future<?>>();
+            for (int t = 0; t < THREAD_COUNT; t++) {
+                final int threadIndex = t;
+                futures.add(executor.submit(() -> {
+                    try {
+                        latch.await();
+                        var subject = subjects.get(threadIndex % subjects.size());
+                        for (int i = 0; i < ITERATIONS_PER_THREAD; i++) {
+                            var matchData = new Pcre2MatchData(api, 3);
+                            var result = code.match(
+                                    subject,
+                                    0,
+                                    EnumSet.noneOf(Pcre2MatchOption.class),
+                                    matchData,
+                                    null
+                            );
+                            Reference.reachabilityFence(matchData);
+                            if (result < 1) {
+                                errors.add(new AssertionError(
+                                        "Expected match on '" + subject + "' but got result=" + result
+                                ));
+                            }
+                        }
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    }
+                }));
+            }
+
+            latch.countDown();
+            for (var future : futures) {
+                future.get(60, TimeUnit.SECONDS);
+            }
+        }
+
+        assertTrue(errors.isEmpty(), () -> "Concurrent capture matching errors: " + errors.getFirst());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void concurrentSubstituteOnSharedPattern(IPcre2 api) throws Exception {
+        var code = new Pcre2Code(api, "\\d+");
+        var errors = Collections.synchronizedList(new ArrayList<Throwable>());
+        var latch = new CountDownLatch(1);
+
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var futures = new ArrayList<Future<?>>();
+            for (int t = 0; t < THREAD_COUNT; t++) {
+                futures.add(executor.submit(() -> {
+                    try {
+                        latch.await();
+                        for (int i = 0; i < ITERATIONS_PER_THREAD; i++) {
+                            var matchData = new Pcre2MatchData(api, 1);
+                            var result = code.substitute(
+                                    "abc123def",
+                                    0,
+                                    EnumSet.noneOf(Pcre2SubstituteOption.class),
+                                    matchData,
+                                    null,
+                                    "NUM"
+                            );
+                            Reference.reachabilityFence(matchData);
+                            if (!"abcNUMdef".equals(result)) {
+                                errors.add(new AssertionError(
+                                        "Expected 'abcNUMdef' but got '" + result + "'"
+                                ));
+                            }
+                        }
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    }
+                }));
+            }
+
+            latch.countDown();
+            for (var future : futures) {
+                future.get(60, TimeUnit.SECONDS);
+            }
+        }
+
+        assertTrue(errors.isEmpty(), () -> "Concurrent substitute errors: " + errors.getFirst());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void concurrentPatternInfoAccess(IPcre2 api) throws Exception {
+        var code = new Pcre2Code(api, "(\\w+)(\\d+)(\\s+)");
+        var expectedCaptureCount = code.captureCount();
+        var errors = Collections.synchronizedList(new ArrayList<Throwable>());
+        var latch = new CountDownLatch(1);
+
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var futures = new ArrayList<Future<?>>();
+            for (int t = 0; t < THREAD_COUNT; t++) {
+                futures.add(executor.submit(() -> {
+                    try {
+                        latch.await();
+                        for (int i = 0; i < ITERATIONS_PER_THREAD; i++) {
+                            var captureCount = code.captureCount();
+                            if (captureCount != expectedCaptureCount) {
+                                errors.add(new AssertionError(
+                                        "Expected captureCount=" + expectedCaptureCount
+                                                + " but got " + captureCount
+                                ));
+                            }
+                            code.size();
+                        }
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    }
+                }));
+            }
+
+            latch.countDown();
+            for (var future : futures) {
+                future.get(60, TimeUnit.SECONDS);
+            }
+        }
+
+        assertTrue(errors.isEmpty(), () -> "Concurrent pattern info errors: " + errors.getFirst());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void concurrentMatchAndSubstituteMixed(IPcre2 api) throws Exception {
+        var code = new Pcre2Code(api, "(\\w+)");
+        var errors = Collections.synchronizedList(new ArrayList<Throwable>());
+        var latch = new CountDownLatch(1);
+
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var futures = new ArrayList<Future<?>>();
+            for (int t = 0; t < THREAD_COUNT; t++) {
+                final boolean doSubstitute = (t % 2 == 0);
+                futures.add(executor.submit(() -> {
+                    try {
+                        latch.await();
+                        for (int i = 0; i < ITERATIONS_PER_THREAD; i++) {
+                            var matchData = new Pcre2MatchData(api, 2);
+                            if (doSubstitute) {
+                                var result = code.substitute(
+                                        "hello",
+                                        0,
+                                        EnumSet.noneOf(Pcre2SubstituteOption.class),
+                                        matchData,
+                                        null,
+                                        "world"
+                                );
+                                if (!"world".equals(result)) {
+                                    errors.add(new AssertionError(
+                                            "Expected 'world' but got '" + result + "'"
+                                    ));
+                                }
+                            } else {
+                                var result = code.match(
+                                        "hello",
+                                        0,
+                                        EnumSet.noneOf(Pcre2MatchOption.class),
+                                        matchData,
+                                        null
+                                );
+                                if (result < 1) {
+                                    errors.add(new AssertionError(
+                                            "Expected match but got result=" + result
+                                    ));
+                                }
+                            }
+                            Reference.reachabilityFence(matchData);
+                        }
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    }
+                }));
+            }
+
+            latch.countDown();
+            for (var future : futures) {
+                future.get(60, TimeUnit.SECONDS);
+            }
+        }
+
+        assertTrue(errors.isEmpty(), () -> "Concurrent mixed operations errors: " + errors.getFirst());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void highConcurrencyMatchCorrectness(IPcre2 api) throws Exception {
+        var code = new Pcre2Code(api, "^(\\d{3})-(\\d{3})-(\\d{4})$");
+        var subject = "555-123-4567";
+        var errors = Collections.synchronizedList(new ArrayList<Throwable>());
+        var latch = new CountDownLatch(1);
+        var matchCount = new java.util.concurrent.atomic.AtomicInteger(0);
+
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var futures = new ArrayList<Future<?>>();
+            for (int t = 0; t < THREAD_COUNT * 4; t++) {
+                futures.add(executor.submit(() -> {
+                    try {
+                        latch.await();
+                        for (int i = 0; i < ITERATIONS_PER_THREAD / 2; i++) {
+                            var matchData = new Pcre2MatchData(api, 4);
+                            var result = code.match(
+                                    subject,
+                                    0,
+                                    EnumSet.noneOf(Pcre2MatchOption.class),
+                                    matchData,
+                                    null
+                            );
+                            Reference.reachabilityFence(matchData);
+                            if (result >= 1) {
+                                matchCount.incrementAndGet();
+                            } else {
+                                errors.add(new AssertionError(
+                                        "Expected match but got result=" + result
+                                ));
+                            }
+                        }
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    }
+                }));
+            }
+
+            latch.countDown();
+            for (var future : futures) {
+                future.get(120, TimeUnit.SECONDS);
+            }
+        }
+
+        assertTrue(errors.isEmpty(), () -> "High concurrency match errors: " + errors.getFirst());
+        assertEquals(
+                THREAD_COUNT * 4 * (ITERATIONS_PER_THREAD / 2),
+                matchCount.get(),
+                "All matches should have succeeded"
+        );
+    }
+}

--- a/regex/build.gradle.kts
+++ b/regex/build.gradle.kts
@@ -12,6 +12,8 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
+import java.time.Duration
+
 plugins {
     id("pcre4j-module")
     id("pcre4j-native-test")
@@ -31,7 +33,49 @@ dependencies {
 //   - compileTestJava: test code may reference FFM-backed types
 //   - test JVM args: JVM must enable preview features for FFM backend loading
 tasks.test {
+    useJUnitPlatform {
+        excludeTags("stress")
+    }
     jvmArgs("--enable-preview")
+}
+
+tasks.register<Test>("stressTest") {
+    description = "Runs stress and thread-safety tests"
+    group = "verification"
+
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
+
+    useJUnitPlatform {
+        includeTags("stress")
+    }
+    jvmArgs("--enable-preview")
+
+    systemProperty(
+        "jna.library.path", listOf(
+            providers.systemProperty("pcre2.library.path").orNull,
+            providers.systemProperty("jna.library.path").orNull
+        ).joinToString(File.pathSeparator)
+    )
+
+    systemProperty(
+        "java.library.path", listOf(
+            providers.systemProperty("pcre2.library.path").orNull,
+            providers.systemProperty("java.library.path").orNull
+        ).joinToString(File.pathSeparator)
+    )
+
+    val pcre2LibraryName = providers.systemProperty("pcre2.library.name").orNull
+    if (pcre2LibraryName != null) {
+        systemProperty("pcre2.library.name", pcre2LibraryName)
+    }
+
+    val pcre2FunctionSuffix = providers.systemProperty("pcre2.function.suffix").orNull
+    if (pcre2FunctionSuffix != null) {
+        systemProperty("pcre2.function.suffix", pcre2FunctionSuffix)
+    }
+
+    timeout = Duration.ofMinutes(10)
 }
 
 tasks.named<JavaCompile>("compileTestJava") {

--- a/regex/src/test/java/org/pcre4j/regex/PatternThreadSafetyTests.java
+++ b/regex/src/test/java/org/pcre4j/regex/PatternThreadSafetyTests.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j.regex;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.pcre4j.api.IPcre2;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Thread-safety tests for the {@code java.util.regex}-compatible API layer.
+ *
+ * <p>{@link Pattern} is immutable and safe to share across threads. Each thread should create its own
+ * {@link Matcher} instance via {@link Pattern#matcher(CharSequence)}. These tests verify these
+ * thread-safety guarantees under concurrent load.</p>
+ */
+@Tag("stress")
+public class PatternThreadSafetyTests {
+
+    private static final int THREAD_COUNT = Runtime.getRuntime().availableProcessors() * 2;
+    private static final int ITERATIONS_PER_THREAD = 10_000;
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void concurrentMatcherCreationFromSharedPattern(IPcre2 api) throws Exception {
+        var pattern = Pattern.compile(api, "(\\w+)@(\\w+\\.\\w+)");
+        var errors = Collections.synchronizedList(new ArrayList<Throwable>());
+        var latch = new CountDownLatch(1);
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var futures = new ArrayList<Future<?>>();
+            for (int t = 0; t < THREAD_COUNT; t++) {
+                futures.add(executor.submit(() -> {
+                    try {
+                        latch.await();
+                        for (int i = 0; i < ITERATIONS_PER_THREAD; i++) {
+                            var matcher = pattern.matcher("user@example.com");
+                            if (!matcher.find()) {
+                                errors.add(new AssertionError("Expected match on 'user@example.com'"));
+                            }
+                            if (!"user".equals(matcher.group(1))) {
+                                errors.add(new AssertionError(
+                                        "Expected group(1)='user' but got '" + matcher.group(1) + "'"
+                                ));
+                            }
+                            if (!"example.com".equals(matcher.group(2))) {
+                                errors.add(new AssertionError(
+                                        "Expected group(2)='example.com' but got '" + matcher.group(2) + "'"
+                                ));
+                            }
+                        }
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    }
+                }));
+            }
+
+            latch.countDown();
+            for (var future : futures) {
+                future.get(60, TimeUnit.SECONDS);
+            }
+        }
+
+        assertTrue(errors.isEmpty(), () -> "Concurrent matcher creation errors: " + errors.getFirst());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void concurrentFindOnDifferentInputs(IPcre2 api) throws Exception {
+        var pattern = Pattern.compile(api, "\\d+");
+        var inputs = List.of("abc123", "def456", "ghi789", "jkl012");
+        var expected = List.of("123", "456", "789", "012");
+        var errors = Collections.synchronizedList(new ArrayList<Throwable>());
+        var latch = new CountDownLatch(1);
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var futures = new ArrayList<Future<?>>();
+            for (int t = 0; t < THREAD_COUNT; t++) {
+                final int threadIndex = t;
+                futures.add(executor.submit(() -> {
+                    try {
+                        latch.await();
+                        int idx = threadIndex % inputs.size();
+                        var input = inputs.get(idx);
+                        var expectedMatch = expected.get(idx);
+                        for (int i = 0; i < ITERATIONS_PER_THREAD; i++) {
+                            var matcher = pattern.matcher(input);
+                            if (!matcher.find()) {
+                                errors.add(new AssertionError(
+                                        "Expected match on '" + input + "'"
+                                ));
+                                return;
+                            }
+                            var group = matcher.group();
+                            if (!expectedMatch.equals(group)) {
+                                errors.add(new AssertionError(
+                                        "Expected '" + expectedMatch + "' but got '" + group + "'"
+                                ));
+                                return;
+                            }
+                        }
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    }
+                }));
+            }
+
+            latch.countDown();
+            for (var future : futures) {
+                future.get(60, TimeUnit.SECONDS);
+            }
+        }
+
+        assertTrue(errors.isEmpty(), () -> "Concurrent find errors: " + errors.getFirst());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void concurrentMatches(IPcre2 api) throws Exception {
+        var pattern = Pattern.compile(api, "^\\d{3}-\\d{3}-\\d{4}$");
+        var errors = Collections.synchronizedList(new ArrayList<Throwable>());
+        var latch = new CountDownLatch(1);
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var futures = new ArrayList<Future<?>>();
+            for (int t = 0; t < THREAD_COUNT; t++) {
+                futures.add(executor.submit(() -> {
+                    try {
+                        latch.await();
+                        for (int i = 0; i < ITERATIONS_PER_THREAD; i++) {
+                            var matcher = pattern.matcher("555-123-4567");
+                            if (!matcher.matches()) {
+                                errors.add(new AssertionError(
+                                        "Expected matches() to return true"
+                                ));
+                                return;
+                            }
+                        }
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    }
+                }));
+            }
+
+            latch.countDown();
+            for (var future : futures) {
+                future.get(60, TimeUnit.SECONDS);
+            }
+        }
+
+        assertTrue(errors.isEmpty(), () -> "Concurrent matches errors: " + errors.getFirst());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void concurrentSplit(IPcre2 api) throws Exception {
+        var pattern = Pattern.compile(api, "[,;]\\s*");
+        var errors = Collections.synchronizedList(new ArrayList<Throwable>());
+        var latch = new CountDownLatch(1);
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var futures = new ArrayList<Future<?>>();
+            for (int t = 0; t < THREAD_COUNT; t++) {
+                futures.add(executor.submit(() -> {
+                    try {
+                        latch.await();
+                        for (int i = 0; i < ITERATIONS_PER_THREAD; i++) {
+                            var parts = pattern.split("apple, banana; cherry, date");
+                            if (parts.length != 4) {
+                                errors.add(new AssertionError(
+                                        "Expected 4 parts but got " + parts.length
+                                ));
+                                return;
+                            }
+                            if (!"apple".equals(parts[0])) {
+                                errors.add(new AssertionError(
+                                        "Expected 'apple' but got '" + parts[0] + "'"
+                                ));
+                                return;
+                            }
+                        }
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    }
+                }));
+            }
+
+            latch.countDown();
+            for (var future : futures) {
+                future.get(60, TimeUnit.SECONDS);
+            }
+        }
+
+        assertTrue(errors.isEmpty(), () -> "Concurrent split errors: " + errors.getFirst());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void concurrentReplaceAll(IPcre2 api) throws Exception {
+        var pattern = Pattern.compile(api, "\\d+");
+        var errors = Collections.synchronizedList(new ArrayList<Throwable>());
+        var latch = new CountDownLatch(1);
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var futures = new ArrayList<Future<?>>();
+            for (int t = 0; t < THREAD_COUNT; t++) {
+                futures.add(executor.submit(() -> {
+                    try {
+                        latch.await();
+                        for (int i = 0; i < ITERATIONS_PER_THREAD; i++) {
+                            var matcher = pattern.matcher("abc123def456ghi");
+                            var result = matcher.replaceAll("NUM");
+                            if (!"abcNUMdefNUMghi".equals(result)) {
+                                errors.add(new AssertionError(
+                                        "Expected 'abcNUMdefNUMghi' but got '" + result + "'"
+                                ));
+                                return;
+                            }
+                        }
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    }
+                }));
+            }
+
+            latch.countDown();
+            for (var future : futures) {
+                future.get(60, TimeUnit.SECONDS);
+            }
+        }
+
+        assertTrue(errors.isEmpty(), () -> "Concurrent replaceAll errors: " + errors.getFirst());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void concurrentLazyInitialization(IPcre2 api) throws Exception {
+        // Pattern with CASE_INSENSITIVE triggers lazy compilation of matchingCode/lookingAtCode
+        var pattern = Pattern.compile(api, "hello", Pattern.CASE_INSENSITIVE);
+        var errors = Collections.synchronizedList(new ArrayList<Throwable>());
+        var latch = new CountDownLatch(1);
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var futures = new ArrayList<Future<?>>();
+            // Use a high thread count to stress the double-checked locking
+            for (int t = 0; t < THREAD_COUNT * 4; t++) {
+                futures.add(executor.submit(() -> {
+                    try {
+                        latch.await();
+                        for (int i = 0; i < 1_000; i++) {
+                            var matcher = pattern.matcher("HELLO world");
+                            if (!matcher.find()) {
+                                errors.add(new AssertionError("Expected find() to succeed"));
+                                return;
+                            }
+                            if (!"HELLO".equals(matcher.group())) {
+                                errors.add(new AssertionError(
+                                        "Expected 'HELLO' but got '" + matcher.group() + "'"
+                                ));
+                                return;
+                            }
+
+                            matcher.reset("HeLLo");
+                            if (!matcher.matches()) {
+                                errors.add(new AssertionError("Expected matches() to succeed"));
+                                return;
+                            }
+
+                            matcher.reset("HELLO world");
+                            if (!matcher.lookingAt()) {
+                                errors.add(new AssertionError(
+                                        "Expected lookingAt() to succeed for prefix match"
+                                ));
+                                return;
+                            }
+                        }
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    }
+                }));
+            }
+
+            latch.countDown();
+            for (var future : futures) {
+                future.get(120, TimeUnit.SECONDS);
+            }
+        }
+
+        assertTrue(errors.isEmpty(), () -> "Concurrent lazy init errors: " + errors.getFirst());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void concurrentPatternCreationAndMatching(IPcre2 api) throws Exception {
+        var errors = Collections.synchronizedList(new ArrayList<Throwable>());
+        var latch = new CountDownLatch(1);
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var futures = new ArrayList<Future<?>>();
+            for (int t = 0; t < THREAD_COUNT; t++) {
+                final int threadIndex = t;
+                futures.add(executor.submit(() -> {
+                    try {
+                        latch.await();
+                        for (int i = 0; i < 5_000; i++) {
+                            var pattern = Pattern.compile(
+                                    api, "thread" + threadIndex + "_" + (i % 100)
+                            );
+                            var matcher = pattern.matcher(
+                                    "thread" + threadIndex + "_42 some text"
+                            );
+                            matcher.find();
+                        }
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    }
+                }));
+            }
+
+            latch.countDown();
+            for (var future : futures) {
+                future.get(120, TimeUnit.SECONDS);
+            }
+        }
+
+        assertTrue(
+                errors.isEmpty(),
+                () -> "Concurrent pattern creation/matching errors: " + errors.getFirst()
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void highConcurrencyCorrectness(IPcre2 api) throws Exception {
+        var pattern = Pattern.compile(api, "(\\w+)\\s+(\\w+)");
+        var input = "hello world";
+        var errors = Collections.synchronizedList(new ArrayList<Throwable>());
+        var latch = new CountDownLatch(1);
+        var matchCount = new java.util.concurrent.atomic.AtomicInteger(0);
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var futures = new ArrayList<Future<?>>();
+            for (int t = 0; t < THREAD_COUNT * 4; t++) {
+                futures.add(executor.submit(() -> {
+                    try {
+                        latch.await();
+                        for (int i = 0; i < ITERATIONS_PER_THREAD / 2; i++) {
+                            var matcher = pattern.matcher(input);
+                            if (!matcher.find()) {
+                                errors.add(new AssertionError("Expected match on '" + input + "'"));
+                                return;
+                            }
+                            if (!"hello".equals(matcher.group(1))) {
+                                errors.add(new AssertionError(
+                                        "Expected group(1)='hello' but got '" + matcher.group(1) + "'"
+                                ));
+                                return;
+                            }
+                            if (!"world".equals(matcher.group(2))) {
+                                errors.add(new AssertionError(
+                                        "Expected group(2)='world' but got '" + matcher.group(2) + "'"
+                                ));
+                                return;
+                            }
+                            matchCount.incrementAndGet();
+                        }
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    }
+                }));
+            }
+
+            latch.countDown();
+            for (var future : futures) {
+                future.get(120, TimeUnit.SECONDS);
+            }
+        }
+
+        assertTrue(errors.isEmpty(), () -> "High concurrency correctness errors: " + errors.getFirst());
+        assertEquals(
+                THREAD_COUNT * 4 * (ITERATIONS_PER_THREAD / 2),
+                matchCount.get(),
+                "All matches should have succeeded"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add `@Tag("stress")` JUnit 5 tag infrastructure with separate Gradle `stressTest` tasks for `lib` and `regex` modules, excluded from normal `test` task (and CI)
- Add `Pcre2CodeThreadSafetyTests`: concurrent matching/substitution on shared `Pcre2Code` instances across virtual threads
- Add `NativeMemoryStressTests`: rapid creation/disposal of native objects (patterns, match data, contexts) with GC pressure
- Add `PatternThreadSafetyTests`: concurrent `Pattern`/`Matcher` operations including find, matches, split, replaceAll, and lazy initialization
- Fix `Matcher` GC reachability bug discovered by stress tests: add `Reference.reachabilityFence(this)` to `search()`, `lookingAt()`, `matches()`, `replaceAll()`, and `replaceFirst()` to prevent premature GC of Matcher's native resources (`matchContext`, `jitStack`) during in-flight native calls

Fixes #336

## Test plan

- [x] `checkstyleMain` and `checkstyleTest` pass for all modules
- [x] Normal `lib:test` and `regex:test` pass (stress tests properly excluded via `excludeTags("stress")`)
- [x] `lib:stressTest` passes — thread-safety and native memory stress tests
- [x] `regex:stressTest` passes — Pattern/Matcher concurrent operations (previously SIGSEGV before Matcher reachability fix)
- [x] Full `./gradlew build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)