### PR TITLE
(feat) lib: expose DFA matching through high-level API

### DIFF
--- a/lib/src/main/java/org/pcre4j/Pcre2DfaMatchOption.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2DfaMatchOption.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j;
+
+import org.pcre4j.api.IPcre2;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Match options for {@link Pcre2Code#dfaMatch}.
+ * <p>
+ * These options control DFA matching behavior. DFA-specific options ({@link #RESTART} and {@link #SHORTEST}) are
+ * only valid for DFA matching, while the remaining options are shared with standard matching.
+ */
+public enum Pcre2DfaMatchOption {
+    /**
+     * Match only at the first position
+     */
+    ANCHORED(IPcre2.ANCHORED),
+
+    /**
+     * On success, make a private subject copy
+     */
+    COPY_MATCHED_SUBJECT(IPcre2.COPY_MATCHED_SUBJECT),
+
+    /**
+     * Pattern can match only at end of subject
+     */
+    ENDANCHORED(IPcre2.ENDANCHORED),
+
+    /**
+     * Subject string is not the beginning of a line
+     */
+    NOTBOL(IPcre2.NOTBOL),
+
+    /**
+     * Subject string is not the end of a line
+     */
+    NOTEOL(IPcre2.NOTEOL),
+
+    /**
+     * An empty string is not a valid match
+     */
+    NOTEMPTY(IPcre2.NOTEMPTY),
+
+    /**
+     * An empty string at the start of the subject is not a valid match
+     */
+    NOTEMPTY_ATSTART(IPcre2.NOTEMPTY_ATSTART),
+
+    /**
+     * Do not check the subject for UTF validity (only relevant if PCRE2_UTF was set at compile time)
+     */
+    NO_UTF_CHECK(IPcre2.NO_UTF_CHECK),
+
+    /**
+     * Return {@link IPcre2#ERROR_PARTIAL} for a partial match even if there is a full match
+     */
+    PARTIAL_HARD(IPcre2.PARTIAL_HARD),
+
+    /**
+     * Return {@link IPcre2#ERROR_PARTIAL} for a partial match if no full matches are found
+     */
+    PARTIAL_SOFT(IPcre2.PARTIAL_SOFT),
+
+    /**
+     * Restart DFA matching after a partial match.
+     * <p>
+     * When a previous DFA match returned a partial match, the matching can be continued with new data using this
+     * option. The workspace must be preserved from the previous call.
+     */
+    RESTART(IPcre2.DFA_RESTART),
+
+    /**
+     * Return only the shortest match.
+     * <p>
+     * Without this option, DFA matching returns all possible match lengths at the same starting position (longest
+     * first). With this option, only the shortest match is returned.
+     */
+    SHORTEST(IPcre2.DFA_SHORTEST);
+
+    /**
+     * The integer value of the option
+     */
+    private final int value;
+
+    /**
+     * Create a new enum value for the given option value.
+     *
+     * @param value the integer value of the option
+     */
+    private Pcre2DfaMatchOption(int value) {
+        this.value = value;
+    }
+
+    /**
+     * Get the enum value by its option value.
+     *
+     * @param value the integer value of the option
+     * @return the flag
+     */
+    public static Optional<Pcre2DfaMatchOption> valueOf(int value) {
+        return Arrays.stream(values())
+                .filter(flag -> flag.value == value)
+                .findFirst();
+    }
+
+    /**
+     * Get the option value of the enum value.
+     *
+     * @return the integer value of the option
+     */
+    public int value() {
+        return value;
+    }
+}

--- a/lib/src/main/java/org/pcre4j/Pcre2DfaMatchResult.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2DfaMatchResult.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j;
+
+/**
+ * Result of a DFA (Deterministic Finite Automaton) match.
+ * <p>
+ * DFA matching returns all possible match lengths at the same starting position. The matches are ordered from longest
+ * to shortest. Unlike standard NFA matching, DFA matching does not support capturing groups — only the overall match
+ * boundaries are available.
+ * <p>
+ * For example, matching the pattern {@code ab(c(d)?)?} against the subject {@code "abcd"} at position 0 could return
+ * matches ending at positions 4, 3, and 2 (for "abcd", "abc", and "ab" respectively).
+ *
+ * @param subject   the subject string that was matched
+ * @param start     the start index (character offset) of the match in the subject string
+ * @param ends      the end indices (character offsets, exclusive) of all possible matches, ordered from longest to
+ *                  shortest
+ * @param isPartial {@code true} if this is a partial match result
+ */
+public record Pcre2DfaMatchResult(String subject, int start, int[] ends, boolean isPartial) {
+
+    /**
+     * Get the number of alternative match lengths found.
+     *
+     * @return the number of matches
+     */
+    public int count() {
+        return ends.length;
+    }
+
+    /**
+     * Get the end index of the longest match (exclusive character offset).
+     *
+     * @return the end index of the longest match
+     */
+    public int longestEnd() {
+        return ends[0];
+    }
+
+    /**
+     * Get the end index of the shortest match (exclusive character offset).
+     *
+     * @return the end index of the shortest match
+     */
+    public int shortestEnd() {
+        return ends[ends.length - 1];
+    }
+
+    /**
+     * Get the longest matched substring.
+     *
+     * @return the longest matched substring
+     */
+    public String longestMatch() {
+        return subject.substring(start, ends[0]);
+    }
+
+    /**
+     * Get the shortest matched substring.
+     *
+     * @return the shortest matched substring
+     */
+    public String shortestMatch() {
+        return subject.substring(start, ends[ends.length - 1]);
+    }
+
+    /**
+     * Get the matched substring for the given match index.
+     *
+     * @param index the match index (0 = longest, count-1 = shortest)
+     * @return the matched substring
+     * @throws ArrayIndexOutOfBoundsException if the index is out of bounds
+     */
+    public String match(int index) {
+        return subject.substring(start, ends[index]);
+    }
+}

--- a/lib/src/test/java/org/pcre4j/Pcre2CodeDfaMatchTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodeDfaMatchTests.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.pcre4j.api.IPcre2;
+
+import java.util.EnumSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Pcre2CodeDfaMatchTests {
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void dfaMatchBasic(IPcre2 api) {
+        var code = new Pcre2Code(api, "hello");
+        var result = code.dfaMatch("hello world");
+
+        assertNotNull(result, "DFA match should succeed");
+        assertEquals(0, result.start(), "Match should start at position 0");
+        assertEquals(5, result.longestEnd(), "Match should end at position 5");
+        assertEquals("hello", result.longestMatch());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void dfaMatchNoMatch(IPcre2 api) {
+        var code = new Pcre2Code(api, "xyz");
+        var result = code.dfaMatch("hello world");
+
+        assertNull(result, "DFA match should return null when no match");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void dfaMatchWithStartOffset(IPcre2 api) {
+        var code = new Pcre2Code(api, "world");
+        var result = code.dfaMatch("hello world", 6, null, null, 1000);
+
+        assertNotNull(result, "DFA match should succeed");
+        assertEquals(6, result.start(), "Match should start at position 6");
+        assertEquals(11, result.longestEnd(), "Match should end at position 11");
+        assertEquals("world", result.longestMatch());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void dfaMatchMultipleAlternatives(IPcre2 api) {
+        // Pattern with explicit alternatives of different lengths
+        var code = new Pcre2Code(api, "a|aa|aaa|aaaa");
+        var result = code.dfaMatch("aaaa", 0, null, null, 1000);
+
+        assertNotNull(result, "DFA match should succeed");
+        assertEquals(0, result.start(), "Match should start at position 0");
+        assertTrue(result.count() >= 1, "DFA should find at least one match");
+        assertEquals(4, result.longestEnd(), "Longest match should be 4 a's");
+        assertEquals(1, result.shortestEnd(), "Shortest match should be 1 a");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void dfaMatchShortestOption(IPcre2 api) {
+        // With DFA_SHORTEST, only the shortest match is returned
+        var code = new Pcre2Code(api, "a|aa|aaa|aaaa");
+        var result = code.dfaMatch("aaaa", 0, EnumSet.of(Pcre2DfaMatchOption.SHORTEST), null, 1000);
+
+        assertNotNull(result, "DFA match should succeed");
+        assertEquals(1, result.count(), "DFA with SHORTEST should return only 1 match");
+        assertEquals(1, result.longestEnd(), "Shortest match should be 1 'a'");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void dfaMatchWithOptionalGroups(IPcre2 api) {
+        // Pattern matches "ab", "abc", or "abcd" - DFA returns multiple match lengths
+        var code = new Pcre2Code(api, "ab(c(d)?)?");
+        var result = code.dfaMatch("abcd", 0, null, null, 1000);
+
+        assertNotNull(result, "DFA match should succeed");
+        assertEquals(0, result.start(), "Match should start at position 0");
+        assertTrue(result.count() >= 1, "DFA should find at least one match");
+        assertEquals(4, result.longestEnd(), "Longest match should be 'abcd' (end=4)");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void dfaMatchUnicode(IPcre2 api) {
+        var code = new Pcre2Code(api, "\\x{1F310}+", EnumSet.of(Pcre2CompileOption.UTF));
+        var result = code.dfaMatch("hello \uD83C\uDF10\uD83C\uDF10\uD83C\uDF10 world");
+
+        assertNotNull(result, "DFA match should succeed for Unicode");
+        assertEquals("hello ".length(), result.start(), "Match should start after 'hello '");
+        assertEquals("hello \uD83C\uDF10\uD83C\uDF10\uD83C\uDF10".length(), result.longestEnd(),
+                "Match should end after all emojis");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void dfaMatchNullSubjectThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "hello");
+        assertThrows(IllegalArgumentException.class, () -> code.dfaMatch(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void dfaMatchNegativeStartOffsetThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "hello");
+        assertThrows(IllegalArgumentException.class, () ->
+                code.dfaMatch("hello", -1, null, null, 1000));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void dfaMatchStartOffsetPastEndThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "hello");
+        assertThrows(IllegalArgumentException.class, () ->
+                code.dfaMatch("abc", 4, null, null, 1000));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void dfaMatchZeroWorkspaceSizeThrows(IPcre2 api) {
+        var code = new Pcre2Code(api, "hello");
+        assertThrows(IllegalArgumentException.class, () ->
+                code.dfaMatch("hello", 0, null, null, 0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void dfaMatchResultMethods(IPcre2 api) {
+        var code = new Pcre2Code(api, "a|aa|aaa");
+        var result = code.dfaMatch("aaa", 0, null, null, 1000);
+
+        assertNotNull(result, "DFA match should succeed");
+        assertEquals("aaa", result.subject());
+        assertEquals(0, result.start());
+
+        // Verify the match(index) method works for all results
+        for (int i = 0; i < result.count(); i++) {
+            var matched = result.match(i);
+            assertNotNull(matched, "match(" + i + ") should not be null");
+            assertTrue(matched.startsWith("a"), "match(" + i + ") should start with 'a'");
+        }
+
+        // Longest and shortest accessors
+        assertEquals(result.match(0), result.longestMatch());
+        assertEquals(result.match(result.count() - 1), result.shortestMatch());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void dfaMatchPartialSoft(IPcre2 api) {
+        var code = new Pcre2Code(api, "hello world");
+        var result = code.dfaMatch("hello", 0, EnumSet.of(Pcre2DfaMatchOption.PARTIAL_SOFT), null, 1000);
+
+        // Partial match: "hello" is a prefix of "hello world"
+        assertNotNull(result, "Partial DFA match should return a result");
+        assertTrue(result.isPartial(), "Result should be marked as partial");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void dfaMatchWithMatchContext(IPcre2 api) {
+        var code = new Pcre2Code(api, "hello");
+        var matchContext = new Pcre2MatchContext(api, null);
+        var result = code.dfaMatch("hello world", 0, null, matchContext, 1000);
+
+        assertNotNull(result, "DFA match with match context should succeed");
+        assertEquals("hello", result.longestMatch());
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void dfaMatchUnsupportedPatternThrows(IPcre2 api) {
+        // Backreferences are not supported in DFA matching
+        var code = new Pcre2Code(api, "(a)\\1");
+        assertThrows(Pcre2MatchException.class, () -> code.dfaMatch("aa"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void dfaMatchNotPartialByDefault(IPcre2 api) {
+        var code = new Pcre2Code(api, "hello");
+        var result = code.dfaMatch("hello");
+
+        assertNotNull(result, "DFA match should succeed");
+        assertEquals(false, result.isPartial(), "Full match should not be partial");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void dfaMatchStartOffsetAtEnd(IPcre2 api) {
+        // Pattern $ matches at end of string
+        var code = new Pcre2Code(api, "$");
+        var subject = "abc";
+        var result = code.dfaMatch(subject, subject.length(), null, null, 1000);
+
+        assertNotNull(result, "Pattern $ should match at end of string with DFA");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void dfaMatchEmptySubject(IPcre2 api) {
+        var code = new Pcre2Code(api, "^$");
+        var result = code.dfaMatch("");
+
+        assertNotNull(result, "Empty string should match pattern ^$ with DFA");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void dfaMatchEnumOptions(IPcre2 api) {
+        // Verify DFA options combine correctly
+        var code = new Pcre2Code(api, "hello");
+        var options = EnumSet.of(Pcre2DfaMatchOption.ANCHORED, Pcre2DfaMatchOption.NOTBOL);
+
+        // ANCHORED + NOTBOL: match only at first position but not at beginning of line
+        // For pattern "hello" in "hello", ANCHORED works but NOTBOL shouldn't affect this
+        var result = code.dfaMatch("hello", 0, options, null, 1000);
+        assertNotNull(result, "DFA match with combined options should succeed");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `Pcre2DfaMatchOption` enum for DFA-specific match options (`RESTART`, `SHORTEST`) plus shared options (`ANCHORED`, `PARTIAL_SOFT`, etc.)
- Adds `Pcre2DfaMatchResult` record with match start, all possible match end positions (longest-to-shortest), and convenience accessors (`longestMatch()`, `shortestMatch()`, `match(index)`)
- Adds `Pcre2Code.dfaMatch()` methods (full overload + convenience) with auto-retry on workspace-too-small, partial match support, and byte-to-character offset translation

Fixes #440

## Test plan

- [x] Basic DFA match succeeds with correct offsets
- [x] No-match returns null
- [x] Start offset matching works correctly
- [x] Multiple alternative match lengths are returned (longest first)
- [x] `SHORTEST` option returns only the shortest match
- [x] Unicode patterns match correctly with proper offset translation
- [x] Partial matching (`PARTIAL_SOFT`) works
- [x] Invalid inputs throw `IllegalArgumentException` (null subject, negative offset, offset past end, zero workspace)
- [x] Unsupported patterns (backreferences) throw `Pcre2MatchException`
- [x] Match context integration works
- [x] Result accessor methods work correctly
- [x] Full build passes across all modules (api, lib, jna, ffm, regex)
- [x] Checkstyle passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)