### PR TITLE
(feat) lib: glob and POSIX pattern conversion through high-level API

### DIFF
--- a/api/src/main/java/org/pcre4j/api/IPcre2.java
+++ b/api/src/main/java/org/pcre4j/api/IPcre2.java
@@ -2052,6 +2052,21 @@ public interface IPcre2 {
     void convertedPatternFree(long convertedPattern);
 
     /**
+     * Read a converted pattern from native memory as a Java String.
+     * <p>
+     * This method reads a UTF-8 encoded string from the native memory pointer returned by
+     * {@link #patternConvert(String, int, long[], long[], long)}. The pointer and length should be
+     * obtained from the {@code buffer} and {@code blength} output parameters of that method.
+     *
+     * @param convertedPattern the pointer to the converted pattern (as returned in the buffer parameter
+     *                         of {@link #patternConvert(String, int, long[], long[], long)})
+     * @param length           the length of the converted pattern in bytes (as returned in the blength
+     *                         parameter of {@link #patternConvert(String, int, long[], long[], long)})
+     * @return the converted pattern as a Java String
+     */
+    String readConvertedPattern(long convertedPattern, long length);
+
+    /**
      * Match a compiled pattern against a subject string.
      *
      * @param code        the compiled pattern handle

--- a/ffm/src/main/java/org/pcre4j/ffm/Pcre2.java
+++ b/ffm/src/main/java/org/pcre4j/ffm/Pcre2.java
@@ -1552,6 +1552,21 @@ public class Pcre2 implements IPcre2, INativeMemoryAccess {
     }
 
     @Override
+    public String readConvertedPattern(long convertedPattern, long length) {
+        if (convertedPattern == 0) {
+            throw new IllegalArgumentException("convertedPattern must not be null");
+        }
+        if (length < 0) {
+            throw new IllegalArgumentException("length must not be negative");
+        }
+
+        final var byteLength = length * codeUnitSize;
+        final var segment = MemorySegment.ofAddress(convertedPattern).reinterpret(byteLength);
+        final var bytes = segment.toArray(ValueLayout.JAVA_BYTE);
+        return new String(bytes, charset);
+    }
+
+    @Override
     public int match(long code, String subject, int startoffset, int options, long matchData, long mcontext) {
         if (subject == null) {
             throw new IllegalArgumentException("subject must not be null");

--- a/jna/src/main/java/org/pcre4j/jna/Pcre2.java
+++ b/jna/src/main/java/org/pcre4j/jna/Pcre2.java
@@ -526,6 +526,20 @@ public class Pcre2 implements IPcre2, INativeMemoryAccess {
     }
 
     @Override
+    public String readConvertedPattern(long convertedPattern, long length) {
+        if (convertedPattern == 0) {
+            throw new IllegalArgumentException("convertedPattern must not be null");
+        }
+        if (length < 0) {
+            throw new IllegalArgumentException("length must not be negative");
+        }
+
+        final var pConvertedPattern = new Pointer(convertedPattern);
+        final var bytes = pConvertedPattern.getByteArray(0, (int) (length * codeUnitSize));
+        return new String(bytes, charset);
+    }
+
+    @Override
     public int match(long code, String subject, int startoffset, int options, long matchData, long mcontext) {
         if (subject == null) {
             throw new IllegalArgumentException("subject must not be null");

--- a/lib/src/main/java/org/pcre4j/Pcre2ConvertContext.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2ConvertContext.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j;
+
+import org.pcre4j.api.IPcre2;
+
+import java.lang.ref.Cleaner;
+
+/**
+ * A convert context for controlling pattern conversion settings.
+ * <p>
+ * Convert contexts are used to hold parameters for the PCRE2 pattern conversion function, which
+ * converts glob patterns or POSIX regular expressions into PCRE2-compatible patterns.
+ * <p>
+ * Settings that can be configured through a convert context include the glob escape character
+ * and the glob path separator character.
+ */
+public class Pcre2ConvertContext {
+
+    /**
+     * The convert context handle
+     */
+    /* package-private */ final long handle;
+
+    /**
+     * The PCRE2 API reference to use across the entire lifecycle of the object
+     */
+    /* package-private */ final IPcre2 api;
+
+    /**
+     * The cleaner to free the resources
+     */
+    private final Cleaner.Cleanable cleanable;
+
+    /**
+     * Create a new convert context using the default PCRE2 API.
+     *
+     * @param generalContext the general context to use or {@code null} to use the default context
+     */
+    public Pcre2ConvertContext(Pcre2GeneralContext generalContext) {
+        this(Pcre4j.api(), generalContext);
+    }
+
+    /**
+     * Create a new convert context.
+     *
+     * @param api            the PCRE2 API to use
+     * @param generalContext the general context to use or {@code null} to use the default context
+     */
+    public Pcre2ConvertContext(IPcre2 api, Pcre2GeneralContext generalContext) {
+        if (api == null) {
+            throw new IllegalArgumentException("api cannot be null");
+        }
+
+        final var handle = api.convertContextCreate(
+                generalContext != null ? generalContext.handle : 0
+        );
+        if (handle == 0) {
+            throw new IllegalStateException("Failed to create convert context");
+        }
+
+        this.api = api;
+        this.handle = handle;
+        this.cleanable = Pcre4jCleaner.INSTANCE.register(this, new Pcre2ConvertContext.Clean(api, handle));
+    }
+
+    /**
+     * Get the PCRE2 API backing this convert context.
+     *
+     * @return the PCRE2 API
+     */
+    public IPcre2 api() {
+        return api;
+    }
+
+    /**
+     * Get the handle of the convert context.
+     *
+     * @return the handle of the convert context
+     */
+    public long handle() {
+        return handle;
+    }
+
+    /**
+     * Set the escape character for glob pattern conversion.
+     * <p>
+     * The escape character allows special glob characters to be treated as literals. The default
+     * escape character is the grave accent ({@code `}) on Windows systems and the backslash
+     * ({@code \}) on other platforms.
+     * <p>
+     * Setting the escape character to zero disables escape processing entirely. The escape character
+     * must be zero (to disable) or a punctuation character with a code point less than 256.
+     *
+     * @param escapeChar the escape character to use, or 0 to disable escape processing
+     */
+    public void setGlobEscape(int escapeChar) {
+        final var result = api.setGlobEscape(handle, escapeChar);
+        if (result != 0) {
+            final var errorMessage = Pcre4jUtils.getErrorMessage(api, result);
+            throw new IllegalStateException(errorMessage);
+        }
+    }
+
+    /**
+     * Set the path separator character for glob pattern conversion.
+     * <p>
+     * This affects how path-like patterns are parsed during glob conversion. The separator character
+     * must be one of forward slash ({@code /}), backslash ({@code \}), or dot ({@code .}).
+     * <p>
+     * On Windows systems, backslash is the default separator; on other platforms, forward slash
+     * is the default.
+     *
+     * @param separatorChar the separator character to use (must be {@code '/'}, {@code '\\'}, or {@code '.'})
+     */
+    public void setGlobSeparator(int separatorChar) {
+        final var result = api.setGlobSeparator(handle, separatorChar);
+        if (result != 0) {
+            final var errorMessage = Pcre4jUtils.getErrorMessage(api, result);
+            throw new IllegalStateException(errorMessage);
+        }
+    }
+
+    private record Clean(IPcre2 api, long convertContext) implements Runnable {
+        @Override
+        public void run() {
+            api.convertContextFree(convertContext);
+        }
+    }
+
+}

--- a/lib/src/main/java/org/pcre4j/Pcre2ConvertException.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2ConvertException.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j;
+
+/**
+ * An exception that occurs when a pattern conversion fails.
+ * <p>
+ * This exception is thrown when PCRE2's pattern conversion function encounters an error while
+ * converting a glob or POSIX pattern to a PCRE2-compatible pattern.
+ */
+public class Pcre2ConvertException extends Pcre2Exception {
+
+    /**
+     * The pattern that caused the error.
+     */
+    private final String pattern;
+
+    /**
+     * Create a new pattern conversion exception.
+     *
+     * @param pattern   the pattern that failed to convert
+     * @param message   the error message
+     * @param errorCode the PCRE2 native error code
+     */
+    public Pcre2ConvertException(String pattern, String message, int errorCode) {
+        this(pattern, message, errorCode, null);
+    }
+
+    /**
+     * Create a new pattern conversion exception.
+     *
+     * @param pattern   the pattern that failed to convert
+     * @param message   the error message
+     * @param errorCode the PCRE2 native error code
+     * @param cause     the cause of the exception
+     */
+    public Pcre2ConvertException(String pattern, String message, int errorCode, Throwable cause) {
+        super(
+                "Error converting pattern \"%s\": %s".formatted(pattern, message),
+                errorCode,
+                cause
+        );
+        this.pattern = pattern;
+    }
+
+    /**
+     * Get the pattern that caused the error.
+     *
+     * @return the pattern
+     */
+    public String pattern() {
+        return pattern;
+    }
+}

--- a/lib/src/main/java/org/pcre4j/Pcre2ConvertOption.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2ConvertOption.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j;
+
+import org.pcre4j.api.IPcre2;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Options for pattern conversion via {@link Pcre2PatternConverter}.
+ * <p>
+ * These options control the behavior of the PCRE2 pattern conversion functions, which convert
+ * glob patterns or POSIX regular expressions into PCRE2-compatible patterns.
+ */
+public enum Pcre2ConvertOption {
+
+    /**
+     * Treat the input pattern as a UTF string
+     */
+    UTF(IPcre2.CONVERT_UTF),
+
+    /**
+     * Skip UTF validity check on the input pattern
+     */
+    NO_UTF_CHECK(IPcre2.CONVERT_NO_UTF_CHECK),
+
+    /**
+     * Convert a POSIX basic regular expression
+     */
+    POSIX_BASIC(IPcre2.CONVERT_POSIX_BASIC),
+
+    /**
+     * Convert a POSIX extended regular expression
+     */
+    POSIX_EXTENDED(IPcre2.CONVERT_POSIX_EXTENDED),
+
+    /**
+     * Convert a glob pattern
+     */
+    GLOB(IPcre2.CONVERT_GLOB),
+
+    /**
+     * Convert a glob pattern where wildcards do not match the path separator
+     */
+    GLOB_NO_WILD_SEPARATOR(IPcre2.CONVERT_GLOB_NO_WILD_SEPARATOR),
+
+    /**
+     * Convert a glob pattern with the double-star ({@code **}) feature disabled
+     */
+    GLOB_NO_STARSTAR(IPcre2.CONVERT_GLOB_NO_STARSTAR);
+
+    /**
+     * The integer value of the option
+     */
+    private final int value;
+
+    /**
+     * Create a new enum value for the given option value.
+     *
+     * @param value the integer value of the option
+     */
+    private Pcre2ConvertOption(int value) {
+        this.value = value;
+    }
+
+    /**
+     * Get the enum value by its option value.
+     *
+     * @param value the integer value of the option
+     * @return the option
+     */
+    public static Optional<Pcre2ConvertOption> valueOf(int value) {
+        return Arrays.stream(values())
+                .filter(flag -> flag.value == value)
+                .findFirst();
+    }
+
+    /**
+     * Get the option value of the enum value.
+     *
+     * @return the integer value of the option
+     */
+    public int value() {
+        return value;
+    }
+
+}

--- a/lib/src/main/java/org/pcre4j/Pcre2Exception.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2Exception.java
@@ -22,6 +22,7 @@ package org.pcre4j;
  * error code when applicable, enabling programmatic error handling.
  *
  * @see Pcre2CompileException
+ * @see Pcre2ConvertException
  * @see Pcre2MatchException
  * @see Pcre2SubstituteException
  * @see Pcre2SubstringException

--- a/lib/src/main/java/org/pcre4j/Pcre2PatternConverter.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2PatternConverter.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j;
+
+import org.pcre4j.api.IPcre2;
+
+import java.util.EnumSet;
+
+/**
+ * Utility class for converting glob patterns and POSIX regular expressions into PCRE2-compatible patterns.
+ * <p>
+ * This class wraps PCRE2's experimental pattern conversion function ({@code pcre2_pattern_convert})
+ * to provide a convenient Java API. It supports three types of pattern conversion:
+ * <ul>
+ * <li><strong>Glob patterns</strong> — shell-style wildcards (e.g., {@code *.txt}, {@code src/**\/*.java})</li>
+ * <li><strong>POSIX Basic Regular Expressions</strong> (BRE) — traditional Unix regex syntax</li>
+ * <li><strong>POSIX Extended Regular Expressions</strong> (ERE) — modern Unix regex syntax</li>
+ * </ul>
+ * <p>
+ * Example usage:
+ * <pre>{@code
+ * // Convert a glob pattern to PCRE2
+ * String pcre2Pattern = Pcre2PatternConverter.fromGlob("*.txt");
+ *
+ * // Convert with glob options
+ * String pcre2Pattern = Pcre2PatternConverter.fromGlob("src/**\/*.java",
+ *         EnumSet.of(Pcre2ConvertOption.GLOB_NO_WILD_SEPARATOR));
+ *
+ * // Convert a POSIX extended regex to PCRE2
+ * String pcre2Pattern = Pcre2PatternConverter.fromPosixEre("[[:alpha:]]+");
+ * }</pre>
+ */
+public final class Pcre2PatternConverter {
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private Pcre2PatternConverter() {
+    }
+
+    /**
+     * Convert a glob pattern to a PCRE2 regular expression using the default PCRE2 API.
+     *
+     * @param glob the glob pattern to convert (e.g., {@code *.txt}, {@code src/**\/*.java})
+     * @return the equivalent PCRE2 regular expression pattern
+     * @throws Pcre2ConvertException if the glob pattern has invalid syntax
+     */
+    public static String fromGlob(String glob) {
+        return fromGlob(Pcre4j.api(), glob, EnumSet.noneOf(Pcre2ConvertOption.class), null);
+    }
+
+    /**
+     * Convert a glob pattern to a PCRE2 regular expression using the default PCRE2 API.
+     *
+     * @param glob    the glob pattern to convert
+     * @param options additional conversion options (e.g., {@link Pcre2ConvertOption#GLOB_NO_WILD_SEPARATOR})
+     * @return the equivalent PCRE2 regular expression pattern
+     * @throws Pcre2ConvertException if the glob pattern has invalid syntax
+     */
+    public static String fromGlob(String glob, EnumSet<Pcre2ConvertOption> options) {
+        return fromGlob(Pcre4j.api(), glob, options, null);
+    }
+
+    /**
+     * Convert a glob pattern to a PCRE2 regular expression using the default PCRE2 API.
+     *
+     * @param glob           the glob pattern to convert
+     * @param options        additional conversion options
+     * @param convertContext the convert context for additional settings (e.g., custom separator), or {@code null}
+     * @return the equivalent PCRE2 regular expression pattern
+     * @throws Pcre2ConvertException if the glob pattern has invalid syntax
+     */
+    public static String fromGlob(String glob, EnumSet<Pcre2ConvertOption> options,
+                                  Pcre2ConvertContext convertContext) {
+        return fromGlob(Pcre4j.api(), glob, options, convertContext);
+    }
+
+    /**
+     * Convert a glob pattern to a PCRE2 regular expression.
+     *
+     * @param api            the PCRE2 API to use
+     * @param glob           the glob pattern to convert
+     * @param options        additional conversion options
+     * @param convertContext the convert context for additional settings, or {@code null}
+     * @return the equivalent PCRE2 regular expression pattern
+     * @throws Pcre2ConvertException if the glob pattern has invalid syntax
+     */
+    public static String fromGlob(IPcre2 api, String glob, EnumSet<Pcre2ConvertOption> options,
+                                  Pcre2ConvertContext convertContext) {
+        if (api == null) {
+            throw new IllegalArgumentException("api must not be null");
+        }
+        if (glob == null) {
+            throw new IllegalArgumentException("glob must not be null");
+        }
+        if (options == null) {
+            options = EnumSet.noneOf(Pcre2ConvertOption.class);
+        }
+
+        var optionBits = IPcre2.CONVERT_GLOB;
+        for (var option : options) {
+            optionBits |= option.value();
+        }
+
+        return convert(api, glob, optionBits, convertContext);
+    }
+
+    /**
+     * Convert a POSIX Basic Regular Expression (BRE) to a PCRE2 pattern using the default PCRE2 API.
+     *
+     * @param bre the POSIX basic regular expression to convert
+     * @return the equivalent PCRE2 regular expression pattern
+     * @throws Pcre2ConvertException if the pattern has invalid syntax
+     */
+    public static String fromPosixBre(String bre) {
+        return fromPosixBre(Pcre4j.api(), bre);
+    }
+
+    /**
+     * Convert a POSIX Basic Regular Expression (BRE) to a PCRE2 pattern.
+     *
+     * @param api the PCRE2 API to use
+     * @param bre the POSIX basic regular expression to convert
+     * @return the equivalent PCRE2 regular expression pattern
+     * @throws Pcre2ConvertException if the pattern has invalid syntax
+     */
+    public static String fromPosixBre(IPcre2 api, String bre) {
+        if (api == null) {
+            throw new IllegalArgumentException("api must not be null");
+        }
+        if (bre == null) {
+            throw new IllegalArgumentException("bre must not be null");
+        }
+
+        return convert(api, bre, IPcre2.CONVERT_POSIX_BASIC, null);
+    }
+
+    /**
+     * Convert a POSIX Extended Regular Expression (ERE) to a PCRE2 pattern using the default PCRE2 API.
+     *
+     * @param ere the POSIX extended regular expression to convert
+     * @return the equivalent PCRE2 regular expression pattern
+     * @throws Pcre2ConvertException if the pattern has invalid syntax
+     */
+    public static String fromPosixEre(String ere) {
+        return fromPosixEre(Pcre4j.api(), ere);
+    }
+
+    /**
+     * Convert a POSIX Extended Regular Expression (ERE) to a PCRE2 pattern.
+     *
+     * @param api the PCRE2 API to use
+     * @param ere the POSIX extended regular expression to convert
+     * @return the equivalent PCRE2 regular expression pattern
+     * @throws Pcre2ConvertException if the pattern has invalid syntax
+     */
+    public static String fromPosixEre(IPcre2 api, String ere) {
+        if (api == null) {
+            throw new IllegalArgumentException("api must not be null");
+        }
+        if (ere == null) {
+            throw new IllegalArgumentException("ere must not be null");
+        }
+
+        return convert(api, ere, IPcre2.CONVERT_POSIX_EXTENDED, null);
+    }
+
+    /**
+     * Convert a pattern using the specified conversion options.
+     * <p>
+     * This is the general-purpose conversion method that accepts raw option bits. Prefer using
+     * the typed methods ({@link #fromGlob}, {@link #fromPosixBre}, {@link #fromPosixEre}) for
+     * most use cases.
+     *
+     * @param api            the PCRE2 API to use
+     * @param pattern        the pattern to convert
+     * @param options        the conversion options
+     * @param convertContext the convert context for additional settings, or {@code null}
+     * @return the equivalent PCRE2 regular expression pattern
+     * @throws Pcre2ConvertException if the pattern has invalid syntax
+     */
+    public static String convert(IPcre2 api, String pattern, EnumSet<Pcre2ConvertOption> options,
+                                 Pcre2ConvertContext convertContext) {
+        if (api == null) {
+            throw new IllegalArgumentException("api must not be null");
+        }
+        if (pattern == null) {
+            throw new IllegalArgumentException("pattern must not be null");
+        }
+        if (options == null || options.isEmpty()) {
+            throw new IllegalArgumentException("options must contain at least one conversion type");
+        }
+
+        var optionBits = 0;
+        for (var option : options) {
+            optionBits |= option.value();
+        }
+
+        return convert(api, pattern, optionBits, convertContext);
+    }
+
+    /**
+     * Internal conversion method that calls the PCRE2 API.
+     *
+     * @param api            the PCRE2 API to use
+     * @param pattern        the pattern to convert
+     * @param options        the raw option bits
+     * @param convertContext the convert context, or {@code null}
+     * @return the converted PCRE2 pattern
+     * @throws Pcre2ConvertException if conversion fails
+     */
+    private static String convert(IPcre2 api, String pattern, int options,
+                                  Pcre2ConvertContext convertContext) {
+        final var buffer = new long[]{0};
+        final var blength = new long[]{0};
+
+        final var result = api.patternConvert(
+                pattern,
+                options,
+                buffer,
+                blength,
+                convertContext != null ? convertContext.handle : 0
+        );
+
+        if (result != 0) {
+            throw new Pcre2ConvertException(pattern, Pcre4jUtils.getErrorMessage(api, result), result);
+        }
+
+        try {
+            return api.readConvertedPattern(buffer[0], blength[0]);
+        } finally {
+            api.convertedPatternFree(buffer[0]);
+        }
+    }
+
+}

--- a/lib/src/test/java/org/pcre4j/Pcre2ContextTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2ContextTests.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for context classes: {@link Pcre2GeneralContext}, {@link Pcre2CompileContext},
- * {@link Pcre2MatchContext}, and {@link Pcre2JitStack}.
+ * {@link Pcre2MatchContext}, {@link Pcre2ConvertContext}, and {@link Pcre2JitStack}.
  */
 public class Pcre2ContextTests {
 
@@ -476,5 +476,79 @@ public class Pcre2ContextTests {
         var matchData = new Pcre2MatchData(code);
         var result = code.match("world", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, matchCtx);
         assertTrue(result > 0, "JIT match with custom stack and general context should succeed");
+    }
+
+    // === Pcre2ConvertContext ===
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void convertContextCreation(IPcre2 api) {
+        var ctx = new Pcre2ConvertContext(api, null);
+        assertNotNull(ctx);
+        assertNotNull(ctx.api());
+        assertEquals(api, ctx.api());
+        assertTrue(ctx.handle() != 0);
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void convertContextNullApiThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () -> new Pcre2ConvertContext(null, null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void convertContextWithGeneralContext(IPcre2 api) {
+        var generalCtx = new Pcre2GeneralContext(api);
+        assertDoesNotThrow(() -> new Pcre2ConvertContext(api, generalCtx));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void convertContextSetGlobEscape(IPcre2 api) {
+        var ctx = new Pcre2ConvertContext(api, null);
+        assertDoesNotThrow(() -> ctx.setGlobEscape('\\'));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void convertContextSetGlobEscapeDisable(IPcre2 api) {
+        var ctx = new Pcre2ConvertContext(api, null);
+        assertDoesNotThrow(() -> ctx.setGlobEscape(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void convertContextSetGlobEscapeInvalid(IPcre2 api) {
+        var ctx = new Pcre2ConvertContext(api, null);
+        assertThrows(IllegalStateException.class, () -> ctx.setGlobEscape('a'));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void convertContextSetGlobSeparatorForwardSlash(IPcre2 api) {
+        var ctx = new Pcre2ConvertContext(api, null);
+        assertDoesNotThrow(() -> ctx.setGlobSeparator('/'));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void convertContextSetGlobSeparatorBackslash(IPcre2 api) {
+        var ctx = new Pcre2ConvertContext(api, null);
+        assertDoesNotThrow(() -> ctx.setGlobSeparator('\\'));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void convertContextSetGlobSeparatorDot(IPcre2 api) {
+        var ctx = new Pcre2ConvertContext(api, null);
+        assertDoesNotThrow(() -> ctx.setGlobSeparator('.'));
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void convertContextSetGlobSeparatorInvalid(IPcre2 api) {
+        var ctx = new Pcre2ConvertContext(api, null);
+        assertThrows(IllegalStateException.class, () -> ctx.setGlobSeparator('a'));
     }
 }

--- a/lib/src/test/java/org/pcre4j/Pcre2EnumTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2EnumTests.java
@@ -405,4 +405,54 @@ public class Pcre2EnumTests {
         assertNotNull(error.getMessage());
         assertEquals(cause, error.getCause());
     }
+
+    // === Pcre2ConvertOption ===
+
+    @Test
+    void convertOptionValueOfValid() {
+        assertTrue(Pcre2ConvertOption.valueOf(IPcre2.CONVERT_GLOB).isPresent());
+        assertEquals(Pcre2ConvertOption.GLOB, Pcre2ConvertOption.valueOf(IPcre2.CONVERT_GLOB).get());
+
+        assertTrue(Pcre2ConvertOption.valueOf(IPcre2.CONVERT_POSIX_BASIC).isPresent());
+        assertEquals(Pcre2ConvertOption.POSIX_BASIC, Pcre2ConvertOption.valueOf(IPcre2.CONVERT_POSIX_BASIC).get());
+
+        assertTrue(Pcre2ConvertOption.valueOf(IPcre2.CONVERT_POSIX_EXTENDED).isPresent());
+        assertEquals(Pcre2ConvertOption.POSIX_EXTENDED,
+                Pcre2ConvertOption.valueOf(IPcre2.CONVERT_POSIX_EXTENDED).get());
+    }
+
+    @Test
+    void convertOptionValueOfInvalid() {
+        assertFalse(Pcre2ConvertOption.valueOf(-999).isPresent());
+    }
+
+    @Test
+    void convertOptionValue() {
+        assertEquals(IPcre2.CONVERT_UTF, Pcre2ConvertOption.UTF.value());
+        assertEquals(IPcre2.CONVERT_NO_UTF_CHECK, Pcre2ConvertOption.NO_UTF_CHECK.value());
+        assertEquals(IPcre2.CONVERT_POSIX_BASIC, Pcre2ConvertOption.POSIX_BASIC.value());
+        assertEquals(IPcre2.CONVERT_POSIX_EXTENDED, Pcre2ConvertOption.POSIX_EXTENDED.value());
+        assertEquals(IPcre2.CONVERT_GLOB, Pcre2ConvertOption.GLOB.value());
+        assertEquals(IPcre2.CONVERT_GLOB_NO_WILD_SEPARATOR, Pcre2ConvertOption.GLOB_NO_WILD_SEPARATOR.value());
+        assertEquals(IPcre2.CONVERT_GLOB_NO_STARSTAR, Pcre2ConvertOption.GLOB_NO_STARSTAR.value());
+    }
+
+    // === Pcre2ConvertException ===
+
+    @Test
+    void convertExceptionMessage() {
+        var ex = new Pcre2ConvertException("*.{bad", "invalid syntax", IPcre2.ERROR_CONVERT_SYNTAX);
+        assertNotNull(ex.getMessage());
+        assertTrue(ex.getMessage().contains("*.{bad"));
+        assertTrue(ex.getMessage().contains("invalid syntax"));
+        assertEquals("*.{bad", ex.pattern());
+        assertEquals(IPcre2.ERROR_CONVERT_SYNTAX, ex.errorCode());
+    }
+
+    @Test
+    void convertExceptionWithCause() {
+        var cause = new RuntimeException("underlying");
+        var ex = new Pcre2ConvertException("pattern", "error", -64, cause);
+        assertEquals(cause, ex.getCause());
+    }
 }

--- a/lib/src/test/java/org/pcre4j/Pcre2PatternConverterTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2PatternConverterTests.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.pcre4j.api.IPcre2;
+
+import java.util.EnumSet;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Pcre2PatternConverterTests {
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void fromGlobSimple(IPcre2 api) {
+        var result = Pcre2PatternConverter.fromGlob(api, "*.txt",
+                EnumSet.noneOf(Pcre2ConvertOption.class), null);
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+
+        // Verify the converted pattern can be compiled and matches correctly
+        var code = new Pcre2Code(api, result);
+        var matchData = new Pcre2MatchData(code);
+
+        assertTrue(code.match("file.txt", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null) >= 0,
+                "Glob *.txt should match file.txt");
+        assertTrue(code.match("report.txt", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null) >= 0,
+                "Glob *.txt should match report.txt");
+        assertTrue(code.match(".txt", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null) >= 0,
+                "Glob *.txt should match .txt");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void fromGlobNoMatch(IPcre2 api) {
+        var result = Pcre2PatternConverter.fromGlob(api, "*.txt",
+                EnumSet.noneOf(Pcre2ConvertOption.class), null);
+        var code = new Pcre2Code(api, result);
+        var matchData = new Pcre2MatchData(code);
+
+        assertTrue(code.match("file.pdf", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null) < 0,
+                "Glob *.txt should not match file.pdf");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void fromGlobQuestionMark(IPcre2 api) {
+        var result = Pcre2PatternConverter.fromGlob(api, "file?.log",
+                EnumSet.noneOf(Pcre2ConvertOption.class), null);
+        var code = new Pcre2Code(api, result);
+        var matchData = new Pcre2MatchData(code);
+
+        assertTrue(code.match("file1.log", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null) >= 0,
+                "Glob file?.log should match file1.log");
+        assertTrue(code.match("fileX.log", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null) >= 0,
+                "Glob file?.log should match fileX.log");
+        assertTrue(code.match("file.log", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null) < 0,
+                "Glob file?.log should not match file.log (? requires exactly one char)");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void fromGlobWithConvertContext(IPcre2 api) {
+        var convertContext = new Pcre2ConvertContext(api, null);
+        convertContext.setGlobSeparator('/');
+
+        var result = Pcre2PatternConverter.fromGlob(api, "*.txt",
+                EnumSet.noneOf(Pcre2ConvertOption.class), convertContext);
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+
+        var code = new Pcre2Code(api, result);
+        var matchData = new Pcre2MatchData(code);
+
+        assertTrue(code.match("file.txt", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null) >= 0,
+                "Glob *.txt with context should match file.txt");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void fromPosixBre(IPcre2 api) {
+        // POSIX BRE: brackets require escaping for grouping
+        var result = Pcre2PatternConverter.fromPosixBre(api, "^[0-9]\\{3\\}$");
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+
+        var code = new Pcre2Code(api, result);
+        var matchData = new Pcre2MatchData(code);
+
+        assertTrue(code.match("123", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null) >= 0,
+                "POSIX BRE ^[0-9]\\{3\\}$ should match 123");
+        assertTrue(code.match("1234", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null) < 0,
+                "POSIX BRE ^[0-9]\\{3\\}$ should not match 1234");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void fromPosixEre(IPcre2 api) {
+        var result = Pcre2PatternConverter.fromPosixEre(api, "^[a-z]+$");
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+
+        var code = new Pcre2Code(api, result);
+        var matchData = new Pcre2MatchData(code);
+
+        assertTrue(code.match("hello", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null) >= 0,
+                "POSIX ERE ^[a-z]+$ should match hello");
+        assertTrue(code.match("Hello", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null) < 0,
+                "POSIX ERE ^[a-z]+$ should not match Hello");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void fromPosixEreWithCharacterClass(IPcre2 api) {
+        var result = Pcre2PatternConverter.fromPosixEre(api, "^[[:alpha:]]+$");
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+
+        var code = new Pcre2Code(api, result);
+        var matchData = new Pcre2MatchData(code);
+
+        assertTrue(code.match("Hello", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null) >= 0,
+                "POSIX ERE ^[[:alpha:]]+$ should match Hello");
+        assertTrue(code.match("123", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null) < 0,
+                "POSIX ERE ^[[:alpha:]]+$ should not match 123");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void convertWithEnumSetOptions(IPcre2 api) {
+        var result = Pcre2PatternConverter.convert(
+                api,
+                "*.java",
+                EnumSet.of(Pcre2ConvertOption.GLOB),
+                null
+        );
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+
+        var code = new Pcre2Code(api, result);
+        var matchData = new Pcre2MatchData(code);
+
+        assertTrue(code.match("Main.java", 0, EnumSet.noneOf(Pcre2MatchOption.class), matchData, null) >= 0,
+                "Converted glob *.java should match Main.java");
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void fromGlobNullPatternThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre2PatternConverter.fromGlob(api, null, EnumSet.noneOf(Pcre2ConvertOption.class), null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void fromPosixBreNullPatternThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre2PatternConverter.fromPosixBre(api, null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void fromPosixEreNullPatternThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre2PatternConverter.fromPosixEre(api, null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void convertNullApiThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre2PatternConverter.fromGlob(null, "*.txt", EnumSet.noneOf(Pcre2ConvertOption.class), null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("org.pcre4j.test.BackendProvider#parameters")
+    void convertEmptyOptionsThrows(IPcre2 api) {
+        assertThrows(IllegalArgumentException.class, () ->
+                Pcre2PatternConverter.convert(api, "*.txt", EnumSet.noneOf(Pcre2ConvertOption.class), null)
+        );
+    }
+}

--- a/lib/src/test/java/org/pcre4j/Pcre4jTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre4jTests.java
@@ -323,6 +323,11 @@ public class Pcre4jTests {
         }
 
         @Override
+        public String readConvertedPattern(long convertedPattern, long length) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public int match(long code, String subject, int startoffset, int options, long matchData, long mcontext) {
             throw new UnsupportedOperationException();
         }

--- a/lib/src/testFixtures/java/org/pcre4j/test/Pcre2PatternConvertContractTest.java
+++ b/lib/src/testFixtures/java/org/pcre4j/test/Pcre2PatternConvertContractTest.java
@@ -18,6 +18,8 @@ import org.junit.jupiter.api.Test;
 import org.pcre4j.api.IPcre2;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -56,6 +58,11 @@ public interface Pcre2PatternConvertContractTest<T extends IPcre2> {
         assertEquals(0, result, "patternConvert should return 0 on success");
         assertTrue(buffer[0] != 0, "Buffer should contain a pointer after conversion");
         assertTrue(blength[0] > 0, "blength should contain the pattern length");
+
+        // Read the converted pattern as a string
+        String convertedPattern = api.readConvertedPattern(buffer[0], blength[0]);
+        assertNotNull(convertedPattern, "Converted pattern should not be null");
+        assertFalse(convertedPattern.isEmpty(), "Converted pattern should not be empty");
 
         // The buffer was allocated by PCRE2, so we need to free it
         api.convertedPatternFree(buffer[0]);


### PR DESCRIPTION
## Summary

- Add `Pcre2PatternConverter` utility class wrapping PCRE2's experimental pattern conversion function to convert glob patterns and POSIX regular expressions (BRE/ERE) into PCRE2-compatible patterns
- Add `Pcre2ConvertOption` enum, `Pcre2ConvertContext` wrapper, and `Pcre2ConvertException` for the conversion API
- Add `IPcre2.readConvertedPattern()` method to both JNA and FFM backends for backend-agnostic reading of native converted pattern buffers

## Test plan

- [x] Glob pattern conversion: `*.txt` converts and matches `file.txt`, doesn't match `file.pdf`
- [x] Glob `?` wildcard: `file?.log` matches `file1.log`, doesn't match `file.log`
- [x] Glob with convert context (custom separator)
- [x] POSIX BRE conversion: `^[0-9]\{3\}$` matches `123`, doesn't match `1234`
- [x] POSIX ERE conversion: `^[a-z]+$` matches `hello`, doesn't match `Hello`
- [x] POSIX ERE character classes: `^[[:alpha:]]+$`
- [x] General `convert()` method with `EnumSet` options
- [x] Null argument validation (null pattern, null api, empty options)
- [x] Convert context creation, glob escape/separator settings
- [x] Enum value mapping tests for `Pcre2ConvertOption`
- [x] Exception message formatting tests for `Pcre2ConvertException`
- [x] Contract test update for `readConvertedPattern` in both backends
- [x] All existing tests continue to pass

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)