### PR TITLE
(feat) lib: add callout support in high-level API

### DIFF
--- a/api/src/main/java/org/pcre4j/api/IPcre2.java
+++ b/api/src/main/java/org/pcre4j/api/IPcre2.java
@@ -2700,4 +2700,49 @@ public interface IPcre2 {
      */
     int serializeGetNumberOfCodes(byte[] bytes);
 
+    /**
+     * Create a native callback function pointer for a callout handler.
+     * <p>
+     * The returned handle represents a native function pointer that, when called by PCRE2 during matching,
+     * reads the native {@code pcre2_callout_block} structure and delegates to the provided Java handler.
+     * <p>
+     * The handle must be freed with {@link #freeCalloutCallback(long)} when no longer needed.
+     *
+     * @param handler the Java callout handler to wrap
+     * @return a handle representing the native callback, for use with {@link #setCallout(long, long, long)}
+     * @throws IllegalArgumentException if handler is null
+     */
+    long createCalloutCallback(Pcre2CalloutHandler handler);
+
+    /**
+     * Free a native callback function pointer previously created by {@link #createCalloutCallback}.
+     *
+     * @param callbackHandle the handle returned by {@link #createCalloutCallback}
+     */
+    void freeCalloutCallback(long callbackHandle);
+
+    /**
+     * Create a native callback function pointer for a callout enumeration handler.
+     * <p>
+     * The returned handle represents a native function pointer that, when called by PCRE2 during
+     * callout enumeration, reads the native {@code pcre2_callout_enumerate_block} structure and
+     * delegates to the provided Java handler.
+     * <p>
+     * The handle must be freed with {@link #freeCalloutEnumerateCallback(long)} when no longer needed.
+     *
+     * @param handler the Java callout enumeration handler to wrap
+     * @return a handle representing the native callback, for use with
+     *         {@link #calloutEnumerate(long, long, long)}
+     * @throws IllegalArgumentException if handler is null
+     */
+    long createCalloutEnumerateCallback(Pcre2CalloutEnumerateHandler handler);
+
+    /**
+     * Free a native callback function pointer previously created by
+     * {@link #createCalloutEnumerateCallback}.
+     *
+     * @param callbackHandle the handle returned by {@link #createCalloutEnumerateCallback}
+     */
+    void freeCalloutEnumerateCallback(long callbackHandle);
+
 }

--- a/api/src/main/java/org/pcre4j/api/Pcre2CalloutBlock.java
+++ b/api/src/main/java/org/pcre4j/api/Pcre2CalloutBlock.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j.api;
+
+/**
+ * Information about a callout point reached during matching.
+ * <p>
+ * This record provides a Java-friendly view of the PCRE2 {@code pcre2_callout_block} structure.
+ * Instances are passed to {@link Pcre2CalloutHandler} during match operations when a callout point
+ * is reached in the pattern.
+ *
+ * @param calloutNumber       the callout number compiled into the pattern via {@code (?Cn)}, or 0 for
+ *                            string callouts ({@code (?C"string")}), or 255 for auto-callouts
+ * @param captureTop          one more than the number of the highest numbered captured group so far
+ * @param captureLast         the number of the most recently captured group
+ * @param startMatch          the offset in the subject where the current match attempt started
+ * @param currentPosition     the current position in the subject
+ * @param patternPosition     the offset in the pattern of the next item to be matched
+ * @param nextItemLength      the length of the next item in the pattern
+ * @param calloutStringOffset the offset to the callout string within the pattern (for string callouts)
+ * @param calloutStringLength the length of the callout string (for string callouts)
+ * @param calloutString       the string compiled into the pattern via {@code (?C"string")}, or {@code null}
+ *                            for numbered or auto-callouts
+ * @param calloutFlags        flags providing additional information:
+ *                            bit 0 ({@code PCRE2_CALLOUT_STARTMATCH}) is set for each bumpalong,
+ *                            bit 1 ({@code PCRE2_CALLOUT_BACKTRACK}) is set after a backtrack
+ * @see <a href="https://www.pcre.org/current/doc/html/pcre2callout.html">PCRE2 Callouts</a>
+ */
+public record Pcre2CalloutBlock(
+        int calloutNumber,
+        int captureTop,
+        int captureLast,
+        long startMatch,
+        long currentPosition,
+        long patternPosition,
+        long nextItemLength,
+        long calloutStringOffset,
+        long calloutStringLength,
+        String calloutString,
+        int calloutFlags
+) {
+}

--- a/api/src/main/java/org/pcre4j/api/Pcre2CalloutEnumerateBlock.java
+++ b/api/src/main/java/org/pcre4j/api/Pcre2CalloutEnumerateBlock.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j.api;
+
+/**
+ * Information about a callout point found during pattern enumeration.
+ * <p>
+ * This record provides a Java-friendly view of the PCRE2 {@code pcre2_callout_enumerate_block} structure.
+ * Instances are passed to {@link Pcre2CalloutEnumerateHandler} when enumerating callout points in a
+ * compiled pattern.
+ *
+ * @param patternPosition     the offset in the pattern of the next item after the callout
+ * @param nextItemLength      the length of the next item in the pattern
+ * @param calloutNumber       the callout number compiled into the pattern via {@code (?Cn)}, or 0 for
+ *                            string callouts ({@code (?C"string")}), or 255 for auto-callouts
+ * @param calloutStringOffset the offset to the callout string within the pattern (for string callouts)
+ * @param calloutStringLength the length of the callout string (for string callouts)
+ * @param calloutString       the string compiled into the pattern via {@code (?C"string")}, or {@code null}
+ *                            for numbered or auto-callouts
+ * @see <a href="https://www.pcre.org/current/doc/html/pcre2callout.html">PCRE2 Callouts</a>
+ */
+public record Pcre2CalloutEnumerateBlock(
+        long patternPosition,
+        long nextItemLength,
+        int calloutNumber,
+        long calloutStringOffset,
+        long calloutStringLength,
+        String calloutString
+) {
+}

--- a/api/src/main/java/org/pcre4j/api/Pcre2CalloutEnumerateHandler.java
+++ b/api/src/main/java/org/pcre4j/api/Pcre2CalloutEnumerateHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j.api;
+
+/**
+ * A handler for enumerating callout points in a compiled PCRE2 pattern.
+ * <p>
+ * The handler is called once for each callout point found in the pattern during enumeration.
+ *
+ * @see Pcre2CalloutEnumerateBlock
+ * @see <a href="https://www.pcre.org/current/doc/html/pcre2callout.html">PCRE2 Callouts</a>
+ */
+@FunctionalInterface
+public interface Pcre2CalloutEnumerateHandler {
+
+    /**
+     * Called for each callout point found in a compiled pattern.
+     *
+     * @param block the callout enumeration information block
+     * @return 0 to continue enumeration, or any non-zero value to stop enumeration
+     *         (the value becomes the return value of the enumeration function)
+     */
+    int onCallout(Pcre2CalloutEnumerateBlock block);
+}

--- a/api/src/main/java/org/pcre4j/api/Pcre2CalloutHandler.java
+++ b/api/src/main/java/org/pcre4j/api/Pcre2CalloutHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j.api;
+
+/**
+ * A handler for PCRE2 callouts during pattern matching.
+ * <p>
+ * When a callout point is reached during a match operation, the handler is invoked with information
+ * about the current match state. The handler can inspect the state and decide whether to continue
+ * or abort matching.
+ *
+ * @see Pcre2CalloutBlock
+ * @see <a href="https://www.pcre.org/current/doc/html/pcre2callout.html">PCRE2 Callouts</a>
+ */
+@FunctionalInterface
+public interface Pcre2CalloutHandler {
+
+    /**
+     * Called by PCRE2 during matching when a callout point is reached.
+     *
+     * @param block the callout information block
+     * @return 0 to continue matching, a positive value to force a match failure at the current point
+     *         (causing backtracking), or a negative value less than {@code PCRE2_ERROR_NOMATCH} to
+     *         abort matching with that error code
+     */
+    int onCallout(Pcre2CalloutBlock block);
+}

--- a/lib/src/test/java/org/pcre4j/Pcre4jTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre4jTests.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.api.Pcre2CalloutEnumerateHandler;
+import org.pcre4j.api.Pcre2CalloutHandler;
 
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
@@ -539,6 +541,26 @@ public class Pcre4jTests {
 
         @Override
         public int serializeGetNumberOfCodes(byte[] bytes) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long createCalloutCallback(Pcre2CalloutHandler handler) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void freeCalloutCallback(long callbackHandle) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long createCalloutEnumerateCallback(Pcre2CalloutEnumerateHandler handler) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void freeCalloutEnumerateCallback(long callbackHandle) {
             throw new UnsupportedOperationException();
         }
     }

--- a/lib/src/testFixtures/java/org/pcre4j/test/Pcre2CalloutContractTest.java
+++ b/lib/src/testFixtures/java/org/pcre4j/test/Pcre2CalloutContractTest.java
@@ -1,0 +1,505 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+package org.pcre4j.test;
+
+import org.junit.jupiter.api.Test;
+import org.pcre4j.Pcre2Code;
+import org.pcre4j.Pcre2CompileOption;
+import org.pcre4j.Pcre2MatchContext;
+import org.pcre4j.Pcre2MatchData;
+import org.pcre4j.Pcre2MatchOption;
+import org.pcre4j.api.IPcre2;
+import org.pcre4j.api.Pcre2CalloutBlock;
+import org.pcre4j.api.Pcre2CalloutEnumerateBlock;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Contract tests for PCRE2 callout operations.
+ *
+ * @param <T> the PCRE2 API implementation type
+ */
+public interface Pcre2CalloutContractTest<T extends IPcre2> {
+
+    /**
+     * Returns the PCRE2 API implementation to test.
+     *
+     * @return the PCRE2 API implementation
+     */
+    T getApi();
+
+    @Test
+    default void numberedCalloutInvokesHandler() {
+        final var code = new Pcre2Code(
+                getApi(),
+                "a(?C1)b",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+        final var matchData = new Pcre2MatchData(code);
+        final var matchContext = new Pcre2MatchContext(getApi(), null);
+
+        final var callouts = new ArrayList<Pcre2CalloutBlock>();
+        matchContext.setCallout(block -> {
+            callouts.add(block);
+            return 0;
+        });
+
+        final var result = code.match(
+                "ab",
+                0,
+                EnumSet.noneOf(Pcre2MatchOption.class),
+                matchData,
+                matchContext
+        );
+
+        assertTrue(result > 0, "Match should succeed");
+        assertFalse(callouts.isEmpty(), "Callout handler should have been invoked");
+        assertEquals(1, callouts.get(0).calloutNumber());
+    }
+
+    @Test
+    default void defaultCalloutInvokesHandlerWithZero() {
+        final var code = new Pcre2Code(
+                getApi(),
+                "a(?C)b",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+        final var matchData = new Pcre2MatchData(code);
+        final var matchContext = new Pcre2MatchContext(getApi(), null);
+
+        final var callouts = new ArrayList<Pcre2CalloutBlock>();
+        matchContext.setCallout(block -> {
+            callouts.add(block);
+            return 0;
+        });
+
+        final var result = code.match(
+                "ab",
+                0,
+                EnumSet.noneOf(Pcre2MatchOption.class),
+                matchData,
+                matchContext
+        );
+
+        assertTrue(result > 0, "Match should succeed");
+        assertFalse(callouts.isEmpty(), "Callout handler should have been invoked");
+        assertEquals(0, callouts.get(0).calloutNumber());
+    }
+
+    @Test
+    default void stringCalloutPassesString() {
+        final var code = new Pcre2Code(
+                getApi(),
+                "a(?C\"test\")b",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+        final var matchData = new Pcre2MatchData(code);
+        final var matchContext = new Pcre2MatchContext(getApi(), null);
+
+        final var callouts = new ArrayList<Pcre2CalloutBlock>();
+        matchContext.setCallout(block -> {
+            callouts.add(block);
+            return 0;
+        });
+
+        final var result = code.match(
+                "ab",
+                0,
+                EnumSet.noneOf(Pcre2MatchOption.class),
+                matchData,
+                matchContext
+        );
+
+        assertTrue(result > 0, "Match should succeed");
+        assertFalse(callouts.isEmpty(), "Callout handler should have been invoked");
+        assertEquals(0, callouts.get(0).calloutNumber(), "String callouts should have callout number 0");
+        assertNotNull(callouts.get(0).calloutString(), "String callout should have a string");
+        assertEquals("test", callouts.get(0).calloutString());
+    }
+
+    @Test
+    default void autoCalloutInvokesHandlerMultipleTimes() {
+        final var code = new Pcre2Code(
+                getApi(),
+                "abc",
+                EnumSet.of(Pcre2CompileOption.AUTO_CALLOUT),
+                null
+        );
+        final var matchData = new Pcre2MatchData(code);
+        final var matchContext = new Pcre2MatchContext(getApi(), null);
+
+        final var callouts = new ArrayList<Pcre2CalloutBlock>();
+        matchContext.setCallout(block -> {
+            callouts.add(block);
+            return 0;
+        });
+
+        final var result = code.match(
+                "abc",
+                0,
+                EnumSet.noneOf(Pcre2MatchOption.class),
+                matchData,
+                matchContext
+        );
+
+        assertTrue(result > 0, "Match should succeed");
+        // Auto-callout places a callout before each item and one at the end
+        assertTrue(callouts.size() > 1, "Auto-callout should invoke handler multiple times, got " + callouts.size());
+        // All auto-callouts have number 255
+        for (var callout : callouts) {
+            assertEquals(255, callout.calloutNumber(), "Auto-callouts should have number 255");
+        }
+    }
+
+    @Test
+    default void calloutAbortCausesNoMatch() {
+        final var code = new Pcre2Code(
+                getApi(),
+                "a(?C1)b",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+        final var matchData = new Pcre2MatchData(code);
+        final var matchContext = new Pcre2MatchContext(getApi(), null);
+
+        // Return 1 to force a backtrack/failure at the callout point
+        matchContext.setCallout(block -> 1);
+
+        final var result = code.match(
+                "ab",
+                0,
+                EnumSet.noneOf(Pcre2MatchOption.class),
+                matchData,
+                matchContext
+        );
+
+        assertEquals(IPcre2.ERROR_NOMATCH, result, "Match should fail when callout returns non-zero");
+    }
+
+    @Test
+    default void calloutAbortWithNegativeReturnsCalloutError() {
+        final var code = new Pcre2Code(
+                getApi(),
+                "a(?C1)b",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+        final var matchData = new Pcre2MatchData(code);
+        final var matchContext = new Pcre2MatchContext(getApi(), null);
+
+        // Return ERROR_CALLOUT to abort matching entirely
+        matchContext.setCallout(block -> IPcre2.ERROR_CALLOUT);
+
+        final var result = code.match(
+                "ab",
+                0,
+                EnumSet.noneOf(Pcre2MatchOption.class),
+                matchData,
+                matchContext
+        );
+
+        assertEquals(IPcre2.ERROR_CALLOUT, result, "Match should return ERROR_CALLOUT when handler returns it");
+    }
+
+    @Test
+    default void setCalloutNullDisablesCallout() {
+        final var code = new Pcre2Code(
+                getApi(),
+                "a(?C1)b",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+        final var matchData = new Pcre2MatchData(code);
+        final var matchContext = new Pcre2MatchContext(getApi(), null);
+
+        // First set a callout that aborts
+        matchContext.setCallout(block -> 1);
+
+        // Then disable it
+        matchContext.setCallout(null);
+
+        final var result = code.match(
+                "ab",
+                0,
+                EnumSet.noneOf(Pcre2MatchOption.class),
+                matchData,
+                matchContext
+        );
+
+        assertTrue(result > 0, "Match should succeed after callout is disabled");
+    }
+
+    @Test
+    default void replaceCalloutHandler() {
+        final var code = new Pcre2Code(
+                getApi(),
+                "a(?C1)b",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+        final var matchData = new Pcre2MatchData(code);
+        final var matchContext = new Pcre2MatchContext(getApi(), null);
+
+        // Set a callout that aborts
+        matchContext.setCallout(block -> 1);
+
+        // Replace with one that allows matching
+        final var callouts = new ArrayList<Pcre2CalloutBlock>();
+        matchContext.setCallout(block -> {
+            callouts.add(block);
+            return 0;
+        });
+
+        final var result = code.match(
+                "ab",
+                0,
+                EnumSet.noneOf(Pcre2MatchOption.class),
+                matchData,
+                matchContext
+        );
+
+        assertTrue(result > 0, "Match should succeed with replacement handler");
+        assertFalse(callouts.isEmpty(), "Replacement handler should have been invoked");
+    }
+
+    @Test
+    default void calloutBlockCurrentPosition() {
+        final var code = new Pcre2Code(
+                getApi(),
+                "a(?C1)b",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+        final var matchData = new Pcre2MatchData(code);
+        final var matchContext = new Pcre2MatchContext(getApi(), null);
+
+        final var callouts = new ArrayList<Pcre2CalloutBlock>();
+        matchContext.setCallout(block -> {
+            callouts.add(block);
+            return 0;
+        });
+
+        // Match "ab" at offset 2 in "XXab"
+        final var result = code.match(
+                "XXab",
+                0,
+                EnumSet.noneOf(Pcre2MatchOption.class),
+                matchData,
+                matchContext
+        );
+
+        assertTrue(result > 0, "Match should succeed");
+        assertFalse(callouts.isEmpty(), "Callout handler should have been invoked");
+        // After matching 'a', current position should be at 'b' (offset 3 in "XXab")
+        assertEquals(3, callouts.get(0).currentPosition(), "Current position should be after 'a'");
+        assertEquals(2, callouts.get(0).startMatch(), "Start match should be at position of 'a'");
+    }
+
+    @Test
+    default void enumerateCalloutsNullHandlerThrows() {
+        final var code = new Pcre2Code(
+                getApi(),
+                "a(?C1)b",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+        assertThrows(IllegalArgumentException.class, () -> code.enumerateCallouts(null));
+    }
+
+    @Test
+    default void enumerateCalloutsFindsNumberedCallout() {
+        final var code = new Pcre2Code(
+                getApi(),
+                "a(?C1)b(?C2)c",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+
+        final var callouts = new ArrayList<Pcre2CalloutEnumerateBlock>();
+        code.enumerateCallouts(block -> {
+            callouts.add(block);
+            return 0;
+        });
+
+        assertEquals(2, callouts.size(), "Should find 2 callout points");
+        assertEquals(1, callouts.get(0).calloutNumber());
+        assertEquals(2, callouts.get(1).calloutNumber());
+    }
+
+    @Test
+    default void enumerateCalloutsFindsStringCallout() {
+        final var code = new Pcre2Code(
+                getApi(),
+                "a(?C\"hello\")b",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+
+        final var callouts = new ArrayList<Pcre2CalloutEnumerateBlock>();
+        code.enumerateCallouts(block -> {
+            callouts.add(block);
+            return 0;
+        });
+
+        assertEquals(1, callouts.size(), "Should find 1 callout point");
+        assertEquals(0, callouts.get(0).calloutNumber(), "String callouts should have callout number 0");
+        assertNotNull(callouts.get(0).calloutString(), "Should have callout string");
+        assertEquals("hello", callouts.get(0).calloutString());
+    }
+
+    @Test
+    default void enumerateCalloutsPatternWithNoCallouts() {
+        final var code = new Pcre2Code(
+                getApi(),
+                "abc",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+
+        final var callouts = new ArrayList<Pcre2CalloutEnumerateBlock>();
+        code.enumerateCallouts(block -> {
+            callouts.add(block);
+            return 0;
+        });
+
+        assertTrue(callouts.isEmpty(), "Should find no callout points in pattern without callouts");
+    }
+
+    @Test
+    default void enumerateCalloutsAutoCallout() {
+        final var code = new Pcre2Code(
+                getApi(),
+                "abc",
+                EnumSet.of(Pcre2CompileOption.AUTO_CALLOUT),
+                null
+        );
+
+        final var callouts = new ArrayList<Pcre2CalloutEnumerateBlock>();
+        code.enumerateCallouts(block -> {
+            callouts.add(block);
+            return 0;
+        });
+
+        // Auto-callout should insert callout points before each item and at end
+        assertTrue(callouts.size() > 1, "Auto-callout should create multiple callout points, got " + callouts.size());
+    }
+
+    @Test
+    default void enumerateCalloutsStopEarly() {
+        final var code = new Pcre2Code(
+                getApi(),
+                "a(?C1)b(?C2)c(?C3)d",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+
+        final var callouts = new ArrayList<Pcre2CalloutEnumerateBlock>();
+        code.enumerateCallouts(block -> {
+            callouts.add(block);
+            // Stop after first callout
+            return 1;
+        });
+
+        assertEquals(1, callouts.size(), "Enumeration should stop after handler returns non-zero");
+        assertEquals(1, callouts.get(0).calloutNumber());
+    }
+
+    @Test
+    default void calloutWithoutHandlerDoesNothing() {
+        // A match context without a callout handler should not interfere with matching
+        final var code = new Pcre2Code(
+                getApi(),
+                "a(?C1)b",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+        final var matchData = new Pcre2MatchData(code);
+        final var matchContext = new Pcre2MatchContext(getApi(), null);
+
+        // Don't set any callout handler
+        final var result = code.match(
+                "ab",
+                0,
+                EnumSet.noneOf(Pcre2MatchOption.class),
+                matchData,
+                matchContext
+        );
+
+        assertTrue(result > 0, "Match should succeed without a callout handler set");
+    }
+
+    @Test
+    default void calloutPatternPosition() {
+        final var code = new Pcre2Code(
+                getApi(),
+                "a(?C1)b",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+
+        final var callouts = new ArrayList<Pcre2CalloutEnumerateBlock>();
+        code.enumerateCallouts(block -> {
+            callouts.add(block);
+            return 0;
+        });
+
+        assertEquals(1, callouts.size());
+        // The pattern position should point to 'b' (the next item after the callout)
+        assertTrue(callouts.get(0).patternPosition() > 0, "Pattern position should be > 0");
+        assertTrue(callouts.get(0).nextItemLength() > 0, "Next item length should be > 0");
+    }
+
+    @Test
+    default void multipleCalloutsWithDifferentNumbers() {
+        final var code = new Pcre2Code(
+                getApi(),
+                "(?C1)a(?C5)b(?C10)c",
+                EnumSet.noneOf(Pcre2CompileOption.class),
+                null
+        );
+        final var matchData = new Pcre2MatchData(code);
+        final var matchContext = new Pcre2MatchContext(getApi(), null);
+
+        final var numbers = new ArrayList<Integer>();
+        matchContext.setCallout(block -> {
+            numbers.add(block.calloutNumber());
+            return 0;
+        });
+
+        final var result = code.match(
+                "abc",
+                0,
+                EnumSet.noneOf(Pcre2MatchOption.class),
+                matchData,
+                matchContext
+        );
+
+        assertTrue(result > 0, "Match should succeed");
+        assertEquals(3, numbers.size(), "Should have 3 callouts");
+        assertEquals(1, numbers.get(0));
+        assertEquals(5, numbers.get(1));
+        assertEquals(10, numbers.get(2));
+    }
+}

--- a/lib/src/testFixtures/java/org/pcre4j/test/Pcre2Tests.java
+++ b/lib/src/testFixtures/java/org/pcre4j/test/Pcre2Tests.java
@@ -35,6 +35,7 @@ import org.pcre4j.api.Pcre2UtfWidth;
  *   <li>{@link Pcre2PatternConvertContractTest} - Pattern conversion (glob, POSIX)</li>
  *   <li>{@link Pcre2MiscContractTest} - Miscellaneous operations</li>
  *   <li>{@link Pcre2UtfWidthContractTest} - UTF width support (UTF-8, UTF-16, UTF-32)</li>
+ *   <li>{@link Pcre2CalloutContractTest} - Callout operations (matching and enumeration)</li>
  * </ul>
  */
 public abstract class Pcre2Tests implements
@@ -49,7 +50,8 @@ public abstract class Pcre2Tests implements
         Pcre2JitContractTest<IPcre2>,
         Pcre2PatternConvertContractTest<IPcre2>,
         Pcre2MiscContractTest<IPcre2>,
-        Pcre2UtfWidthContractTest<IPcre2> {
+        Pcre2UtfWidthContractTest<IPcre2>,
+        Pcre2CalloutContractTest<IPcre2> {
 
     protected final IPcre2 api;
 


### PR DESCRIPTION
## Summary
- Add callout support to the mid-level (lib) API with `Pcre2MatchContext.setCallout()` for match-time callout handling and `Pcre2Code.enumerateCallouts()` for pattern introspection
- Implement backend-agnostic callback lifecycle via `IPcre2.createCalloutCallback()`/`freeCalloutCallback()` factory methods with JNA and FFM backend implementations
- Add comprehensive contract tests covering numbered callouts, string callouts, auto-callouts, callout abort, handler replacement, and callout enumeration

## Test plan
- [x] All existing tests pass (JNA + FFM backends)
- [x] New `Pcre2CalloutContractTest` contract test suite with 17 tests covering:
  - Numbered callout `(?C1)` invocation and correct callout number
  - Default callout `(?C)` with callout number 0
  - String callout `(?C"test")` with string extraction
  - Auto-callout via `AUTO_CALLOUT` compile option
  - Callout abort (positive return → backtrack, negative return → error)
  - Handler replacement and null handler (disable)
  - Callout enumeration: numbered, string, auto-callout, no callouts, early stop
  - Callout block field verification (currentPosition, startMatch, patternPosition)
- [x] Checkstyle passes

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)