### PR TITLE
(feat) regex: support GraalVM native-image compilation

### DIFF
--- a/.github/native-image-test/NativeImageSmokeTest.java
+++ b/.github/native-image-test/NativeImageSmokeTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2024-2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+import org.pcre4j.Pcre4j;
+import org.pcre4j.ffm.Pcre2;
+import org.pcre4j.regex.Pattern;
+
+/**
+ * Smoke test for GraalVM native-image compilation of PCRE4J with the FFM backend.
+ * <p>
+ * Tests basic regex operations to verify that FFM downcalls, native library loading,
+ * and the high-level API all work correctly in a native image.
+ */
+public class NativeImageSmokeTest {
+
+    public static void main(String[] args) {
+        int failures = 0;
+
+        // Test 1: Explicit FFM backend initialization
+        try {
+            var api = new Pcre2();
+            Pcre4j.setup(api);
+            System.out.println("PASS: FFM backend initialized");
+        } catch (Exception e) {
+            System.err.println("FAIL: FFM backend initialization: " + e.getMessage());
+            failures++;
+        }
+
+        // Test 2: Basic pattern compilation and matching
+        try {
+            var pattern = Pattern.compile("\\d{3}-(\\d{3})-(\\d{4})");
+            var matcher = pattern.matcher("Call 555-123-4567 today");
+            if (!matcher.find()) {
+                throw new AssertionError("Expected match not found");
+            }
+            if (!matcher.group().equals("555-123-4567")) {
+                throw new AssertionError("Full match mismatch: " + matcher.group());
+            }
+            if (!matcher.group(1).equals("123")) {
+                throw new AssertionError("Group 1 mismatch: " + matcher.group(1));
+            }
+            if (!matcher.group(2).equals("4567")) {
+                throw new AssertionError("Group 2 mismatch: " + matcher.group(2));
+            }
+            System.out.println("PASS: Basic pattern matching");
+        } catch (Exception e) {
+            System.err.println("FAIL: Basic pattern matching: " + e.getMessage());
+            failures++;
+        }
+
+        // Test 3: Named capture groups
+        try {
+            var pattern = Pattern.compile("(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})");
+            var matcher = pattern.matcher("Date: 2026-02-14");
+            if (!matcher.find()) {
+                throw new AssertionError("Expected match not found");
+            }
+            if (!matcher.group("year").equals("2026")) {
+                throw new AssertionError("Named group mismatch: " + matcher.group("year"));
+            }
+            System.out.println("PASS: Named capture groups");
+        } catch (Exception e) {
+            System.err.println("FAIL: Named capture groups: " + e.getMessage());
+            failures++;
+        }
+
+        // Test 4: Pattern.matches convenience method
+        try {
+            if (!Pattern.matches("^[a-z]+$", "hello")) {
+                throw new AssertionError("Expected match");
+            }
+            if (Pattern.matches("^[a-z]+$", "Hello")) {
+                throw new AssertionError("Expected no match");
+            }
+            System.out.println("PASS: Pattern.matches");
+        } catch (Exception e) {
+            System.err.println("FAIL: Pattern.matches: " + e.getMessage());
+            failures++;
+        }
+
+        // Test 5: Case insensitive flag
+        try {
+            var pattern = Pattern.compile("hello", Pattern.CASE_INSENSITIVE);
+            var matcher = pattern.matcher("Hello World");
+            if (!matcher.find()) {
+                throw new AssertionError("Case insensitive match failed");
+            }
+            System.out.println("PASS: Case insensitive matching");
+        } catch (Exception e) {
+            System.err.println("FAIL: Case insensitive matching: " + e.getMessage());
+            failures++;
+        }
+
+        // Test 6: Replacement
+        try {
+            var pattern = Pattern.compile("\\bfoo\\b");
+            var result = pattern.matcher("foo bar foo").replaceAll("baz");
+            if (!result.equals("baz bar baz")) {
+                throw new AssertionError("Replacement mismatch: " + result);
+            }
+            System.out.println("PASS: Replacement");
+        } catch (Exception e) {
+            System.err.println("FAIL: Replacement: " + e.getMessage());
+            failures++;
+        }
+
+        // Summary
+        System.out.println();
+        if (failures == 0) {
+            System.out.println("All tests passed!");
+        } else {
+            System.out.println(failures + " test(s) failed!");
+            System.exit(1);
+        }
+    }
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -210,6 +210,93 @@ jobs:
             }
             core.info(`${compatJobs.length} compatibility job(s) completed successfully`);
 
+  native-image:
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+
+    timeout-minutes: 30
+
+    needs:
+      - lint
+      - compatibility-all
+
+    env:
+      PCRE2_VERSION: '10.47'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v4
+
+      # JDK 21 for building base MRJAR classes
+      - name: Set up temurin-jdk-21 (MRJAR base)
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      # JDK 22 for building MRJAR overlay classes
+      - name: Set up temurin-jdk-22 (MRJAR overlay)
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: temurin
+          java-version: 22
+
+      # Gradle needs JDK 21 as daemon JVM
+      - name: Configure Gradle JVM
+        run: echo "JAVA_HOME=$JAVA_HOME_21_X64" >> $GITHUB_ENV
+
+      - name: Cache Gradle packages
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-${{ runner.os }}
+
+      - name: Build PCRE2
+        uses: ./.github/actions/build-pcre2
+        with:
+          version: ${{ env.PCRE2_VERSION }}
+
+      - name: Build PCRE4J JARs
+        run: ./gradlew api:jar lib:jar ffm:jar regex:jar -Dpcre2.library.path=/opt/pcre2/lib
+
+      # GraalVM JDK 25 for native-image (full FFM + reachability-metadata.json foreign section)
+      # Installed AFTER Gradle build to avoid toolchain auto-detection conflicts
+      - name: Set up GraalVM JDK 25 (native-image + FFM GA)
+        uses: graalvm/setup-graalvm@54b4f5a65c1a84b2fdfdc2078fe43df32819e4b1 # v1.4.5
+        with:
+          java-version: '25'
+          distribution: 'graalvm'
+          set-java-home: 'false'
+
+      - name: Compile smoke test
+        run: |
+          CP=$(find api/build/libs lib/build/libs ffm/build/libs regex/build/libs -name '*.jar' ! -name '*-sources*' ! -name '*-javadoc*' | tr '\n' ':')
+          "$GRAALVM_HOME/bin/javac" -cp "$CP" \
+            -d build/native-image-test \
+            .github/native-image-test/NativeImageSmokeTest.java
+
+      - name: Build native image
+        run: |
+          CP=$(find api/build/libs lib/build/libs ffm/build/libs regex/build/libs -name '*.jar' ! -name '*-sources*' ! -name '*-javadoc*' | tr '\n' ':')
+          "$GRAALVM_HOME/bin/native-image" \
+            -cp "${CP}build/native-image-test" \
+            --no-fallback \
+            --enable-native-access=ALL-UNNAMED \
+            -H:Name=build/native-image-test/pcre4j-smoke-test \
+            NativeImageSmokeTest
+
+      - name: Run native image smoke test
+        run: |
+          LD_LIBRARY_PATH=/opt/pcre2/lib ./build/native-image-test/pcre4j-smoke-test
+
   package:
     runs-on: ubuntu-24.04
 

--- a/api/src/main/resources/META-INF/native-image/org.pcre4j/pcre4j-api/native-image.properties
+++ b/api/src/main/resources/META-INF/native-image/org.pcre4j/pcre4j-api/native-image.properties
@@ -1,0 +1,1 @@
+Args = -H:+AddAllCharsets

--- a/api/src/main/resources/META-INF/native-image/org.pcre4j/pcre4j-api/reachability-metadata.json
+++ b/api/src/main/resources/META-INF/native-image/org.pcre4j/pcre4j-api/reachability-metadata.json
@@ -1,0 +1,7 @@
+{
+  "resources": [
+    {
+      "glob": "META-INF/native/**"
+    }
+  ]
+}

--- a/ffm/src/main/resources/META-INF/native-image/org.pcre4j/pcre4j-ffm/reachability-metadata.json
+++ b/ffm/src/main/resources/META-INF/native-image/org.pcre4j/pcre4j-ffm/reachability-metadata.json
@@ -1,0 +1,67 @@
+{
+  "reflection": [
+    {
+      "condition": {
+        "typeReached": "org.pcre4j.ffm.Pcre2"
+      },
+      "type": "org.pcre4j.ffm.Pcre2",
+      "allDeclaredConstructors": true,
+      "methods": [
+        {
+          "name": "calloutCallbackImpl",
+          "parameterTypes": [
+            "org.pcre4j.api.Pcre2CalloutHandler",
+            "int",
+            "java.nio.charset.Charset",
+            "java.lang.foreign.MemorySegment",
+            "java.lang.foreign.MemorySegment"
+          ]
+        },
+        {
+          "name": "calloutEnumerateCallbackImpl",
+          "parameterTypes": [
+            "org.pcre4j.api.Pcre2CalloutEnumerateHandler",
+            "int",
+            "java.nio.charset.Charset",
+            "java.lang.foreign.MemorySegment",
+            "java.lang.foreign.MemorySegment"
+          ]
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "glob": "META-INF/services/org.pcre4j.api.IPcre2"
+    }
+  ],
+  "foreign": {
+    "downcalls": [
+      { "returnType": "void", "parameterTypes": ["void*"] },
+      { "returnType": "void*", "parameterTypes": ["void*"] },
+      { "returnType": "int", "parameterTypes": ["void*"] },
+      { "returnType": "int", "parameterTypes": ["int", "void*"] },
+      { "returnType": "void*", "parameterTypes": ["int", "void*"] },
+      { "returnType": "int", "parameterTypes": ["void*", "int"] },
+      { "returnType": "void", "parameterTypes": ["void*", "void*"] },
+      { "returnType": "void*", "parameterTypes": ["void*", "void*"] },
+      { "returnType": "int", "parameterTypes": ["void*", "void*"] },
+      { "returnType": "int", "parameterTypes": ["int", "void*", "void*"] },
+      { "returnType": "int", "parameterTypes": ["void*", "int", "void*"] },
+      { "returnType": "void", "parameterTypes": ["void*", "void*", "void*"] },
+      { "returnType": "int", "parameterTypes": ["void*", "void*", "void*"] },
+      { "returnType": "void*", "parameterTypes": ["void*", "void*", "void*"] },
+      { "returnType": "int", "parameterTypes": ["void*", "int", "void*", "void*"] },
+      { "returnType": "int", "parameterTypes": ["void*", "void*", "void*", "void*"] },
+      { "returnType": "int", "parameterTypes": ["void*", "int", "void*", "void*", "void*"] },
+      { "returnType": "void*", "parameterTypes": ["void*", "void*", "int", "void*", "void*", "void*"] },
+      { "returnType": "int", "parameterTypes": ["void*", "void*", "int", "void*", "void*", "void*"] },
+      { "returnType": "int", "parameterTypes": ["void*", "void*", "void*", "void*", "int", "void*", "void*"] },
+      { "returnType": "int", "parameterTypes": ["void*", "void*", "void*", "void*", "int", "void*", "void*", "void*", "void*"] },
+      { "returnType": "int", "parameterTypes": ["void*", "void*", "void*", "void*", "int", "void*", "void*", "void*", "void*", "void*", "void*"] }
+    ],
+    "upcalls": [
+      { "returnType": "int", "parameterTypes": ["void*", "void*"] }
+    ]
+  }
+}

--- a/lib/src/main/resources/META-INF/native-image/org.pcre4j/pcre4j-lib/reachability-metadata.json
+++ b/lib/src/main/resources/META-INF/native-image/org.pcre4j/pcre4j-lib/reachability-metadata.json
@@ -1,0 +1,7 @@
+{
+  "resources": [
+    {
+      "glob": "META-INF/services/org.pcre4j.api.IPcre2"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add GraalVM native-image reachability metadata to `api`, `lib`, and `ffm` modules
- Register FFM downcall/upcall descriptors, reflection metadata for callback methods, ServiceLoader service files, and native library resources for inclusion in native images
- Add a native-image smoke test CI job that compiles and runs a test application as a GraalVM native executable

## Details

### Reachability Metadata (GraalVM 25 schema)

**FFM module** (`ffm/src/main/resources/META-INF/native-image/org.pcre4j/pcre4j-ffm/reachability-metadata.json`):
- `foreign.downcalls`: All unique FunctionDescriptor signatures used for PCRE2 native function bindings (22 unique signatures)
- `foreign.upcalls`: Callback descriptor for callout/callout-enumerate callbacks
- `reflection`: Constructor and static callback method registration for `Pcre2` class (needed by `MethodHandles.lookup().findStatic()` for upcall stub creation)
- `resources`: ServiceLoader registration file

**Lib module** (`lib/src/main/resources/META-INF/native-image/org.pcre4j/pcre4j-lib/reachability-metadata.json`):
- `resources`: ServiceLoader service files for `IPcre2` backend discovery

**API module**:
- `reachability-metadata.json`: Bundled native library resources (`META-INF/native/`) for `Pcre2NativeLoader`
- `native-image.properties`: `-H:+AddAllCharsets` for UTF-32LE/BE charset support required by `Pcre2UtfWidth`

### CI Integration

New `native-image` CI job that:
1. Builds PCRE4J JARs with temurin JDK 21 + 22 (MRJAR base + overlay)
2. Sets up GraalVM JDK 25 (full FFM support, reachability-metadata.json foreign section)
3. Compiles a smoke test application that exercises FFM backend init, pattern matching, named groups, case-insensitive matching, and replacement
4. Builds a native image with `--no-fallback` (ensures no JVM fallback)
5. Runs the native executable against system-installed PCRE2

### Scope

- **FFM backend only** — JNA is not supported by GraalVM native-image
- Targets GraalVM 25 which has FFM enabled by default and full reachability-metadata.json support

Fixes #435

## Test plan

- [x] Existing tests pass (no regressions from metadata addition)
- [x] New `native-image` CI job builds and runs the smoke test successfully
- [x] Metadata JSON files are included in the built JARs

🤖 Generated with [Claude Code](https://claude.com/claude-code)