### PR TITLE
(fix) test: exclude FFM backend from parameterized tests on OpenJ9/Semeru

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,10 +170,11 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-24.04' && matrix.java-version == 21 && matrix.java-distribution != 'adopt-openj9' && matrix.java-distribution != 'semeru' }}
         run: ./gradlew lib:test regex:test ffm:test jna:test -Dpcre2.library.path=/opt/pcre2/lib
 
-      # OpenJ9/Semeru Java 21 crashes in FFM preview due to a JVM bug (memory corruption assertion)
+      # OpenJ9/Semeru Java 21 crashes in FFM preview due to a JVM bug (memory corruption assertion);
+      # exclude FFM from both the task list and parameterized backend tests via pcre4j.test.backends
       - name: Test (Java 21 without FFM)
         if: ${{ matrix.os == 'ubuntu-24.04' && matrix.java-version == 21 && (matrix.java-distribution == 'adopt-openj9' || matrix.java-distribution == 'semeru') }}
-        run: ./gradlew lib:test regex:test jna:test -Dpcre2.library.path=/opt/pcre2/lib
+        run: ./gradlew lib:test regex:test jna:test -Dpcre2.library.path=/opt/pcre2/lib -Dpcre4j.test.backends=jna
 
       - name: Test (Java 22+ with MRJAR)
         if: ${{ matrix.os == 'ubuntu-24.04' && matrix.java-version >= 22 }}

--- a/buildSrc/src/main/kotlin/pcre4j-native-test.gradle.kts
+++ b/buildSrc/src/main/kotlin/pcre4j-native-test.gradle.kts
@@ -52,4 +52,9 @@ tasks.withType<Test>().configureEach {
     if (pcre2FunctionSuffix != null) {
         systemProperty("pcre2.function.suffix", pcre2FunctionSuffix)
     }
+
+    val pcre4jTestBackends = providers.systemProperty("pcre4j.test.backends").orNull
+    if (pcre4jTestBackends != null) {
+        systemProperty("pcre4j.test.backends", pcre4jTestBackends)
+    }
 }


### PR DESCRIPTION
## Summary

- The "Test (Java 21 without FFM)" CI step excluded the `ffm:test` Gradle task but `lib:test` still ran parameterized tests against the FFM backend via `BackendProvider`, causing flaky failures on Semeru 21 + PCRE2 10.43 due to OpenJ9's buggy FFM preview (memory corruption assertion)
- Added a `pcre4j.test.backends` system property to `BackendProvider` that controls which backends are included in parameterized tests
- Pass `-Dpcre4j.test.backends=jna` in the "without FFM" CI step to fully exclude the FFM backend

## Root Cause

`BackendProvider.parameters()` always loaded both JNA and FFM backends reflectively. When `lib:test` runs on OpenJ9/Semeru Java 21, the FFM module is on the classpath (via `testRuntimeOnly`), so the FFM backend gets loaded and used in parameterized tests. OpenJ9's FFM preview has a known bug causing sporadic memory corruption assertions, leading to intermittent `Pcre2Exception` failures during serialization operations.

## Test plan

- [x] Full build passes locally (`./gradlew build`)
- [x] Verified `pcre4j.test.backends=jna` correctly halves parameterized test count (FFM tests excluded)
- [x] Verified default behavior (no property) includes both backends
- [x] Checkstyle passes
- [ ] CI compatibility matrix passes (including Semeru 21 job)

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)