### PR TITLE
(chore) lib: extract option and exception sub-packages

### DIFF
--- a/benchmark/src/jmh/java/org/pcre4j/benchmark/BacktrackingBenchmark.java
+++ b/benchmark/src/jmh/java/org/pcre4j/benchmark/BacktrackingBenchmark.java
@@ -25,7 +25,7 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
-import org.pcre4j.Pcre2MatchException;
+import org.pcre4j.exception.Pcre2MatchException;
 
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;

--- a/lib/src/main/java/module-info.java
+++ b/lib/src/main/java/module-info.java
@@ -24,4 +24,6 @@ module org.pcre4j {
     requires transitive org.pcre4j.api;
 
     exports org.pcre4j;
+    exports org.pcre4j.exception;
+    exports org.pcre4j.option;
 }

--- a/lib/src/main/java/org/pcre4j/Pcre2Code.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2Code.java
@@ -17,6 +17,21 @@ package org.pcre4j;
 import org.pcre4j.api.INativeMemoryAccess;
 import org.pcre4j.api.IPcre2;
 import org.pcre4j.api.Pcre2CalloutEnumerateHandler;
+import org.pcre4j.exception.Pcre2CompileException;
+import org.pcre4j.exception.Pcre2Exception;
+import org.pcre4j.exception.Pcre2MatchException;
+import org.pcre4j.exception.Pcre2NoSubstringException;
+import org.pcre4j.exception.Pcre2NoUniqueSubstringException;
+import org.pcre4j.exception.Pcre2PatternInfoSizeException;
+import org.pcre4j.exception.Pcre2SubstituteException;
+import org.pcre4j.option.Pcre2Bsr;
+import org.pcre4j.option.Pcre2CompileExtraOption;
+import org.pcre4j.option.Pcre2CompileOption;
+import org.pcre4j.option.Pcre2DfaMatchOption;
+import org.pcre4j.option.Pcre2MatchOption;
+import org.pcre4j.option.Pcre2Newline;
+import org.pcre4j.option.Pcre2PatternInfo;
+import org.pcre4j.option.Pcre2SubstituteOption;
 
 import java.lang.ref.Cleaner;
 import java.nio.ByteBuffer;
@@ -846,7 +861,7 @@ public class Pcre2Code {
      * @param matchContext the match context to use or null
      * @param replacement  the replacement string (supports backreferences like $1, ${name})
      * @return the result string after substitution
-     * @throws Pcre2SubstituteError if an error occurs during substitution
+     * @throws Pcre2SubstituteException if an error occurs during substitution
      */
     public String substitute(
             String subject,

--- a/lib/src/main/java/org/pcre4j/Pcre2CompileContext.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2CompileContext.java
@@ -15,6 +15,9 @@
 package org.pcre4j;
 
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.option.Pcre2Bsr;
+import org.pcre4j.option.Pcre2CompileExtraOption;
+import org.pcre4j.option.Pcre2Newline;
 
 import java.lang.ref.Cleaner;
 import java.util.EnumSet;

--- a/lib/src/main/java/org/pcre4j/Pcre2JitCode.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2JitCode.java
@@ -15,6 +15,9 @@
 package org.pcre4j;
 
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.option.Pcre2CompileOption;
+import org.pcre4j.option.Pcre2JitOption;
+import org.pcre4j.option.Pcre2MatchOption;
 
 import java.util.EnumSet;
 

--- a/lib/src/main/java/org/pcre4j/Pcre2MatchContext.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2MatchContext.java
@@ -16,6 +16,7 @@ package org.pcre4j;
 
 import org.pcre4j.api.IPcre2;
 import org.pcre4j.api.Pcre2CalloutHandler;
+import org.pcre4j.option.Pcre2CompileOption;
 
 import java.lang.ref.Cleaner;
 

--- a/lib/src/main/java/org/pcre4j/Pcre2MatchData.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2MatchData.java
@@ -16,6 +16,7 @@ package org.pcre4j;
 
 import org.pcre4j.api.INativeMemoryAccess;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.option.Pcre2MatchOption;
 
 import java.lang.ref.Cleaner;
 import java.nio.ByteBuffer;

--- a/lib/src/main/java/org/pcre4j/Pcre2PatternConverter.java
+++ b/lib/src/main/java/org/pcre4j/Pcre2PatternConverter.java
@@ -15,6 +15,8 @@
 package org.pcre4j;
 
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.exception.Pcre2ConvertException;
+import org.pcre4j.option.Pcre2ConvertOption;
 
 import java.util.EnumSet;
 

--- a/lib/src/main/java/org/pcre4j/Pcre4jUtils.java
+++ b/lib/src/main/java/org/pcre4j/Pcre4jUtils.java
@@ -16,6 +16,8 @@ package org.pcre4j;
 
 import org.pcre4j.api.IPcre2;
 import org.pcre4j.api.Pcre2UtfWidth;
+import org.pcre4j.option.Pcre2Bsr;
+import org.pcre4j.option.Pcre2Newline;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;

--- a/lib/src/main/java/org/pcre4j/exception/Pcre2CompileError.java
+++ b/lib/src/main/java/org/pcre4j/exception/Pcre2CompileError.java
@@ -12,37 +12,41 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.exception;
 
 /**
- * An error indicating that a named substring is not unique (duplicate names exist when using the {@code (?J)} option).
+ * An error that occurs when a pattern fails to compile.
  *
- * @deprecated Use {@link Pcre2NoUniqueSubstringException} instead. This class will be removed in a future release.
+ * @deprecated Use {@link Pcre2CompileException} instead. This class will be removed in a future release.
  */
 @Deprecated(forRemoval = true)
-public class Pcre2NoUniqueSubstringError extends Pcre2NoUniqueSubstringException {
+public class Pcre2CompileError extends Pcre2CompileException {
 
     /**
-     * Create a new no unique substring error.
+     * Create a new pattern compilation error.
      *
+     * @param pattern the pattern
+     * @param offset  the offset of the error in the pattern
      * @param message the error message
-     * @deprecated Use {@link Pcre2NoUniqueSubstringException#Pcre2NoUniqueSubstringException(String, int)} instead.
+     * @deprecated Use {@link Pcre2CompileException#Pcre2CompileException(String, long, String, int)} instead.
      */
     @Deprecated(forRemoval = true)
-    public Pcre2NoUniqueSubstringError(String message) {
-        this(message, null);
+    public Pcre2CompileError(String pattern, long offset, String message) {
+        this(pattern, offset, message, null);
     }
 
     /**
-     * Create a new no unique substring error.
+     * Create a new pattern compilation error.
      *
+     * @param pattern the pattern
+     * @param offset  the offset of the error in the pattern
      * @param message the error message
      * @param cause   the cause of the error
-     * @deprecated Use {@link Pcre2NoUniqueSubstringException#Pcre2NoUniqueSubstringException(String, int, Throwable)}
+     * @deprecated Use {@link Pcre2CompileException#Pcre2CompileException(String, long, String, int, Throwable)}
      *     instead.
      */
     @Deprecated(forRemoval = true)
-    public Pcre2NoUniqueSubstringError(String message, Throwable cause) {
-        super(message, 0, cause);
+    public Pcre2CompileError(String pattern, long offset, String message, Throwable cause) {
+        super(pattern, offset, message, 0, cause);
     }
 }

--- a/lib/src/main/java/org/pcre4j/exception/Pcre2CompileException.java
+++ b/lib/src/main/java/org/pcre4j/exception/Pcre2CompileException.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.exception;
 
 /**
  * An exception that occurs when a pattern fails to compile.

--- a/lib/src/main/java/org/pcre4j/exception/Pcre2ConvertException.java
+++ b/lib/src/main/java/org/pcre4j/exception/Pcre2ConvertException.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.exception;
 
 /**
  * An exception that occurs when a pattern conversion fails.

--- a/lib/src/main/java/org/pcre4j/exception/Pcre2Exception.java
+++ b/lib/src/main/java/org/pcre4j/exception/Pcre2Exception.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.exception;
 
 /**
  * Base exception for all PCRE4J-specific errors.

--- a/lib/src/main/java/org/pcre4j/exception/Pcre2InternalException.java
+++ b/lib/src/main/java/org/pcre4j/exception/Pcre2InternalException.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.exception;
 
 /**
  * An exception indicating an unexpected internal error in PCRE4J.

--- a/lib/src/main/java/org/pcre4j/exception/Pcre2MatchException.java
+++ b/lib/src/main/java/org/pcre4j/exception/Pcre2MatchException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Oleksii PELYKH
+ * Copyright (C) 2024-2026 Oleksii PELYKH
  *
  * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
@@ -12,34 +12,33 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.exception;
 
 /**
- * An exception related to substring or capture group operations.
+ * An exception that occurs during a match operation.
  *
- * @see Pcre2NoSubstringException
- * @see Pcre2NoUniqueSubstringException
+ * @see Pcre2MatchLimitException
  */
-public class Pcre2SubstringException extends Pcre2Exception {
+public class Pcre2MatchException extends Pcre2Exception {
 
     /**
-     * Creates a new substring exception.
+     * Creates a new match exception.
      *
      * @param message   the error message
      * @param errorCode the PCRE2 native error code
      */
-    public Pcre2SubstringException(String message, int errorCode) {
+    public Pcre2MatchException(String message, int errorCode) {
         this(message, errorCode, null);
     }
 
     /**
-     * Creates a new substring exception.
+     * Creates a new match exception.
      *
      * @param message   the error message
      * @param errorCode the PCRE2 native error code
      * @param cause     the cause of the exception, or {@code null}
      */
-    public Pcre2SubstringException(String message, int errorCode, Throwable cause) {
+    public Pcre2MatchException(String message, int errorCode, Throwable cause) {
         super(message, errorCode, cause);
     }
 }

--- a/lib/src/main/java/org/pcre4j/exception/Pcre2MatchLimitException.java
+++ b/lib/src/main/java/org/pcre4j/exception/Pcre2MatchLimitException.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.exception;
 
 import org.pcre4j.api.IPcre2;
 

--- a/lib/src/main/java/org/pcre4j/exception/Pcre2NoSubstringError.java
+++ b/lib/src/main/java/org/pcre4j/exception/Pcre2NoSubstringError.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.exception;
 
 /**
  * An error indicating that a named substring does not exist.

--- a/lib/src/main/java/org/pcre4j/exception/Pcre2NoSubstringException.java
+++ b/lib/src/main/java/org/pcre4j/exception/Pcre2NoSubstringException.java
@@ -12,31 +12,31 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.exception;
 
 /**
- * An exception that occurs during a substitute operation.
+ * An exception indicating that a named substring does not exist.
  */
-public class Pcre2SubstituteException extends Pcre2Exception {
+public class Pcre2NoSubstringException extends Pcre2SubstringException {
 
     /**
-     * Creates a new substitute exception.
+     * Creates a new no substring exception.
      *
      * @param message   the error message
      * @param errorCode the PCRE2 native error code
      */
-    public Pcre2SubstituteException(String message, int errorCode) {
+    public Pcre2NoSubstringException(String message, int errorCode) {
         this(message, errorCode, null);
     }
 
     /**
-     * Creates a new substitute exception.
+     * Creates a new no substring exception.
      *
      * @param message   the error message
      * @param errorCode the PCRE2 native error code
      * @param cause     the cause of the exception, or {@code null}
      */
-    public Pcre2SubstituteException(String message, int errorCode, Throwable cause) {
+    public Pcre2NoSubstringException(String message, int errorCode, Throwable cause) {
         super(message, errorCode, cause);
     }
 }

--- a/lib/src/main/java/org/pcre4j/exception/Pcre2NoUniqueSubstringError.java
+++ b/lib/src/main/java/org/pcre4j/exception/Pcre2NoUniqueSubstringError.java
@@ -12,41 +12,37 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.exception;
 
 /**
- * An error that occurs when a pattern fails to compile.
+ * An error indicating that a named substring is not unique (duplicate names exist when using the {@code (?J)} option).
  *
- * @deprecated Use {@link Pcre2CompileException} instead. This class will be removed in a future release.
+ * @deprecated Use {@link Pcre2NoUniqueSubstringException} instead. This class will be removed in a future release.
  */
 @Deprecated(forRemoval = true)
-public class Pcre2CompileError extends Pcre2CompileException {
+public class Pcre2NoUniqueSubstringError extends Pcre2NoUniqueSubstringException {
 
     /**
-     * Create a new pattern compilation error.
+     * Create a new no unique substring error.
      *
-     * @param pattern the pattern
-     * @param offset  the offset of the error in the pattern
      * @param message the error message
-     * @deprecated Use {@link Pcre2CompileException#Pcre2CompileException(String, long, String, int)} instead.
+     * @deprecated Use {@link Pcre2NoUniqueSubstringException#Pcre2NoUniqueSubstringException(String, int)} instead.
      */
     @Deprecated(forRemoval = true)
-    public Pcre2CompileError(String pattern, long offset, String message) {
-        this(pattern, offset, message, null);
+    public Pcre2NoUniqueSubstringError(String message) {
+        this(message, null);
     }
 
     /**
-     * Create a new pattern compilation error.
+     * Create a new no unique substring error.
      *
-     * @param pattern the pattern
-     * @param offset  the offset of the error in the pattern
      * @param message the error message
      * @param cause   the cause of the error
-     * @deprecated Use {@link Pcre2CompileException#Pcre2CompileException(String, long, String, int, Throwable)}
+     * @deprecated Use {@link Pcre2NoUniqueSubstringException#Pcre2NoUniqueSubstringException(String, int, Throwable)}
      *     instead.
      */
     @Deprecated(forRemoval = true)
-    public Pcre2CompileError(String pattern, long offset, String message, Throwable cause) {
-        super(pattern, offset, message, 0, cause);
+    public Pcre2NoUniqueSubstringError(String message, Throwable cause) {
+        super(message, 0, cause);
     }
 }

--- a/lib/src/main/java/org/pcre4j/exception/Pcre2NoUniqueSubstringException.java
+++ b/lib/src/main/java/org/pcre4j/exception/Pcre2NoUniqueSubstringException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2026 Oleksii PELYKH
+ * Copyright (C) 2026 Oleksii PELYKH
  *
  * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
@@ -12,31 +12,32 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.exception;
 
 /**
- * An exception indicating that a named substring does not exist.
+ * An exception indicating that a named substring is not unique (duplicate names exist when using the {@code (?J)}
+ * option).
  */
-public class Pcre2NoSubstringException extends Pcre2SubstringException {
+public class Pcre2NoUniqueSubstringException extends Pcre2SubstringException {
 
     /**
-     * Creates a new no substring exception.
+     * Creates a new no unique substring exception.
      *
      * @param message   the error message
      * @param errorCode the PCRE2 native error code
      */
-    public Pcre2NoSubstringException(String message, int errorCode) {
+    public Pcre2NoUniqueSubstringException(String message, int errorCode) {
         this(message, errorCode, null);
     }
 
     /**
-     * Creates a new no substring exception.
+     * Creates a new no unique substring exception.
      *
      * @param message   the error message
      * @param errorCode the PCRE2 native error code
      * @param cause     the cause of the exception, or {@code null}
      */
-    public Pcre2NoSubstringException(String message, int errorCode, Throwable cause) {
+    public Pcre2NoUniqueSubstringException(String message, int errorCode, Throwable cause) {
         super(message, errorCode, cause);
     }
 }

--- a/lib/src/main/java/org/pcre4j/exception/Pcre2PatternInfoSizeError.java
+++ b/lib/src/main/java/org/pcre4j/exception/Pcre2PatternInfoSizeError.java
@@ -12,7 +12,9 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.exception;
+
+import org.pcre4j.option.Pcre2PatternInfo;
 
 /**
  * An error indicating an unexpected data size for a {@link Pcre2PatternInfo} query.

--- a/lib/src/main/java/org/pcre4j/exception/Pcre2PatternInfoSizeException.java
+++ b/lib/src/main/java/org/pcre4j/exception/Pcre2PatternInfoSizeException.java
@@ -12,7 +12,9 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.exception;
+
+import org.pcre4j.option.Pcre2PatternInfo;
 
 /**
  * An exception indicating an unexpected data size for a {@link Pcre2PatternInfo} query.

--- a/lib/src/main/java/org/pcre4j/exception/Pcre2SubstituteError.java
+++ b/lib/src/main/java/org/pcre4j/exception/Pcre2SubstituteError.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.exception;
 
 /**
  * An error that occurs during a substitute operation.

--- a/lib/src/main/java/org/pcre4j/exception/Pcre2SubstituteException.java
+++ b/lib/src/main/java/org/pcre4j/exception/Pcre2SubstituteException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Oleksii PELYKH
+ * Copyright (C) 2024-2026 Oleksii PELYKH
  *
  * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
@@ -12,32 +12,31 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.exception;
 
 /**
- * An exception indicating that a named substring is not unique (duplicate names exist when using the {@code (?J)}
- * option).
+ * An exception that occurs during a substitute operation.
  */
-public class Pcre2NoUniqueSubstringException extends Pcre2SubstringException {
+public class Pcre2SubstituteException extends Pcre2Exception {
 
     /**
-     * Creates a new no unique substring exception.
+     * Creates a new substitute exception.
      *
      * @param message   the error message
      * @param errorCode the PCRE2 native error code
      */
-    public Pcre2NoUniqueSubstringException(String message, int errorCode) {
+    public Pcre2SubstituteException(String message, int errorCode) {
         this(message, errorCode, null);
     }
 
     /**
-     * Creates a new no unique substring exception.
+     * Creates a new substitute exception.
      *
      * @param message   the error message
      * @param errorCode the PCRE2 native error code
      * @param cause     the cause of the exception, or {@code null}
      */
-    public Pcre2NoUniqueSubstringException(String message, int errorCode, Throwable cause) {
+    public Pcre2SubstituteException(String message, int errorCode, Throwable cause) {
         super(message, errorCode, cause);
     }
 }

--- a/lib/src/main/java/org/pcre4j/exception/Pcre2SubstringException.java
+++ b/lib/src/main/java/org/pcre4j/exception/Pcre2SubstringException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2026 Oleksii PELYKH
+ * Copyright (C) 2026 Oleksii PELYKH
  *
  * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
@@ -12,33 +12,34 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.exception;
 
 /**
- * An exception that occurs during a match operation.
+ * An exception related to substring or capture group operations.
  *
- * @see Pcre2MatchLimitException
+ * @see Pcre2NoSubstringException
+ * @see Pcre2NoUniqueSubstringException
  */
-public class Pcre2MatchException extends Pcre2Exception {
+public class Pcre2SubstringException extends Pcre2Exception {
 
     /**
-     * Creates a new match exception.
+     * Creates a new substring exception.
      *
      * @param message   the error message
      * @param errorCode the PCRE2 native error code
      */
-    public Pcre2MatchException(String message, int errorCode) {
+    public Pcre2SubstringException(String message, int errorCode) {
         this(message, errorCode, null);
     }
 
     /**
-     * Creates a new match exception.
+     * Creates a new substring exception.
      *
      * @param message   the error message
      * @param errorCode the PCRE2 native error code
      * @param cause     the cause of the exception, or {@code null}
      */
-    public Pcre2MatchException(String message, int errorCode, Throwable cause) {
+    public Pcre2SubstringException(String message, int errorCode, Throwable cause) {
         super(message, errorCode, cause);
     }
 }

--- a/lib/src/main/java/org/pcre4j/option/Pcre2Bsr.java
+++ b/lib/src/main/java/org/pcre4j/option/Pcre2Bsr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2026 Oleksii PELYKH
+ * Copyright (C) 2024 Oleksii PELYKH
  *
  * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.option;
 
 import org.pcre4j.api.IPcre2;
 
@@ -20,38 +20,18 @@ import java.util.Arrays;
 import java.util.Optional;
 
 /**
- * The newline convention.
+ * The \R processing option.
  */
-public enum Pcre2Newline {
+public enum Pcre2Bsr {
     /**
-     * Carriage return only (\r)
+     * \R corresponds to the Unicode line endings
      */
-    CR(IPcre2.NEWLINE_CR),
+    UNICODE(IPcre2.BSR_UNICODE),
 
     /**
-     * Linefeed only (\n)
+     * \R corresponds to CR, LF, and CRLF only
      */
-    LF(IPcre2.NEWLINE_LF),
-
-    /**
-     * CR followed by LF only (\r\n)
-     */
-    CRLF(IPcre2.NEWLINE_CRLF),
-
-    /**
-     * Any Unicode newline sequence
-     */
-    ANY(IPcre2.NEWLINE_ANY),
-
-    /**
-     * Any of {@link #CR}, {@link #LF}, or {@link #CRLF}
-     */
-    ANYCRLF(IPcre2.NEWLINE_ANYCRLF),
-
-    /**
-     * NUL character (\0)
-     */
-    NUL(IPcre2.NEWLINE_NUL);
+    ANYCRLF(IPcre2.BSR_ANYCRLF);
 
     /**
      * The integer value
@@ -63,7 +43,7 @@ public enum Pcre2Newline {
      *
      * @param value the integer value
      */
-    private Pcre2Newline(int value) {
+    private Pcre2Bsr(int value) {
         this.value = value;
     }
 
@@ -73,7 +53,7 @@ public enum Pcre2Newline {
      * @param value the integer value
      * @return the enum entry
      */
-    public static Optional<Pcre2Newline> valueOf(int value) {
+    public static Optional<Pcre2Bsr> valueOf(int value) {
         return Arrays.stream(values())
                 .filter(entry -> entry.value == value)
                 .findFirst();
@@ -87,5 +67,4 @@ public enum Pcre2Newline {
     public int value() {
         return value;
     }
-
 }

--- a/lib/src/main/java/org/pcre4j/option/Pcre2CompileExtraOption.java
+++ b/lib/src/main/java/org/pcre4j/option/Pcre2CompileExtraOption.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.option;
 
 import org.pcre4j.api.IPcre2;
 
@@ -22,7 +22,8 @@ import java.util.Optional;
 /**
  * Extra compile options for PCRE2 patterns.
  * <p>
- * These options are set via {@link Pcre2CompileContext#setCompileExtraOptions(java.util.EnumSet)} and provide
+ * These options are set via
+ * {@link org.pcre4j.Pcre2CompileContext#setCompileExtraOptions(java.util.EnumSet)} and provide
  * additional control over pattern compilation beyond the standard compile options.
  */
 public enum Pcre2CompileExtraOption {

--- a/lib/src/main/java/org/pcre4j/option/Pcre2CompileOption.java
+++ b/lib/src/main/java/org/pcre4j/option/Pcre2CompileOption.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.option;
 
 import org.pcre4j.api.IPcre2;
 
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 /**
- * Compile options for {@link Pcre2Code}
+ * Compile options for {@link org.pcre4j.Pcre2Code}
  */
 public enum Pcre2CompileOption {
     /**

--- a/lib/src/main/java/org/pcre4j/option/Pcre2ConvertOption.java
+++ b/lib/src/main/java/org/pcre4j/option/Pcre2ConvertOption.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.option;
 
 import org.pcre4j.api.IPcre2;
 
@@ -20,28 +20,47 @@ import java.util.Arrays;
 import java.util.Optional;
 
 /**
- * JIT compilation options for {@link Pcre2JitCode}
+ * Options for pattern conversion via {@link org.pcre4j.Pcre2PatternConverter}.
+ * <p>
+ * These options control the behavior of the PCRE2 pattern conversion functions, which convert
+ * glob patterns or POSIX regular expressions into PCRE2-compatible patterns.
  */
-public enum Pcre2JitOption {
-    /**
-     * Compile code for full matching
-     */
-    COMPLETE(IPcre2.JIT_COMPLETE),
+public enum Pcre2ConvertOption {
 
     /**
-     * Compile code for soft partial matching
+     * Treat the input pattern as a UTF string
      */
-    PARTIAL_SOFT(IPcre2.JIT_PARTIAL_SOFT),
+    UTF(IPcre2.CONVERT_UTF),
 
     /**
-     * Compile code for hard partial matching
+     * Skip UTF validity check on the input pattern
      */
-    PARTIAL_HARD(IPcre2.JIT_PARTIAL_HARD),
+    NO_UTF_CHECK(IPcre2.CONVERT_NO_UTF_CHECK),
 
     /**
-     * @deprecated Use {@link Pcre2CompileOption#MATCH_INVALID_UTF}
+     * Convert a POSIX basic regular expression
      */
-    @Deprecated INVALID_UTF(IPcre2.JIT_INVALID_UTF);
+    POSIX_BASIC(IPcre2.CONVERT_POSIX_BASIC),
+
+    /**
+     * Convert a POSIX extended regular expression
+     */
+    POSIX_EXTENDED(IPcre2.CONVERT_POSIX_EXTENDED),
+
+    /**
+     * Convert a glob pattern
+     */
+    GLOB(IPcre2.CONVERT_GLOB),
+
+    /**
+     * Convert a glob pattern where wildcards do not match the path separator
+     */
+    GLOB_NO_WILD_SEPARATOR(IPcre2.CONVERT_GLOB_NO_WILD_SEPARATOR),
+
+    /**
+     * Convert a glob pattern with the double-star ({@code **}) feature disabled
+     */
+    GLOB_NO_STARSTAR(IPcre2.CONVERT_GLOB_NO_STARSTAR);
 
     /**
      * The integer value of the option
@@ -53,7 +72,7 @@ public enum Pcre2JitOption {
      *
      * @param value the integer value of the option
      */
-    private Pcre2JitOption(int value) {
+    private Pcre2ConvertOption(int value) {
         this.value = value;
     }
 
@@ -61,9 +80,9 @@ public enum Pcre2JitOption {
      * Get the enum value by its option value.
      *
      * @param value the integer value of the option
-     * @return the flag
+     * @return the option
      */
-    public static Optional<Pcre2JitOption> valueOf(int value) {
+    public static Optional<Pcre2ConvertOption> valueOf(int value) {
         return Arrays.stream(values())
                 .filter(flag -> flag.value == value)
                 .findFirst();
@@ -77,4 +96,5 @@ public enum Pcre2JitOption {
     public int value() {
         return value;
     }
+
 }

--- a/lib/src/main/java/org/pcre4j/option/Pcre2DfaMatchOption.java
+++ b/lib/src/main/java/org/pcre4j/option/Pcre2DfaMatchOption.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.option;
 
 import org.pcre4j.api.IPcre2;
 
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 /**
- * Match options for {@link Pcre2Code#dfaMatch}.
+ * Match options for {@link org.pcre4j.Pcre2Code#dfaMatch}.
  * <p>
  * These options control DFA matching behavior. DFA-specific options ({@link #RESTART} and {@link #SHORTEST}) are
  * only valid for DFA matching, while the remaining options are shared with standard matching.

--- a/lib/src/main/java/org/pcre4j/option/Pcre2JitOption.java
+++ b/lib/src/main/java/org/pcre4j/option/Pcre2JitOption.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.option;
 
 import org.pcre4j.api.IPcre2;
 
@@ -20,47 +20,28 @@ import java.util.Arrays;
 import java.util.Optional;
 
 /**
- * Options for pattern conversion via {@link Pcre2PatternConverter}.
- * <p>
- * These options control the behavior of the PCRE2 pattern conversion functions, which convert
- * glob patterns or POSIX regular expressions into PCRE2-compatible patterns.
+ * JIT compilation options for {@link org.pcre4j.Pcre2JitCode}
  */
-public enum Pcre2ConvertOption {
+public enum Pcre2JitOption {
+    /**
+     * Compile code for full matching
+     */
+    COMPLETE(IPcre2.JIT_COMPLETE),
 
     /**
-     * Treat the input pattern as a UTF string
+     * Compile code for soft partial matching
      */
-    UTF(IPcre2.CONVERT_UTF),
+    PARTIAL_SOFT(IPcre2.JIT_PARTIAL_SOFT),
 
     /**
-     * Skip UTF validity check on the input pattern
+     * Compile code for hard partial matching
      */
-    NO_UTF_CHECK(IPcre2.CONVERT_NO_UTF_CHECK),
+    PARTIAL_HARD(IPcre2.JIT_PARTIAL_HARD),
 
     /**
-     * Convert a POSIX basic regular expression
+     * @deprecated Use {@link Pcre2CompileOption#MATCH_INVALID_UTF}
      */
-    POSIX_BASIC(IPcre2.CONVERT_POSIX_BASIC),
-
-    /**
-     * Convert a POSIX extended regular expression
-     */
-    POSIX_EXTENDED(IPcre2.CONVERT_POSIX_EXTENDED),
-
-    /**
-     * Convert a glob pattern
-     */
-    GLOB(IPcre2.CONVERT_GLOB),
-
-    /**
-     * Convert a glob pattern where wildcards do not match the path separator
-     */
-    GLOB_NO_WILD_SEPARATOR(IPcre2.CONVERT_GLOB_NO_WILD_SEPARATOR),
-
-    /**
-     * Convert a glob pattern with the double-star ({@code **}) feature disabled
-     */
-    GLOB_NO_STARSTAR(IPcre2.CONVERT_GLOB_NO_STARSTAR);
+    @Deprecated INVALID_UTF(IPcre2.JIT_INVALID_UTF);
 
     /**
      * The integer value of the option
@@ -72,7 +53,7 @@ public enum Pcre2ConvertOption {
      *
      * @param value the integer value of the option
      */
-    private Pcre2ConvertOption(int value) {
+    private Pcre2JitOption(int value) {
         this.value = value;
     }
 
@@ -80,9 +61,9 @@ public enum Pcre2ConvertOption {
      * Get the enum value by its option value.
      *
      * @param value the integer value of the option
-     * @return the option
+     * @return the flag
      */
-    public static Optional<Pcre2ConvertOption> valueOf(int value) {
+    public static Optional<Pcre2JitOption> valueOf(int value) {
         return Arrays.stream(values())
                 .filter(flag -> flag.value == value)
                 .findFirst();
@@ -96,5 +77,4 @@ public enum Pcre2ConvertOption {
     public int value() {
         return value;
     }
-
 }

--- a/lib/src/main/java/org/pcre4j/option/Pcre2MatchOption.java
+++ b/lib/src/main/java/org/pcre4j/option/Pcre2MatchOption.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.option;
 
 import org.pcre4j.api.IPcre2;
 
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 /**
- * Match options for {@link Pcre2Code#match}
+ * Match options for {@link org.pcre4j.Pcre2Code#match}
  */
 public enum Pcre2MatchOption {
     /**

--- a/lib/src/main/java/org/pcre4j/option/Pcre2Newline.java
+++ b/lib/src/main/java/org/pcre4j/option/Pcre2Newline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Oleksii PELYKH
+ * Copyright (C) 2024-2026 Oleksii PELYKH
  *
  * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.option;
 
 import org.pcre4j.api.IPcre2;
 
@@ -20,18 +20,38 @@ import java.util.Arrays;
 import java.util.Optional;
 
 /**
- * The \R processing option.
+ * The newline convention.
  */
-public enum Pcre2Bsr {
+public enum Pcre2Newline {
     /**
-     * \R corresponds to the Unicode line endings
+     * Carriage return only (\r)
      */
-    UNICODE(IPcre2.BSR_UNICODE),
+    CR(IPcre2.NEWLINE_CR),
 
     /**
-     * \R corresponds to CR, LF, and CRLF only
+     * Linefeed only (\n)
      */
-    ANYCRLF(IPcre2.BSR_ANYCRLF);
+    LF(IPcre2.NEWLINE_LF),
+
+    /**
+     * CR followed by LF only (\r\n)
+     */
+    CRLF(IPcre2.NEWLINE_CRLF),
+
+    /**
+     * Any Unicode newline sequence
+     */
+    ANY(IPcre2.NEWLINE_ANY),
+
+    /**
+     * Any of {@link #CR}, {@link #LF}, or {@link #CRLF}
+     */
+    ANYCRLF(IPcre2.NEWLINE_ANYCRLF),
+
+    /**
+     * NUL character (\0)
+     */
+    NUL(IPcre2.NEWLINE_NUL);
 
     /**
      * The integer value
@@ -43,7 +63,7 @@ public enum Pcre2Bsr {
      *
      * @param value the integer value
      */
-    private Pcre2Bsr(int value) {
+    private Pcre2Newline(int value) {
         this.value = value;
     }
 
@@ -53,7 +73,7 @@ public enum Pcre2Bsr {
      * @param value the integer value
      * @return the enum entry
      */
-    public static Optional<Pcre2Bsr> valueOf(int value) {
+    public static Optional<Pcre2Newline> valueOf(int value) {
         return Arrays.stream(values())
                 .filter(entry -> entry.value == value)
                 .findFirst();
@@ -67,4 +87,5 @@ public enum Pcre2Bsr {
     public int value() {
         return value;
     }
+
 }

--- a/lib/src/main/java/org/pcre4j/option/Pcre2PatternInfo.java
+++ b/lib/src/main/java/org/pcre4j/option/Pcre2PatternInfo.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.option;
 
 import org.pcre4j.api.IPcre2;
 
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 /**
- * Pattern information codes for {@link Pcre2Code} introspection.
+ * Pattern information codes for {@link org.pcre4j.Pcre2Code} introspection.
  */
 public enum Pcre2PatternInfo {
     /**

--- a/lib/src/main/java/org/pcre4j/option/Pcre2SubstituteOption.java
+++ b/lib/src/main/java/org/pcre4j/option/Pcre2SubstituteOption.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
  * <https://www.gnu.org/licenses/>.
  */
-package org.pcre4j;
+package org.pcre4j.option;
 
 import org.pcre4j.api.IPcre2;
 
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 /**
- * Substitute options for {@link Pcre2Code#substitute}
+ * Substitute options for {@link org.pcre4j.Pcre2Code#substitute}
  */
 public enum Pcre2SubstituteOption {
     /**

--- a/lib/src/test/java/org/pcre4j/NativeMemoryStressTests.java
+++ b/lib/src/test/java/org/pcre4j/NativeMemoryStressTests.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.option.Pcre2MatchOption;
 
 import java.lang.ref.Reference;
 import java.util.ArrayList;

--- a/lib/src/test/java/org/pcre4j/Pcre2CodeDfaMatchTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodeDfaMatchTests.java
@@ -17,6 +17,9 @@ package org.pcre4j;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.exception.Pcre2MatchException;
+import org.pcre4j.option.Pcre2CompileOption;
+import org.pcre4j.option.Pcre2DfaMatchOption;
 
 import java.util.EnumSet;
 

--- a/lib/src/test/java/org/pcre4j/Pcre2CodeErrorHandlingTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodeErrorHandlingTests.java
@@ -17,6 +17,8 @@ package org.pcre4j;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.exception.Pcre2CompileException;
+import org.pcre4j.option.Pcre2MatchOption;
 
 import java.util.EnumSet;
 

--- a/lib/src/test/java/org/pcre4j/Pcre2CodePatternInfoTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodePatternInfoTests.java
@@ -17,6 +17,11 @@ package org.pcre4j;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.exception.Pcre2NoSubstringException;
+import org.pcre4j.exception.Pcre2NoUniqueSubstringException;
+import org.pcre4j.option.Pcre2Bsr;
+import org.pcre4j.option.Pcre2CompileExtraOption;
+import org.pcre4j.option.Pcre2CompileOption;
 
 import java.util.EnumSet;
 

--- a/lib/src/test/java/org/pcre4j/Pcre2CodeSerializationTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodeSerializationTests.java
@@ -17,6 +17,9 @@ package org.pcre4j;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.exception.Pcre2Exception;
+import org.pcre4j.option.Pcre2CompileOption;
+import org.pcre4j.option.Pcre2MatchOption;
 
 import java.util.EnumSet;
 

--- a/lib/src/test/java/org/pcre4j/Pcre2CodeSubstituteTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodeSubstituteTests.java
@@ -17,6 +17,7 @@ package org.pcre4j;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.option.Pcre2SubstituteOption;
 
 import java.util.EnumSet;
 

--- a/lib/src/test/java/org/pcre4j/Pcre2CodeTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodeTests.java
@@ -17,6 +17,9 @@ package org.pcre4j;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.exception.Pcre2CompileException;
+import org.pcre4j.option.Pcre2CompileOption;
+import org.pcre4j.option.Pcre2MatchOption;
 
 import java.util.EnumSet;
 

--- a/lib/src/test/java/org/pcre4j/Pcre2CodeThreadSafetyTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2CodeThreadSafetyTests.java
@@ -18,6 +18,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.option.Pcre2MatchOption;
+import org.pcre4j.option.Pcre2SubstituteOption;
 
 import java.lang.ref.Reference;
 import java.util.ArrayList;

--- a/lib/src/test/java/org/pcre4j/Pcre2ContextTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2ContextTests.java
@@ -18,6 +18,12 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.exception.Pcre2CompileException;
+import org.pcre4j.option.Pcre2Bsr;
+import org.pcre4j.option.Pcre2CompileExtraOption;
+import org.pcre4j.option.Pcre2CompileOption;
+import org.pcre4j.option.Pcre2MatchOption;
+import org.pcre4j.option.Pcre2Newline;
 
 import java.util.EnumSet;
 

--- a/lib/src/test/java/org/pcre4j/Pcre2EnumFlagCombinationTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2EnumFlagCombinationTests.java
@@ -17,6 +17,10 @@ package org.pcre4j;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.option.Pcre2CompileExtraOption;
+import org.pcre4j.option.Pcre2CompileOption;
+import org.pcre4j.option.Pcre2MatchOption;
+import org.pcre4j.option.Pcre2SubstituteOption;
 
 import java.util.EnumSet;
 

--- a/lib/src/test/java/org/pcre4j/Pcre2EnumTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2EnumTests.java
@@ -16,6 +16,21 @@ package org.pcre4j;
 
 import org.junit.jupiter.api.Test;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.exception.Pcre2CompileError;
+import org.pcre4j.exception.Pcre2ConvertException;
+import org.pcre4j.exception.Pcre2NoSubstringError;
+import org.pcre4j.exception.Pcre2NoUniqueSubstringError;
+import org.pcre4j.exception.Pcre2PatternInfoSizeError;
+import org.pcre4j.exception.Pcre2SubstituteError;
+import org.pcre4j.option.Pcre2Bsr;
+import org.pcre4j.option.Pcre2CompileExtraOption;
+import org.pcre4j.option.Pcre2CompileOption;
+import org.pcre4j.option.Pcre2ConvertOption;
+import org.pcre4j.option.Pcre2JitOption;
+import org.pcre4j.option.Pcre2MatchOption;
+import org.pcre4j.option.Pcre2Newline;
+import org.pcre4j.option.Pcre2PatternInfo;
+import org.pcre4j.option.Pcre2SubstituteOption;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/lib/src/test/java/org/pcre4j/Pcre2ErrorClassTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2ErrorClassTests.java
@@ -15,6 +15,22 @@
 package org.pcre4j;
 
 import org.junit.jupiter.api.Test;
+import org.pcre4j.exception.Pcre2CompileError;
+import org.pcre4j.exception.Pcre2CompileException;
+import org.pcre4j.exception.Pcre2Exception;
+import org.pcre4j.exception.Pcre2InternalException;
+import org.pcre4j.exception.Pcre2MatchException;
+import org.pcre4j.exception.Pcre2MatchLimitException;
+import org.pcre4j.exception.Pcre2NoSubstringError;
+import org.pcre4j.exception.Pcre2NoSubstringException;
+import org.pcre4j.exception.Pcre2NoUniqueSubstringError;
+import org.pcre4j.exception.Pcre2NoUniqueSubstringException;
+import org.pcre4j.exception.Pcre2PatternInfoSizeError;
+import org.pcre4j.exception.Pcre2PatternInfoSizeException;
+import org.pcre4j.exception.Pcre2SubstituteError;
+import org.pcre4j.exception.Pcre2SubstituteException;
+import org.pcre4j.exception.Pcre2SubstringException;
+import org.pcre4j.option.Pcre2PatternInfo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;

--- a/lib/src/test/java/org/pcre4j/Pcre2JitCodeTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2JitCodeTests.java
@@ -17,6 +17,10 @@ package org.pcre4j;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.option.Pcre2CompileOption;
+import org.pcre4j.option.Pcre2JitOption;
+import org.pcre4j.option.Pcre2MatchOption;
+import org.pcre4j.option.Pcre2Newline;
 
 import java.util.EnumSet;
 

--- a/lib/src/test/java/org/pcre4j/Pcre2MatchDataTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2MatchDataTests.java
@@ -17,6 +17,7 @@ package org.pcre4j;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.option.Pcre2MatchOption;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;

--- a/lib/src/test/java/org/pcre4j/Pcre2PatternConverterTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2PatternConverterTests.java
@@ -17,6 +17,8 @@ package org.pcre4j;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.option.Pcre2ConvertOption;
+import org.pcre4j.option.Pcre2MatchOption;
 
 import java.util.EnumSet;
 

--- a/lib/src/test/java/org/pcre4j/Pcre2PatternInfoSizeErrorTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre2PatternInfoSizeErrorTests.java
@@ -15,6 +15,10 @@
 package org.pcre4j;
 
 import org.junit.jupiter.api.Test;
+import org.pcre4j.exception.Pcre2Exception;
+import org.pcre4j.exception.Pcre2InternalException;
+import org.pcre4j.exception.Pcre2PatternInfoSizeException;
+import org.pcre4j.option.Pcre2PatternInfo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;

--- a/lib/src/test/java/org/pcre4j/Pcre4jUtilsExtendedTests.java
+++ b/lib/src/test/java/org/pcre4j/Pcre4jUtilsExtendedTests.java
@@ -19,6 +19,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
 import org.pcre4j.api.Pcre2UtfWidth;
+import org.pcre4j.option.Pcre2Bsr;
+import org.pcre4j.option.Pcre2CompileOption;
+import org.pcre4j.option.Pcre2MatchOption;
 
 import java.util.EnumSet;
 

--- a/lib/src/test/java/org/pcre4j/ResourceCleanupTests.java
+++ b/lib/src/test/java/org/pcre4j/ResourceCleanupTests.java
@@ -17,6 +17,8 @@ package org.pcre4j;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.option.Pcre2MatchOption;
+import org.pcre4j.option.Pcre2Newline;
 
 import java.lang.ref.WeakReference;
 import java.util.EnumSet;

--- a/lib/src/testFixtures/java/org/pcre4j/test/Pcre2CalloutContractTest.java
+++ b/lib/src/testFixtures/java/org/pcre4j/test/Pcre2CalloutContractTest.java
@@ -16,11 +16,11 @@ package org.pcre4j.test;
 
 import org.junit.jupiter.api.Test;
 import org.pcre4j.Pcre2Code;
-import org.pcre4j.Pcre2CompileOption;
 import org.pcre4j.Pcre2MatchContext;
 import org.pcre4j.Pcre2MatchData;
-import org.pcre4j.Pcre2MatchOption;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.option.Pcre2CompileOption;
+import org.pcre4j.option.Pcre2MatchOption;
 import org.pcre4j.api.Pcre2CalloutBlock;
 import org.pcre4j.api.Pcre2CalloutEnumerateBlock;
 

--- a/lib/src/testFixtures/java/org/pcre4j/test/Pcre2CompileContextContractTest.java
+++ b/lib/src/testFixtures/java/org/pcre4j/test/Pcre2CompileContextContractTest.java
@@ -15,16 +15,16 @@
 package org.pcre4j.test;
 
 import org.junit.jupiter.api.Test;
-import org.pcre4j.Pcre2Bsr;
 import org.pcre4j.Pcre2Code;
 import org.pcre4j.Pcre2CompileContext;
-import org.pcre4j.Pcre2CompileException;
-import org.pcre4j.Pcre2CompileExtraOption;
-import org.pcre4j.Pcre2CompileOption;
 import org.pcre4j.Pcre2MatchData;
-import org.pcre4j.Pcre2MatchOption;
 import org.pcre4j.Pcre4jUtils;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.exception.Pcre2CompileException;
+import org.pcre4j.option.Pcre2Bsr;
+import org.pcre4j.option.Pcre2CompileExtraOption;
+import org.pcre4j.option.Pcre2CompileOption;
+import org.pcre4j.option.Pcre2MatchOption;
 
 import java.util.EnumSet;
 

--- a/lib/src/testFixtures/java/org/pcre4j/test/Pcre2MatchContextContractTest.java
+++ b/lib/src/testFixtures/java/org/pcre4j/test/Pcre2MatchContextContractTest.java
@@ -16,11 +16,11 @@ package org.pcre4j.test;
 
 import org.junit.jupiter.api.Test;
 import org.pcre4j.Pcre2Code;
-import org.pcre4j.Pcre2CompileOption;
 import org.pcre4j.Pcre2MatchContext;
 import org.pcre4j.Pcre2MatchData;
-import org.pcre4j.Pcre2MatchOption;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.option.Pcre2CompileOption;
+import org.pcre4j.option.Pcre2MatchOption;
 
 import java.util.EnumSet;
 

--- a/lib/src/testFixtures/java/org/pcre4j/test/Pcre2MatchingContractTest.java
+++ b/lib/src/testFixtures/java/org/pcre4j/test/Pcre2MatchingContractTest.java
@@ -16,10 +16,10 @@ package org.pcre4j.test;
 
 import org.junit.jupiter.api.Test;
 import org.pcre4j.Pcre2Code;
-import org.pcre4j.Pcre2CompileOption;
 import org.pcre4j.Pcre2MatchData;
-import org.pcre4j.Pcre2MatchOption;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.option.Pcre2CompileOption;
+import org.pcre4j.option.Pcre2MatchOption;
 
 import java.util.EnumSet;
 

--- a/lib/src/testFixtures/java/org/pcre4j/test/Pcre2SubstitutionContractTest.java
+++ b/lib/src/testFixtures/java/org/pcre4j/test/Pcre2SubstitutionContractTest.java
@@ -16,9 +16,9 @@ package org.pcre4j.test;
 
 import org.junit.jupiter.api.Test;
 import org.pcre4j.Pcre2Code;
-import org.pcre4j.Pcre2CompileOption;
-import org.pcre4j.Pcre2SubstituteOption;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.option.Pcre2CompileOption;
+import org.pcre4j.option.Pcre2SubstituteOption;
 
 import java.util.EnumSet;
 

--- a/lib/src/testFixtures/java/org/pcre4j/test/Pcre2SubstringContractTest.java
+++ b/lib/src/testFixtures/java/org/pcre4j/test/Pcre2SubstringContractTest.java
@@ -16,12 +16,12 @@ package org.pcre4j.test;
 
 import org.junit.jupiter.api.Test;
 import org.pcre4j.Pcre2Code;
-import org.pcre4j.Pcre2CompileOption;
 import org.pcre4j.Pcre2MatchData;
-import org.pcre4j.Pcre2MatchOption;
-import org.pcre4j.Pcre2NoSubstringException;
-import org.pcre4j.Pcre2NoUniqueSubstringException;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.exception.Pcre2NoSubstringException;
+import org.pcre4j.exception.Pcre2NoUniqueSubstringException;
+import org.pcre4j.option.Pcre2CompileOption;
+import org.pcre4j.option.Pcre2MatchOption;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;

--- a/regex/src/main/java/org/pcre4j/regex/MatchLimitException.java
+++ b/regex/src/main/java/org/pcre4j/regex/MatchLimitException.java
@@ -14,7 +14,7 @@
  */
 package org.pcre4j.regex;
 
-import org.pcre4j.Pcre2MatchLimitException;
+import org.pcre4j.exception.Pcre2MatchLimitException;
 import org.pcre4j.api.IPcre2;
 
 /**

--- a/regex/src/main/java/org/pcre4j/regex/Matcher.java
+++ b/regex/src/main/java/org/pcre4j/regex/Matcher.java
@@ -16,16 +16,16 @@ package org.pcre4j.regex;
 
 import org.pcre4j.Pcre2Code;
 import org.pcre4j.Pcre2CompileContext;
-import org.pcre4j.Pcre2CompileException;
-import org.pcre4j.Pcre2CompileOption;
 import org.pcre4j.Pcre2JitStack;
 import org.pcre4j.Pcre2MatchContext;
 import org.pcre4j.Pcre2MatchData;
-import org.pcre4j.Pcre2MatchOption;
-import org.pcre4j.Pcre2Newline;
-import org.pcre4j.Pcre2SubstituteOption;
 import org.pcre4j.Pcre4jUtils;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.exception.Pcre2CompileException;
+import org.pcre4j.option.Pcre2CompileOption;
+import org.pcre4j.option.Pcre2MatchOption;
+import org.pcre4j.option.Pcre2Newline;
+import org.pcre4j.option.Pcre2SubstituteOption;
 
 import java.lang.ref.Reference;
 import java.nio.charset.StandardCharsets;

--- a/regex/src/main/java/org/pcre4j/regex/Pattern.java
+++ b/regex/src/main/java/org/pcre4j/regex/Pattern.java
@@ -16,14 +16,14 @@ package org.pcre4j.regex;
 
 import org.pcre4j.Pcre2Code;
 import org.pcre4j.Pcre2CompileContext;
-import org.pcre4j.Pcre2CompileException;
-import org.pcre4j.Pcre2CompileOption;
 import org.pcre4j.Pcre2JitCode;
-import org.pcre4j.Pcre2JitOption;
-import org.pcre4j.Pcre2Newline;
 import org.pcre4j.Pcre4j;
 import org.pcre4j.Pcre4jUtils;
 import org.pcre4j.api.IPcre2;
+import org.pcre4j.exception.Pcre2CompileException;
+import org.pcre4j.option.Pcre2CompileOption;
+import org.pcre4j.option.Pcre2JitOption;
+import org.pcre4j.option.Pcre2Newline;
 
 import java.text.Normalizer;
 import java.util.ArrayList;
@@ -58,42 +58,43 @@ public class Pattern {
 
     /**
      * A {@link java.util.regex.Pattern#CASE_INSENSITIVE}-compatible flag implemented via
-     * {@link org.pcre4j.Pcre2CompileOption#CASELESS}
+     * {@link org.pcre4j.option.Pcre2CompileOption#CASELESS}
      */
     public static final int CASE_INSENSITIVE = java.util.regex.Pattern.CASE_INSENSITIVE;
 
     /**
      * A {@link java.util.regex.Pattern#DOTALL}-compatible flag implemented via
-     * {@link org.pcre4j.Pcre2CompileOption#DOTALL}
+     * {@link org.pcre4j.option.Pcre2CompileOption#DOTALL}
      */
     public static final int DOTALL = java.util.regex.Pattern.DOTALL;
 
     /**
      * A {@link java.util.regex.Pattern#LITERAL}-compatible flag implemented via
-     * {@link org.pcre4j.Pcre2CompileOption#LITERAL}
+     * {@link org.pcre4j.option.Pcre2CompileOption#LITERAL}
      */
     public static final int LITERAL = java.util.regex.Pattern.LITERAL;
 
     /**
      * A {@link java.util.regex.Pattern#MULTILINE}-compatible flag implemented via
-     * {@link org.pcre4j.Pcre2CompileOption#MULTILINE}
+     * {@link org.pcre4j.option.Pcre2CompileOption#MULTILINE}
      */
     public static final int MULTILINE = java.util.regex.Pattern.MULTILINE;
 
     /**
      * A {@link java.util.regex.Pattern#UNICODE_CHARACTER_CLASS}-compatible flag implemented via
-     * {@link org.pcre4j.Pcre2CompileOption#UCP}
+     * {@link org.pcre4j.option.Pcre2CompileOption#UCP}
      */
     public static final int UNICODE_CHARACTER_CLASS = java.util.regex.Pattern.UNICODE_CHARACTER_CLASS;
 
     /**
-     * A {@link java.util.regex.Pattern#UNIX_LINES}-compatible flag implemented via {@link org.pcre4j.Pcre2Newline#LF}
+     * A {@link java.util.regex.Pattern#UNIX_LINES}-compatible flag implemented via
+     * {@link org.pcre4j.option.Pcre2Newline#LF}
      */
     public static final int UNIX_LINES = java.util.regex.Pattern.UNIX_LINES;
 
     /**
      * A {@link java.util.regex.Pattern#COMMENTS}-compatible flag implemented via
-     * {@link org.pcre4j.Pcre2CompileOption#EXTENDED}
+     * {@link org.pcre4j.option.Pcre2CompileOption#EXTENDED}
      * <p>
      * Permits whitespace and comments in the pattern. In this mode, whitespace is ignored except when escaped or
      * inside a character class, and comments starting with {@code #} are ignored until end of line.


### PR DESCRIPTION
## Summary

- Split the `org.pcre4j` package (39 classes) into three focused sub-packages per the investigation report recommendation:
  - `org.pcre4j` — core wrappers (13 classes: Pcre2Code, contexts, match data, utilities)
  - `org.pcre4j.option` — enum/config types (10 classes: compile, match, substitute options, etc.)
  - `org.pcre4j.exception` — exception types (16 classes: compile, match, substitute exceptions, etc.)
- Updated all imports across lib, regex, benchmark modules, test fixtures, and tests
- Updated `module-info.java` to export `org.pcre4j.option` and `org.pcre4j.exception`
- Fixed cross-package javadoc references

Fixes #372

## Test plan

- [x] Full `./gradlew build` passes (compilation, tests, javadoc, checkstyle)
- [x] All existing tests pass without modification (only import changes needed)
- [x] Module-info exports verified for new packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)