### PR TITLE
(docs) fix documentation audit findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ PCRE4J is a Java binding for the PCRE2 (Perl Compatible Regular Expressions 2) l
 ```
 pcre4j/
 ├── api/    → IPcre2 interface (backend contract, ~290 PCRE2 constants)
-├── lib/    → Core wrapper (Pcre2Code, contexts, enums, utilities, shared test fixtures)
+├── lib/    → Core wrapper (Pcre2Code, contexts, options (`option`), exceptions (`exception`), utilities, shared test fixtures)
 ├── jna/    → JNA backend (Java Native Access implementation)
 ├── ffm/    → FFM backend (Multi-Release JAR: Java 21 preview + Java 22+ GA)
 ├── regex/  → java.util.regex compatibility layer (Pattern, Matcher)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ public interface Pcre2MatchingContractTest<T extends IPcre2> {
 }
 ```
 
-There are 12 contract interfaces covering all PCRE2 functionality areas (configuration, matching, substitution, substrings, match context, DFA matching, compile context, serialization, JIT, pattern conversion, miscellaneous, and UTF width support).
+There are 13 contract interfaces covering all PCRE2 functionality areas (configuration, matching, substitution, substrings, match context, DFA matching, compile context, serialization, JIT, pattern conversion, callout, miscellaneous, and UTF width support).
 
 ### Base Test Class (`Pcre2Tests`)
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ Proceed using the PCRE4J library in your Java code:
 
 ```java
 import org.pcre4j.*;
+import org.pcre4j.option.*;
+
+import java.util.EnumSet;
 
 public class Usage {
     public static String[] example(String pattern, String subject) {

--- a/docs/adr/0002-backend-strategy-pattern-with-global-singleton.md
+++ b/docs/adr/0002-backend-strategy-pattern-with-global-singleton.md
@@ -38,8 +38,9 @@ The singleton validates at setup time that the backend supports UTF-8 via
 
 - Applications call `Pcre4j.setup(new org.pcre4j.jna.Pcre2())` once at startup and then use the
   convenience API without passing backend references.
-- Calling `Pcre4j.api()` before `setup()` throws `IllegalStateException`, making misconfiguration
-  obvious.
+- Calling `Pcre4j.api()` before `setup()` throws `IllegalStateException` if no backend can be
+  auto-discovered via `ServiceLoader`, making misconfiguration obvious. When a backend artifact is
+  on the classpath, `api()` discovers it automatically and no explicit `setup()` call is needed.
 - Tests and multi-backend scenarios use the explicit-API overloads and never depend on global state.
 - In multi-classloader environments (application servers, OSGi), each classloader gets its own
   `Pcre4j` class and must call `setup()` independently.

--- a/docs/adr/0008-unified-exception-hierarchy.md
+++ b/docs/adr/0008-unified-exception-hierarchy.md
@@ -44,6 +44,7 @@ Intermediate classes group exceptions by PCRE2 operation phase:
 RuntimeException
 └── Pcre2Exception (common base)
     ├── Pcre2CompileException (compile-phase errors)
+    ├── Pcre2ConvertException (conversion-phase errors)
     ├── Pcre2MatchException (match-phase errors)
     │   └── Pcre2MatchLimitException (resource limit violations)
     ├── Pcre2SubstituteException (substitute-phase errors)


### PR DESCRIPTION
## Summary

- Fix broken import in README Advanced Usage example: add missing `org.pcre4j.option.*` and `java.util.EnumSet` imports after option sub-package extraction
- Update CLAUDE.md lib module description to reflect `option` and `exception` sub-packages
- Add `Pcre2ConvertException` to ADR-0008 exception hierarchy diagram
- Update CONTRIBUTING.md contract interface count from 12 to 13 (callout was added)
- Update ADR-0002 consequence to reflect ServiceLoader auto-discovery

## Test plan

- [ ] Verify README Advanced Usage example imports are correct by checking against `org.pcre4j.option.Pcre2CompileOption` and `org.pcre4j.option.Pcre2MatchOption` package locations
- [ ] Verify ADR-0008 hierarchy matches actual exception classes in `lib/src/main/java/org/pcre4j/exception/`
- [ ] Verify CONTRIBUTING.md count matches `Pcre2Tests.java` interface list (13 interfaces)
- [ ] Verify ADR-0002 consequence matches `Pcre4j.api()` behavior with ServiceLoader

🤖 Generated with [Claude Code](https://claude.com/claude-code)