### PR TITLE
(chore) docs: prepare CHANGELOG and ROADMAP for 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-02-16
+
+### Added
+
+- lib: scoped backend API for multi-backend support ([#522](https://github.com/alexey-pelykh/pcre4j/pull/522))
+- regex: GraalVM native-image compilation support ([#517](https://github.com/alexey-pelykh/pcre4j/pull/517))
+- lib: callout support in high-level API ([#516](https://github.com/alexey-pelykh/pcre4j/pull/516))
+- dist: platform-specific PCRE2 native library bundles ([#515](https://github.com/alexey-pelykh/pcre4j/pull/515))
+- lib: glob and POSIX pattern conversion through high-level API ([#514](https://github.com/alexey-pelykh/pcre4j/pull/514))
+- lib: DFA matching through high-level API ([#512](https://github.com/alexey-pelykh/pcre4j/pull/512))
+- lib: high-level pattern serialization and deserialization API ([#511](https://github.com/alexey-pelykh/pcre4j/pull/511))
+- lib: ServiceLoader-based backend auto-discovery ([#510](https://github.com/alexey-pelykh/pcre4j/pull/510))
+- lib: unified exception hierarchy ([#507](https://github.com/alexey-pelykh/pcre4j/pull/507))
+- regex: per-pattern match limit configuration ([#505](https://github.com/alexey-pelykh/pcre4j/pull/505))
+- api: JPMS module-info.java descriptors ([#498](https://github.com/alexey-pelykh/pcre4j/pull/498))
+- lib: pattern info methods ([#491](https://github.com/alexey-pelykh/pcre4j/pull/491))
+- regex: lazy-initialize matching and lookingAt JIT codes ([#459](https://github.com/alexey-pelykh/pcre4j/pull/459))
+- api: validate native library discovery output ([#238](https://github.com/alexey-pelykh/pcre4j/pull/238))
+- regex: configurable ReDoS protection via match limits ([#237](https://github.com/alexey-pelykh/pcre4j/pull/237))
+- regex: Pattern.splitAsStream ([#207](https://github.com/alexey-pelykh/pcre4j/pull/207))
+
+### Fixed
+
+- lib: use CONFIG_NEVER_BACKSLASH_C in isBackslashCDisabled() ([#397](https://github.com/alexey-pelykh/pcre4j/pull/397))
+- lib: remove double-wrapping of exceptions in Pcre2CompileContext ([#386](https://github.com/alexey-pelykh/pcre4j/pull/386))
+- ffm: avoid catching Throwable and wrapping Error in RuntimeException ([#384](https://github.com/alexey-pelykh/pcre4j/pull/384))
+- api: catch IOException instead of Exception in Pcre2LibraryFinder.runCommand ([#383](https://github.com/alexey-pelykh/pcre4j/pull/383))
+- lib: rename misnamed Clean record parameter in Pcre2JitStack ([#382](https://github.com/alexey-pelykh/pcre4j/pull/382))
+- build: fix JNA transitive dependency leak in lib test scope ([#236](https://github.com/alexey-pelykh/pcre4j/pull/236))
+- build: replace hardcoded ':' with File.pathSeparator for Windows support ([#410](https://github.com/alexey-pelykh/pcre4j/pull/410))
+
 ## [0.7.0] - 2026-02-02
 
 ### Added
@@ -187,7 +218,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Minimum viable implementation with JNA and FFM backends ([#1](https://github.com/alexey-pelykh/pcre4j/pull/1))
 
-[Unreleased]: https://github.com/alexey-pelykh/pcre4j/compare/0.7.0...HEAD
+[Unreleased]: https://github.com/alexey-pelykh/pcre4j/compare/1.0.0...HEAD
+[1.0.0]: https://github.com/alexey-pelykh/pcre4j/compare/0.7.0...1.0.0
 [0.7.0]: https://github.com/alexey-pelykh/pcre4j/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/alexey-pelykh/pcre4j/compare/0.5.0...0.6.0
 [0.5.0]: https://github.com/alexey-pelykh/pcre4j/compare/0.4.4...0.5.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,15 +1,13 @@
 # Roadmap
 
-PCRE4J is currently at **v0.7.x** (pre-1.0). This document describes what the project provides
-today and what remains for a stable 1.0 release.
+PCRE4J **v1.0** is the first stable release, with an API stability commitment.
 
-## Current State
-
-The 0.x release series has built out the core functionality:
+## What's Included
 
 - **Three API layers**: low-level (`api`), mid-level (`lib`), and `java.util.regex`-compatible
   (`regex`)
 - **Two backends**: JNA and FFM (Foreign Function & Memory API)
+- **100% PCRE2 API coverage** across both backends
 - **Platform-specific native library bundles** for Linux, macOS, and Windows
 - **GraalVM native-image** support
 - **ServiceLoader-based backend discovery** for zero-configuration setup
@@ -17,11 +15,9 @@ The 0.x release series has built out the core functionality:
   conversion
 - **Thread-scoped backend API** for multi-backend support (`Pcre4j.withBackend()`)
 - **JPMS module descriptors** across all modules
-- **Architecture Decision Records** documenting key design choices
+- **Built-in ReDoS protection** via configurable match, depth, and heap limits
 
-## v1.0
+## Future Direction
 
-The first stable release, with an API stability commitment.
-
-Remaining work is tracked in the
-[v1.0 milestone](https://github.com/alexey-pelykh/pcre4j/milestone/5).
+Post-1.0 work is tracked in the
+[GitHub Issues](https://github.com/alexey-pelykh/pcre4j/issues).


### PR DESCRIPTION
## Summary

- Add `[1.0.0]` section to CHANGELOG.md with all feat/fix PRs merged since 0.7.0
- Rewrite ROADMAP.md to reflect 1.0 as the current stable release (remove pre-1.0 language)
- Update comparison links in CHANGELOG footer

## Test plan

- [ ] Verify CHANGELOG.md formatting and PR links are correct
- [ ] Verify ROADMAP.md reads correctly for the stable release state

🤖 Generated with [Claude Code](https://claude.com/claude-code)