### PR TITLE
(docs) readme: warn about non-functional native bundles in 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ can set the `pcre2.regex.jit` system property with the value `false` to the JVM.
 
 Add a platform-specific bundle to your dependencies and PCRE4J loads the library automatically:
 
+> [!WARNING]
+> **Known issue in 1.0.0:** The `pcre4j-native-*:1.0.0` artifacts on Maven Central are empty
+> and will cause `UnsatisfiedLinkError` at runtime (see
+> [#556](https://github.com/alexey-pelykh/pcre4j/issues/556)).
+> Upgrade to **1.0.1+** once released, or use **Option B** (system-installed PCRE2) below as
+> the workaround for 1.0.0.
+
 | Artifact | Platform |
 |----------|----------|
 | `org.pcre4j:pcre4j-native-linux-x86_64` | Linux x86_64 |


### PR DESCRIPTION
## Summary

Adds a visible GitHub `[!WARNING]` callout above the Option A dependency table in the README, warning users that `pcre4j-native-*:1.0.0` artifacts on Maven Central are empty and cause `UnsatisfiedLinkError` at runtime.

## Context

The native-bundle artifacts published for 1.0.0 are empty shells (659-667 B each, containing only `META-INF/MANIFEST.MF` and an empty `.gitkeep`). Any user following the documented "zero-install" golden path hits `UnsatisfiedLinkError`. Root cause and remediation are tracked in #556.

This PR provides immediate **user-facing protection** for the 1.0.0 regression. It is independent of the fix work (#557, #558) and can ship before, alongside, or after 1.0.1.

## Changes

- `README.md` — insert `> [!WARNING]` callout above Option A dependency table:
  - Explicitly scopes the warning to `1.0.0`
  - Links to #556
  - Recommends upgrading to **1.0.1+** once released, OR using **Option B** (system-installed PCRE2) as the workaround

The `implementation("org.pcre4j:pcre4j-native-linux-x86_64:1.0.0")` example on line 127 is intentionally left unchanged — 1.0.1 isn't published yet, so updating the example would mislead. The warning above makes the status clear.

## Acceptance Criteria

Scenario 1 (from #560) — **satisfied**:

- [x] Callout appears in "Option A: Native Library Bundles" section
- [x] Callout is above the dependency table
- [x] Callout links to #556
- [x] Callout recommends upgrading to 1.0.1+ OR using Option B

Scenario 2 (remove/rewrite when 1.0.1 ships) — deferred to the 1.0.1 release PR per issue description.

## Test plan

- [ ] Preview README on GitHub — verify `[!WARNING]` callout renders with yellow warning icon above dependency table
- [ ] Verify the `#556` link resolves to the umbrella issue
- [ ] Verify no other Option A / native-bundle references in the README contradict the warning

Fixes #560