### PR TITLE
(docs) roadmap: annotate native bundles as non-functional in 1.0.0

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,8 @@ PCRE4J **v1.0** is the first stable release, with an API stability commitment.
 - **Two backends**: JNA and FFM (Foreign Function & Memory API)
 - **100% PCRE2 API coverage** across both backends
 - **Platform-specific native library bundles** for Linux, macOS, and Windows
+  (**WARNING:** non-functional in 1.0.0, fixed in 1.0.1 — see
+  [#556](https://github.com/alexey-pelykh/pcre4j/issues/556))
 - **GraalVM native-image** support
 - **ServiceLoader-based backend discovery** for zero-configuration setup
 - **High-level API coverage**: pattern serialization, DFA matching, callout support, glob/POSIX


### PR DESCRIPTION
## Summary

- Annotate the ROADMAP.md "Platform-specific native library bundles" bullet with a visible **WARNING:** indicator noting that the bundles are non-functional in 1.0.0 and fixed in 1.0.1, with a link to tracking issue #556.
- Appended as a 2-line continuation block on the existing bullet so it can be cleanly removed in the 1.0.1 release PR without reflowing the surrounding list.
- Indicator style matches project conventions: `**WARNING:**` follows the `**Note:**` precedent used in README.md; `[#556](full-URL)` matches CHANGELOG.md's inline issue/PR link format.

## Why

The ROADMAP advertises native bundles as a shipped 1.0 feature, but all `pcre4j-native-*:1.0.0` JARs on Maven Central are empty placeholders (see #556). Readers scanning "What's Included" today are misled about current capability.

## Scope

Documentation-only, single file, 2-line addition. Independent of the #556 native-bundle fix itself, as explicitly called out in the issue ("Small, single-file edit"). Sibling user-facing communication items ship separately: #560 (README) and #562 (1.0.0 GitHub Release notes).

## Test plan

- [ ] Rendered ROADMAP.md on GitHub shows bold **WARNING:** on the native-bundle bullet
- [ ] #556 auto-links (or full URL link resolves) to the tracking issue
- [ ] Bullet remains under "What's Included"; no other sections altered
- [ ] Continuation-indent renders identically to the existing 2-line bullets (lines 7–8, 16–17)

## Follow-up (1.0.1 release PR, not this PR)

- Remove lines 12–13 of ROADMAP.md when 1.0.1 publishes (per issue AC).

Fixes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)