### PR TITLE
(chore) ci: fail release if pcre4j-native-* JARs lack bundled libraries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,6 +63,12 @@ jobs:
       - name: Build artifacts
         run: ./gradlew build jacocoAggregatedTestReport -Dpcre2.library.path=/opt/pcre2/lib
 
+      # Safety net: fail the release if any pcre4j-native-* JAR was staged without
+      # the expected PCRE2 shared library (>= 10 KB). Guards against a recurrence
+      # of the 1.0.0 empty-native regression. See #557.
+      - name: Verify native bundles
+        run: ./gradlew verifyNativeBundles -Ppcre4j.version=${{ github.ref_name }}
+
       - name: Stage artifacts
         run: ./gradlew publishAllPublicationsToStagingDeployRepository -Ppcre4j.version=${{ github.ref_name }}
 

--- a/buildSrc/src/main/kotlin/pcre4j-native-lib.gradle.kts
+++ b/buildSrc/src/main/kotlin/pcre4j-native-lib.gradle.kts
@@ -25,7 +25,11 @@
  *   - Maven publication with artifactId = "pcre4j-native-{platform}"
  *   - No test dependencies (native bundles contain only resources)
  *   - No checkstyle (no source code to check)
+ *   - `verifyNativeBundles` verification task (see issue #557)
  */
+
+import java.util.zip.ZipFile
+
 plugins {
     `java-library`
     `maven-publish`
@@ -59,6 +63,68 @@ publishing {
         create<MavenPublication>("mavenJava") {
             from(components["java"])
             artifactId = nativeArtifactId
+        }
+    }
+}
+
+// Release safety net: verify that platform-specific native bundle JARs actually
+// contain the PCRE2 shared library before they can be staged for deploy.
+// See issue #557.
+//
+// The :native:all module aggregates the 5 platform modules via `api` dependencies
+// and does not bundle a library of its own, so it is excluded here.
+if (project.name != "all") {
+    val platform = project.name
+    val expectedLibName = when {
+        platform.startsWith("linux-") -> "libpcre2-8.so"
+        platform.startsWith("macos-") -> "libpcre2-8.dylib"
+        platform.startsWith("windows-") -> "pcre2-8.dll"
+        else -> throw GradleException(
+            "pcre4j-native-lib: unknown native platform '$platform' (expected linux-*, macos-*, or windows-*)"
+        )
+    }
+    val expectedPath = "META-INF/native/$platform/$expectedLibName"
+    val minSizeBytes = 10L * 1024L
+    val projectPath = project.path
+
+    // The task is invoked explicitly by .github/workflows/release.yaml before the
+    // "Stage artifacts" step. It is intentionally NOT wired into the default `check`
+    // or `publish*` task graphs, so it does not break CI snapshot staging for PRs
+    // where the library-copy workflow step (see umbrella #556) has not run yet.
+    tasks.register("verifyNativeBundles") {
+        group = "verification"
+        description = "Verifies the platform-specific native bundle JAR contains " +
+            "the expected PCRE2 shared library of at least 10 KB."
+
+        // The jar producer dependency is inferred via `inputs.file(jarFile)` below —
+        // `jarFile` is a Provider<RegularFile> derived from the jar TaskProvider,
+        // so Gradle automatically wires the task dependency.
+        val jarFile = tasks.named<Jar>("jar").flatMap { it.archiveFile }
+        inputs.file(jarFile)
+
+        doLast {
+            val jar = jarFile.get().asFile
+            ZipFile(jar).use { zip ->
+                val entry = zip.getEntry(expectedPath)
+                    ?: throw GradleException(
+                        "Native bundle verification failed for $projectPath: " +
+                            "JAR ${jar.name} is missing expected library entry '$expectedPath'. " +
+                            "The PCRE2 shared library was not copied into " +
+                            "native/$platform/src/main/resources/$expectedPath before building. " +
+                            "See .github/workflows/build-natives.yaml for the per-platform build/copy steps."
+                    )
+                if (entry.size < minSizeBytes) {
+                    throw GradleException(
+                        "Native bundle verification failed for $projectPath: " +
+                            "entry '$expectedPath' in ${jar.name} is ${entry.size} bytes " +
+                            "(expected >= $minSizeBytes). This indicates a placeholder file " +
+                            "(e.g. .gitkeep) was bundled instead of the real PCRE2 library."
+                    )
+                }
+                logger.lifecycle(
+                    "Verified $projectPath: ${jar.name} contains $expectedPath (${entry.size} bytes)"
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Add a `verifyNativeBundles` Gradle task as a release safety net for the empty-native-JAR regression tracked in #556. The task opens each platform-specific native bundle JAR and fails if it is missing the expected PCRE2 shared library or the entry is smaller than 10 KB.

Invoked from `.github/workflows/release.yaml` as a dedicated step between **Build artifacts** and **Stage artifacts**, so a missing native on any of the 5 platforms fails the release before anything is staged for deploy.

## Design

- Task is registered on the 5 platform modules (`:native:linux-x86_64`, `:native:linux-aarch64`, `:native:macos-x86_64`, `:native:macos-aarch64`, `:native:windows-x86_64`) via the `pcre4j-native-lib` convention plugin.
- `:native:all` is an api-only aggregator (no bundled library) and is intentionally excluded.
- Platform → expected library name is derived from `project.name`:
  - `linux-*` → `libpcre2-8.so`
  - `macos-*` → `libpcre2-8.dylib`
  - `windows-*` → `pcre2-8.dll`
- Threshold: `entry.size >= 10240` bytes (10 KiB) — catches `.gitkeep` placeholders and any truncated artifact.

### Why not wired into `check` or `publish*`

The task is intentionally NOT wired into the default `check` or `publish*` task graphs. Doing so would break CI snapshot staging on branches that predate the library-copy workflow step (umbrella #556 fix). The release workflow invokes `./gradlew verifyNativeBundles` explicitly — Gradle fans the unqualified name out across all 5 platform subprojects that register the task, and the default fail-fast behavior aborts the release on any failure.

## Test plan

- [x] `./gradlew :native:linux-x86_64:verifyNativeBundles` against the current `.gitkeep`-only state → FAILS with clear error identifying the missing `META-INF/native/linux-x86_64/libpcre2-8.so` entry
- [x] Same task against a 5 KB synthetic library → FAILS with "5120 bytes (expected >= 10240)" and placeholder-file hint
- [x] Same task against a 50 KB synthetic library → SUCCEEDS, logs `Verified :native:linux-x86_64: ... (51200 bytes)`
- [x] `./gradlew :native:all:tasks --group=verification` → task NOT registered (correctly excluded)
- [x] All 5 platforms produce correct platform-specific error messages (`libpcre2-8.so` / `libpcre2-8.dylib` / `pcre2-8.dll`)
- [x] `./gradlew :native:<platform>:check` and `build` on all platforms → SUCCESS without the library present (verify intentionally not in `check` graph)
- [x] `./gradlew :native:linux-x86_64:publishMavenJavaPublicationToStagingDeployRepository --dry-run` → verify NOT in task graph (intentional, protects CI snapshot staging)
- [x] `./gradlew checkstyleMain checkstyleTest` → SUCCESS
- [x] `./gradlew :native:linux-x86_64:verifyNativeBundles --dry-run` → task graph: `compileJava → processResources → classes → jar → verifyNativeBundles` (jar dependency correctly inferred from `inputs.file(Provider<RegularFile>)`)
- [ ] CI green on this PR (pending)

## Notes for reviewers

- Once this PR merges, every release tag push triggers verify before staging. If the umbrella #556 fix has not landed yet, the release will correctly fail — that is the safety net working as intended.
- Non-blocking follow-up (flagged during review, deliberately out of scope): snapshot/PR staging path is unguarded. If the same empty-native regression occurred on a snapshot, it would silently publish. Worth a follow-up issue if desired.

Fixes #557
Related: #556, #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)