### PR TITLE
(fix) ci: build native libraries on 5-platform matrix before release publish

### DIFF
--- a/.github/workflows/build-natives.yaml
+++ b/.github/workflows/build-natives.yaml
@@ -4,9 +4,11 @@ name: Build Natives
 # library matrix build. It is invoked in two modes:
 #
 #   - workflow_call: from .github/workflows/release.yaml during a tagged release,
-#     where each matrix job's populated native/<platform>/src/main/resources/...
-#     directory is uploaded as an artifact and downloaded by the release's
-#     `package` job before Gradle publish. This is the canonical release path.
+#     where each matrix job uploads the built libpcre2-8.{so|dylib|dll} file for
+#     its platform as an artifact, and the release's `package` job downloads
+#     those artifacts and places them into
+#     native/<platform>/src/main/resources/META-INF/native/<platform>/ before
+#     running Gradle publish. This is the canonical release path.
 #
 #   - workflow_dispatch: for on-demand diagnostic builds (reproducing a
 #     single-platform build off-cycle without triggering a full release).

--- a/.github/workflows/build-natives.yaml
+++ b/.github/workflows/build-natives.yaml
@@ -1,6 +1,24 @@
 name: Build Natives
 
+# This workflow is the single source of truth for the 5-platform PCRE2 native
+# library matrix build. It is invoked in two modes:
+#
+#   - workflow_call: from .github/workflows/release.yaml during a tagged release,
+#     where each matrix job's populated native/<platform>/src/main/resources/...
+#     directory is uploaded as an artifact and downloaded by the release's
+#     `package` job before Gradle publish. This is the canonical release path.
+#
+#   - workflow_dispatch: for on-demand diagnostic builds (reproducing a
+#     single-platform build off-cycle without triggering a full release).
+#     See ADR-0010 (docs/adr/0010-native-bundle-release-procedure.md).
+
 on:
+  workflow_call:
+    inputs:
+      pcre2-version:
+        description: 'PCRE2 version to build'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       pcre2-version:
@@ -82,4 +100,5 @@ jobs:
         with:
           name: native-${{ matrix.platform }}
           path: native/${{ matrix.platform }}/src/main/resources/META-INF/native/${{ matrix.platform }}/${{ matrix.lib-name }}
+          if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,9 +22,10 @@ env:
 
 jobs:
   # Build platform-specific PCRE2 native libraries on a 5-platform matrix and
-  # upload each populated native/<platform>/src/main/resources/META-INF/native/
-  # directory as a workflow artifact. The `package` job downloads these before
-  # running Gradle publish so every pcre4j-native-<platform>-<version>.jar on
+  # upload each built libpcre2-8.{so|dylib|dll} file as a workflow artifact.
+  # The `package` job downloads the 5 artifacts and places each library into
+  # native/<platform>/src/main/resources/META-INF/native/<platform>/ before
+  # running Gradle publish, so every pcre4j-native-<platform>-<version>.jar on
   # Maven Central carries its expected libpcre2-8.{so|dylib|dll}.
   #
   # See ADR-0010 (docs/adr/0010-native-bundle-release-procedure.md, Decision 1)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,17 +11,42 @@ concurrency:
 
 permissions: {}
 
+env:
+  # Single source of truth for the PCRE2 version built in this release. This
+  # env var is consumed by the `package` job's `Build PCRE2` step below.
+  # IMPORTANT: the reusable-workflow call to `build-natives.yaml` MUST pass the
+  # same version as a literal string — GitHub Actions does not evaluate the
+  # workflow-level `env` context inside reusable-workflow `with:` expressions,
+  # so the two sites must be kept in lockstep by hand on any PCRE2 bump.
+  PCRE2_VERSION: '10.47'
+
 jobs:
+  # Build platform-specific PCRE2 native libraries on a 5-platform matrix and
+  # upload each populated native/<platform>/src/main/resources/META-INF/native/
+  # directory as a workflow artifact. The `package` job downloads these before
+  # running Gradle publish so every pcre4j-native-<platform>-<version>.jar on
+  # Maven Central carries its expected libpcre2-8.{so|dylib|dll}.
+  #
+  # See ADR-0010 (docs/adr/0010-native-bundle-release-procedure.md, Decision 1)
+  # and umbrella issue #556 for the rationale.
+  build-natives:
+    # Keep `pcre2-version` in lockstep with `env.PCRE2_VERSION` above. See the
+    # note on the env block for why a literal is used here.
+    uses: ./.github/workflows/build-natives.yaml
+    with:
+      pcre2-version: '10.47'
+    permissions:
+      contents: read
+
   package:
+    needs: build-natives
+
     runs-on: ubuntu-24.04
 
     permissions:
       contents: read
 
     timeout-minutes: 30
-
-    env:
-      PCRE2_VERSION: '10.47'
 
     steps:
       - name: Checkout
@@ -59,6 +84,49 @@ jobs:
         uses: ./.github/actions/build-pcre2
         with:
           version: ${{ env.PCRE2_VERSION }}
+
+      # Download the 5 per-platform native libraries produced by the build-natives
+      # matrix. Each artifact name is `native-<platform>` and contains the
+      # platform's libpcre2-8.{so|dylib|dll} at the archive root (per
+      # build-natives.yaml's upload step).
+      - name: Download native library artifacts
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          pattern: native-*
+          path: .tmp/natives
+
+      # Place each downloaded library into the matching Gradle module's resources
+      # so that Gradle's java-library resource processing bundles it into the
+      # corresponding pcre4j-native-<platform>-<version>.jar. The per-platform
+      # native/<platform>/src/main/resources/META-INF/native/<platform>/ directories
+      # already exist (with .gitkeep placeholders); this step populates them.
+      # The platform-to-library mapping mirrors buildSrc/.../pcre4j-native-lib.gradle.kts.
+      - name: Place native libraries into module resources
+        shell: bash
+        run: |
+          set -euo pipefail
+          for platform in linux-x86_64 linux-aarch64 macos-x86_64 macos-aarch64 windows-x86_64; do
+            case "$platform" in
+              linux-*)   lib=libpcre2-8.so ;;
+              macos-*)   lib=libpcre2-8.dylib ;;
+              windows-*) lib=pcre2-8.dll ;;
+              *)
+                echo "::error::Unknown native platform '$platform'"
+                exit 1
+                ;;
+            esac
+            src=".tmp/natives/native-$platform/$lib"
+            dst_dir="native/$platform/src/main/resources/META-INF/native/$platform"
+            if [[ ! -f "$src" ]]; then
+              echo "::error::Expected native library missing for $platform: $src"
+              ls -laR ".tmp/natives/native-$platform" 2>/dev/null || true
+              exit 1
+            fi
+            mkdir -p "$dst_dir"
+            cp "$src" "$dst_dir/$lib"
+            size=$(stat -c '%s' "$dst_dir/$lib")
+            echo "Placed $platform: $dst_dir/$lib ($size bytes)"
+          done
 
       - name: Build artifacts
         run: ./gradlew build jacocoAggregatedTestReport -Dpcre2.library.path=/opt/pcre2/lib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- dist: populate `pcre4j-native-*` JARs with the PCRE2 shared library at release time ([#556](https://github.com/alexey-pelykh/pcre4j/issues/556))
+
 ## [1.0.0] - 2026-02-16
 
 ### Added

--- a/docs/adr/0010-native-bundle-release-procedure.md
+++ b/docs/adr/0010-native-bundle-release-procedure.md
@@ -54,9 +54,10 @@ so that recovery of the native bundle does not depend on any single point of cor
 
 ## Decision
 
-The release procedure for native bundles is codified as **five compounding decisions**, each
-independently capable of catching a regression that the others missed (Decision 2 implements two
-distinct verification checks, so the relationship table below enumerates six rows):
+The release procedure for native bundles is codified as **five compounding checks**, each
+independently capable of catching a regression that the others missed. Check 2 combines a
+build-time Gradle task with a post-publish staging inspector, so the relationship table below
+enumerates six rows — one per independent assertion, not per numbered section:
 
 ### 1. Matrix-build natives within `release.yaml`
 
@@ -67,7 +68,7 @@ same workflow run that publishes to Maven Central**. Each matrix job:
 - Builds PCRE2 from source using the shared `.github/actions/build-pcre2` composite action.
 - Copies the produced `libpcre2-8.{so|dylib|dll}` into
   `native/<platform>/src/main/resources/META-INF/native/<platform>/`.
-- Uploads the populated directory as a workflow artifact.
+- Uploads the produced `libpcre2-8.{so|dylib|dll}` file as a workflow artifact.
 
 A downstream `package` job downloads all five artifacts into the expected resource directories
 before running Gradle publish. `release.yaml` invokes `build-natives.yaml` as a reusable workflow

--- a/docs/adr/0010-native-bundle-release-procedure.md
+++ b/docs/adr/0010-native-bundle-release-procedure.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -54,8 +54,9 @@ so that recovery of the native bundle does not depend on any single point of cor
 
 ## Decision
 
-The release procedure for native bundles is codified as **five compounding checks**, each
-independently capable of catching a regression that the others missed:
+The release procedure for native bundles is codified as **five compounding decisions**, each
+independently capable of catching a regression that the others missed (Decision 2 implements two
+distinct verification checks, so the relationship table below enumerates six rows):
 
 ### 1. Matrix-build natives within `release.yaml`
 
@@ -69,9 +70,11 @@ same workflow run that publishes to Maven Central**. Each matrix job:
 - Uploads the populated directory as a workflow artifact.
 
 A downstream `package` job downloads all five artifacts into the expected resource directories
-before running Gradle publish. The `build-natives.yaml` workflow retains its `workflow_dispatch`
-entry point for on-demand diagnostic builds but is no longer the source of truth for release
-artifacts — the matrix-build-then-publish path in `release.yaml` is.
+before running Gradle publish. `release.yaml` invokes `build-natives.yaml` as a reusable workflow
+via `workflow_call`, so `build-natives.yaml` houses the canonical 5-platform matrix logic;
+`release.yaml` adds only the artifact download + placement steps around the existing publish
+chain. `build-natives.yaml` retains its `workflow_dispatch` entry point for on-demand diagnostic
+builds off-cycle.
 
 ### 2. Build-time verification task (`verifyNativeBundles`)
 
@@ -83,6 +86,17 @@ library is ~500 KB to ~1 MB depending on platform, so 10 KB is a generous lower 
 catches empty placeholders, zero-size files, and manifest-only JARs). The task runs **before**
 `publishAllPublicationsToStagingDeployRepository` in `release.yaml`, so a missing native on any
 of the five platforms fails the release before anything is staged.
+
+A complementary post-publish, pre-deploy inspection script
+(`.github/scripts/verify-staged-natives.sh`, per [#564](https://github.com/alexey-pelykh/pcre4j/issues/564))
+runs between `publishAllPublicationsToStagingDeployRepository` and `jreleaserDeploy`. It walks
+every `{module}/build/staging-deploy/**/pcre4j-native-*-<version>.jar` (ignoring `-sources`,
+`-javadoc`, and the POM-only `pcre4j-native-all` aggregator), asserts each main JAR is at least
+10 KB on disk, and asserts each contains an entry at least 10 KB under
+`META-INF/native/<platform>/`. It is the last gate before Maven Central staging and guards
+against regressions that slip past the in-Gradle verification (e.g., a staged JAR being emptied
+by a downstream Gradle plugin, or an artifact name drifting out of the `verifyNativeBundles`
+coverage).
 
 ### 3. Fixture-based `Pcre2NativeLoader` integration test
 
@@ -119,7 +133,7 @@ the following policy:
 The combination ensures that a developer clone has the directory structure preserved without
 making `.gitkeep` load-bearing for the release pipeline or runtime behaviour.
 
-### Relationship between the five checks
+### Relationship between the six checks
 
 Each check guards a different failure surface:
 
@@ -127,6 +141,7 @@ Each check guards a different failure surface:
 |-------|---------|-------------------------|
 | Matrix-build in `release.yaml` | Missing cross-platform build step | Yes (by construction) |
 | `verifyNativeBundles` | Missing library in the local JAR | Yes |
+| `verify-staged-natives.sh` (post-publish) | Staging-deploy regression that bypasses the Gradle task | Yes |
 | Fixture-based loader test | Logic bugs in extraction / placeholder handling | Yes (via placeholder scenario) |
 | Post-deploy smoke test | Artifact corruption across the publish pipeline | Yes |
 | `.gitkeep` policy | Placeholder leaking into final JAR | Yes (flagged by loader test) |
@@ -151,20 +166,21 @@ one of them alone would have caught #556.
   before it runs. An artifact upload failure on any platform fails the release — which is the
   desired safety behaviour (better a failed release than a partial publish) but requires release
   engineers to debug upload failures as a first-class concern. Artifact retention for the
-  populated `META-INF/native/` directories is set to the default 90 days, shared across the
-  matrix; this is sufficient for post-release forensics.
+  populated `META-INF/native/` directories is set to 7 days (see `build-natives.yaml`), which
+  covers the same-run hand-off to the `package` job plus a short post-release forensics window.
 - **Platform coverage is frozen at 5 platforms.** Adding a new platform (e.g., linux-riscv64,
   freebsd-x86_64) requires adding a row to the matrix, a corresponding `native-<platform>` Gradle
   module, and a new fixture for the loader test. Platform additions become a schema change, not a
   configuration tweak.
-- **`build-natives.yaml` becomes secondary.** Its ongoing purpose is diagnostic — reproducing a
-  single-platform build off-cycle without triggering a full release. It remains
-  `workflow_dispatch`-only to avoid being mistaken for a release path.
-- **Release engineers need not manually verify bundle contents.** The five checks guarantee that
+- **`build-natives.yaml` becomes a reusable workflow.** `release.yaml` invokes it via
+  `workflow_call` for the matrix build, so it houses the canonical 5-platform matrix logic. Its
+  `workflow_dispatch` entry point is retained for on-demand diagnostic builds — reproducing a
+  single-platform build off-cycle without triggering a full release.
+- **Release engineers need not manually verify bundle contents.** The six checks guarantee that
   any empty, undersized, or misnamed bundle fails the release before Maven Central staging. A
   release that completes successfully is a release where all five platforms have verified native
   bundles in Maven Central.
 - **Downstream consumers gain two guarantees that 1.0.0 lacked**: (1) every future release has
   populated native bundles for each supported platform, and (2) regressions introduced in the
-  release pipeline are caught by at least one of the five independent checks rather than
+  release pipeline are caught by at least one of the six independent checks rather than
   discovered by consumers in production.


### PR DESCRIPTION
## Summary

- Rework `.github/workflows/release.yaml` so PCRE2 native libraries are built on a 5-platform matrix (linux-x86_64, linux-aarch64, macos-x86_64, macos-aarch64, windows-x86_64) **before** `./gradlew publishAllPublicationsToStagingDeployRepository`, and each platform's library is placed under `native/<platform>/src/main/resources/META-INF/native/<platform>/` so Gradle's `java-library` resource processing packages it into the corresponding `pcre4j-native-<platform>-<version>.jar`. This fixes the 1.0.0 empty-native regression ([#556](https://github.com/alexey-pelykh/pcre4j/issues/556)).
- Reuse the existing 5-platform matrix logic in `.github/workflows/build-natives.yaml` by adding a `workflow_call` trigger alongside its existing `workflow_dispatch`; `release.yaml` now invokes it as a reusable workflow. `build-natives.yaml` keeps its `workflow_dispatch` entry point for on-demand diagnostic builds, per the ADR-0010 decision.
- Flip `docs/adr/0010-native-bundle-release-procedure.md` Status `Proposed` → `Accepted`, bring the ADR body in line with the implementation (reusable-workflow wording, staging-inspector paragraph under Decision 2 referencing #564, corrected 7-day retention figure), and add a CHANGELOG entry under `## [Unreleased]` → `### Fixed`.

## Pipeline shape after this change

```
push tag
  ↓
build-natives (reusable workflow call)          ← new
  ├── linux-x86_64     → artifact native-linux-x86_64
  ├── linux-aarch64    → artifact native-linux-aarch64
  ├── macos-x86_64     → artifact native-macos-x86_64
  ├── macos-aarch64    → artifact native-macos-aarch64
  └── windows-x86_64   → artifact native-windows-x86_64
  ↓  needs:
package  (existing steps + new download/placement)
  ├── Download native library artifacts (pattern: native-*)  ← new
  ├── Place native libraries into module resources            ← new
  ├── ./gradlew build jacocoAggregatedTestReport
  ├── ./gradlew verifyNativeBundles                           [#557 gate — added previously]
  ├── ./gradlew publishAllPublicationsToStagingDeployRepository
  ├── .github/scripts/verify-staged-natives.sh .              [#564 gate — added previously]
  └── ./gradlew jreleaserDeploy
```

## Changes by file

| File | Change |
|---|---|
| `.github/workflows/build-natives.yaml` | Add `workflow_call` trigger; add `if-no-files-found: error` to the upload; add dual-mode header comment. |
| `.github/workflows/release.yaml` | Split into `build-natives` (reusable-workflow call, explicit `permissions: contents: read`) + `package` (with `needs: build-natives`). Add `Download native library artifacts` (v6.0.0 pin) + `Place native libraries into module resources` (case-statement bash, no associative arrays; mirrors `pcre4j-native-lib.gradle.kts`). Comment the `pcre2-version` lockstep constraint (GHA `env` context is unavailable in reusable-workflow `with:` expressions). |
| `CHANGELOG.md` | `## [Unreleased]` → `### Fixed` entry referencing #556. |
| `docs/adr/0010-native-bundle-release-procedure.md` | Status `Proposed` → `Accepted`; Decision 1 prose updated to describe the reusable-workflow split; Decision 2 gains the staging-inspector paragraph + table row; Consequences bullet corrected for `workflow_dispatch`-only wording and 7-day retention figure. |

## How this was validated

- **AC verification** — the three Gherkin scenarios in [#556](https://github.com/alexey-pelykh/pcre4j/issues/556) map to: (1) matrix-build + artifact placement ensure downstream consumers can rely on bundled natives; (2) each of the 5 `pcre4j-native-*` JARs now carries `META-INF/native/<platform>/libpcre2-8.{so|dylib|dll}` ≥ 10 KB; `pcre4j-native-all` keeps its aggregator role via `api(project(":native:<p>"))`; (3) `verifyNativeBundles` runs **before** `publishAllPublicationsToStagingDeployRepository` in `release.yaml` and blocks any regression.
- **End-to-end local simulation** — placed a real `/opt/homebrew/lib/libpcre2-8.dylib` (~588 KB) into `native/macos-aarch64/src/main/resources/META-INF/native/macos-aarch64/` and ran `./gradlew :native:macos-aarch64:verifyNativeBundles` — PASS (`Verified :native:macos-aarch64: ... (588224 bytes)`). Removing the library and re-running reproduced the expected `Native bundle verification failed` error message documented in `pcre4j-native-lib.gradle.kts`.
- **Local checks** — `./gradlew checkstyleMain checkstyleTest` PASS; `.github/scripts/verify-staged-natives.test.sh` PASS (7/7); YAML syntax validated via `yq`; bash step smoke-tested.
- **Fresh-context adversarial validation + polish** — two independent subprocess passes against the staged diff. Validator: CLEAN on all three ACs after acting on 3 findings (PCRE2 version lockstep comment, caller-job `permissions: contents: read`, ADR staging-inspector note). Polish: CLEAN after 3 iterations (CHANGELOG conciseness, ADR Decision 1 + Consequences prose corrections, "five decisions / six checks" framing consistency, retention-days figure).

## Note for the release engineer

This PR is the first production trigger for the 5-platform matrix code path in both `build-natives.yaml` and `release.yaml`. Before pushing the 1.0.1 tag, consider dispatching `build-natives.yaml` manually via `workflow_dispatch` to flush out any per-platform PCRE2 build issues (particularly the Windows CMake DLL discovery path) without burning a release tag.

## Test plan

- [ ] CI `package` job and all `compatibility` matrix jobs pass on this PR (snapshot dry-run validates the Gradle-side effect of the workflow change; the tag-triggered release path itself is only exercised on the next tagged release).
- [ ] `lint` job runs `checkstyleMain checkstyleTest` + `verify-staged-natives.test.sh` unit tests — confirms no regression in the sibling staging inspector.
- [ ] DCO check: single commit with `Signed-off-by: Oleksii PELYKH <oleksii@pelykh.com>`.
- [ ] (Optional, pre-tag) Dispatch `build-natives.yaml` via the Actions UI to verify per-platform PCRE2 builds and artifact uploads succeed before tagging 1.0.1.

Fixes #556