### PR TITLE
(chore) ci: post-deploy smoke test of Maven Central native bundles

### DIFF
--- a/.github/post-deploy-smoke/.gitignore
+++ b/.github/post-deploy-smoke/.gitignore
@@ -1,0 +1,6 @@
+# Ephemeral artifacts produced by local reproduction of the workflow steps
+# (see README.md § Local validation). These are all regeneratable.
+pom.xml
+cp.txt
+build/
+target/

--- a/.github/post-deploy-smoke/README.md
+++ b/.github/post-deploy-smoke/README.md
@@ -1,0 +1,72 @@
+# Post-Deploy Smoke Test
+
+Driven by [`.github/workflows/post-deploy-smoke.yaml`](../workflows/post-deploy-smoke.yaml).
+
+## Purpose
+
+Resolves the freshly-published `org.pcre4j:pcre4j-native-<platform>:<version>` from
+Maven Central on a 3-OS matrix (Linux/macOS/Windows) and exercises PCRE4J end-to-end
+with no `-Dpcre2.library.path` set. This is Decision 4 in ADR-0010's defense-in-depth
+release procedure (#559), catching regressions that the build-time and pre-deploy
+checks cannot reach because they cross trust boundaries (JReleaser staging, Sonatype
+Central, the CDN).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `SmokeTest.java` | The minimal Java program: bundle assertion + JNA backend init + `a(b\|c)+` match |
+| `pom.xml.template` | Maven project template, rendered by the workflow with `@VERSION@` and `@PLATFORM@` substituted |
+
+## Local validation
+
+Once `<version>` is published to Maven Central (e.g. `1.0.1`), reproduce a single
+platform locally without waiting for a release:
+
+```bash
+cd .github/post-deploy-smoke
+sed -e "s/@VERSION@/1.0.1/g" -e "s/@PLATFORM@/linux-x86_64/g" pom.xml.template > pom.xml
+mvn -B -ntp -q dependency:build-classpath -Dmdep.outputFile=cp.txt
+mkdir -p build && javac -cp "$(cat cp.txt)" -d build SmokeTest.java
+java \
+  -Dpcre2.library.discovery=false \
+  -Djava.util.logging.SimpleFormatter.format='%4$s: %5$s%n' \
+  -cp "build:$(cat cp.txt)" \
+  SmokeTest
+```
+
+Replace `linux-x86_64` with `macos-aarch64`, `macos-x86_64`, `linux-aarch64`, or
+`windows-x86_64` to test other bundles. On Windows, replace the `:` classpath
+separator with `;`.
+
+Expected output on success (3 `OK` lines, then the summary):
+
+```
+OK: bundled native extracted to /tmp/pcre4j-native<random>/
+OK: JNA backend initialized
+OK: Pattern "a(b|c)+" matched "abbc"
+
+Smoke test PASSED
+```
+
+(The first line shows the extraction **directory**; the actual
+`libpcre2-8.so`/`.dylib`/`.dll` sits inside it.)
+
+Pinning the smoke test against `1.0.0` is a useful negative check: that release
+shipped empty native bundles (the #556 regression), so the first assertion fires
+and the program exits 1 with a clear `FAIL: pcre4j-native-* bundle did not provide
+an extractable native library` message.
+
+## Why JNA and not FFM
+
+JNA works on Java 21+ with no preview flags or `--enable-native-access` opt-ins, which
+keeps the smoke test dependency surface minimal. Adding an FFM variant in the future
+is reasonable; this PR keeps the footprint tight to what the #559 acceptance criteria
+require.
+
+## Why discovery is disabled
+
+`-Dpcre2.library.discovery=false` disables `Pcre2LibraryFinder` so a system-installed
+PCRE2 (Homebrew on macOS, distro packages on Linux) cannot mask an empty bundle by
+satisfying the JNA fallback path. The bundle assertion in `SmokeTest.java` is the
+primary safety net; disabling discovery makes the negative path observable in CI.

--- a/.github/post-deploy-smoke/SmokeTest.java
+++ b/.github/post-deploy-smoke/SmokeTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Oleksii PELYKH
+ *
+ * This file is a part of the PCRE4J. The PCRE4J is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this program. If not, see
+ * <https://www.gnu.org/licenses/>.
+ */
+import org.pcre4j.Pcre4j;
+import org.pcre4j.api.Pcre2NativeLoader;
+import org.pcre4j.jna.Pcre2;
+import org.pcre4j.regex.Pattern;
+
+/**
+ * Post-deploy smoke test for the {@code pcre4j-native-<platform>} Maven Central artifacts.
+ * <p>
+ * Run by {@code .github/workflows/post-deploy-smoke.yaml} on a 3-OS matrix after the Release
+ * workflow publishes a new version. The runner classpath is composed entirely from artifacts
+ * resolved from Maven Central (NOT the local build), and the JVM is launched without any
+ * {@code -Dpcre2.library.path}/{@code -Djna.library.path}/{@code -Djava.library.path} so
+ * the only path that succeeds is the one through the bundled native.
+ * <p>
+ * Three checks, in order:
+ * <ol>
+ *   <li>{@link Pcre2NativeLoader#load} returns a non-empty path. Catches the #556 regression
+ *       directly: an empty {@code pcre4j-native-*} JAR (only {@code .gitkeep}) returns
+ *       {@link java.util.Optional#empty} here, before any backend is constructed.</li>
+ *   <li>{@code new Pcre2()} succeeds. Catches a corrupt or unloadable native — JNA loads the
+ *       extracted file by absolute path and surfaces an {@link UnsatisfiedLinkError} that we
+ *       turn into a non-zero exit.</li>
+ *   <li>{@link Pattern#compile} of {@code "a(b|c)+"} matches {@code "abbc"}. The end-to-end
+ *       smoke that the bundled library actually executes a match.</li>
+ * </ol>
+ * <p>
+ * The workflow runs this with {@code -Dpcre2.library.discovery=false} so that
+ * {@link org.pcre4j.api.Pcre2LibraryFinder} cannot mask an empty bundle by discovering a
+ * system-installed PCRE2 via {@code pcre2-config}/{@code pkg-config}/well-known paths.
+ */
+public class SmokeTest {
+
+    public static void main(String[] args) {
+        // 1. Bundle resolves to an extracted, non-empty file.
+        var bundled = Pcre2NativeLoader.load("pcre2-8");
+        if (bundled.isEmpty()) {
+            System.err.println(
+                "FAIL: pcre4j-native-* bundle did not provide an extractable native library "
+                    + "(see issue #556 for the canonical empty-bundle failure mode)."
+            );
+            System.exit(1);
+        }
+        System.out.println("OK: bundled native extracted to " + bundled.get());
+
+        // 2. Backend loads from the extracted absolute path. A corrupt bundle surfaces here.
+        try {
+            Pcre4j.setup(new Pcre2());
+        } catch (Throwable t) {
+            System.err.println("FAIL: JNA backend initialization failed: " + t);
+            t.printStackTrace();
+            System.exit(1);
+        }
+        System.out.println("OK: JNA backend initialized");
+
+        // 3. End-to-end: compile + match per #559 acceptance criteria.
+        try {
+            var pattern = Pattern.compile("a(b|c)+");
+            var matcher = pattern.matcher("abbc");
+            if (!matcher.matches()) {
+                System.err.println("FAIL: Pattern \"a(b|c)+\" did not match \"abbc\"");
+                System.exit(1);
+            }
+        } catch (Throwable t) {
+            System.err.println("FAIL: pattern compile/match raised: " + t);
+            t.printStackTrace();
+            System.exit(1);
+        }
+        System.out.println("OK: Pattern \"a(b|c)+\" matched \"abbc\"");
+
+        System.out.println();
+        System.out.println("Smoke test PASSED");
+    }
+}

--- a/.github/post-deploy-smoke/pom.xml.template
+++ b/.github/post-deploy-smoke/pom.xml.template
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Maven project template for the post-deploy smoke test.
+
+  The workflow renders this template by replacing:
+    @VERSION@   - the published PCRE4J version under test (e.g. 1.0.1)
+    @PLATFORM@  - the runner-mapped native platform (linux-x86_64,
+                  macos-aarch64, windows-x86_64)
+
+  All three pcre4j-* dependencies are resolved from Maven Central; nothing
+  from the local build is consumed. Maven Central is declared explicitly so
+  the smoke test does not depend on the runner's ~/.m2/settings.xml content.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.pcre4j.smoke</groupId>
+    <artifactId>post-deploy-smoke</artifactId>
+    <version>1</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <url>https://repo1.maven.apache.org/maven2/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.pcre4j</groupId>
+            <artifactId>pcre4j-jna</artifactId>
+            <version>@VERSION@</version>
+        </dependency>
+        <dependency>
+            <groupId>org.pcre4j</groupId>
+            <artifactId>pcre4j-regex</artifactId>
+            <version>@VERSION@</version>
+        </dependency>
+        <dependency>
+            <groupId>org.pcre4j</groupId>
+            <artifactId>pcre4j-native-@PLATFORM@</artifactId>
+            <version>@VERSION@</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/.github/workflows/post-deploy-smoke.yaml
+++ b/.github/workflows/post-deploy-smoke.yaml
@@ -1,0 +1,277 @@
+name: Post-Deploy Smoke
+
+# Resolves the freshly-published org.pcre4j:pcre4j-native-<platform>:<version>
+# from Maven Central on a 3-OS matrix and exercises PCRE4J end-to-end with NO
+# pcre2.library.path set. This crosses every trust boundary that the build-time
+# checks (#557, #564) and runtime fixture test (#558) cannot reach: JReleaser
+# staging, Sonatype Central, and the CDN. See ADR-0010 Decision 4 and #559.
+
+on:
+  # Auto-trigger after a successful Release run.
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+  # Manual trigger to smoke-test any published version off-cycle.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'PCRE4J version to smoke test (e.g. 1.0.1)'
+        required: true
+        type: string
+
+# workflow_run subscribers receive a read-only token by default; jobs that need
+# write scopes opt in at the job level (see alert-on-failure below).
+permissions: {}
+
+concurrency:
+  group: post-deploy-smoke-${{ github.event.workflow_run.head_branch || inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  determine-version:
+    # workflow_run fires for every Release completion; only smoke-test successful releases.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+
+    runs-on: ubuntu-24.04
+
+    # No additional permissions: this job only resolves the version string from
+    # the event payload + inputs and does not touch the repo or any API.
+    permissions: {}
+
+    timeout-minutes: 5
+
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+
+    steps:
+      - name: Resolve version
+        id: resolve
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            v="$INPUT_VERSION"
+          else
+            # Release runs are tag-pushed; head_branch carries the tag name.
+            v="$RUN_HEAD_BRANCH"
+          fi
+          if [[ -z "$v" ]]; then
+            echo "::error::Could not determine smoke-test version"
+            exit 1
+          fi
+          # Reject anything that does not match the release tag pattern from
+          # release.yaml so an accidentally-dispatched branch name cannot drive
+          # a smoke test.
+          if ! [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Refusing to smoke-test non-release version: '$v'"
+            exit 1
+          fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          echo "Smoke testing version: $v"
+
+  smoke:
+    needs: determine-version
+
+    permissions:
+      contents: read
+
+    # Generous to absorb Maven Central propagation delay (typically 5-30 min
+    # post-deploy) before the actual test runs.
+    timeout-minutes: 45
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            platform: linux-x86_64
+          - os: macos-14
+            platform: macos-aarch64
+          - os: windows-2022
+            platform: windows-x86_64
+
+    runs-on: ${{ matrix.os }}
+
+    env:
+      PCRE4J_VERSION: ${{ needs.determine-version.outputs.version }}
+      NATIVE_PLATFORM: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up temurin-jdk-21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Wait for Maven Central propagation
+        # JReleaser deploy succeeds before the artifacts are reachable on
+        # repo1.maven.apache.org (Sonatype/CDN sync delay). Sonatype Central +
+        # the CDN do not guarantee same-instant visibility across all artifacts
+        # in a deploy batch, so poll all three the consumer needs (jna, regex,
+        # native bundle) and proceed only when ALL are visible. 30-minute cap.
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifacts=(
+            "pcre4j-jna"
+            "pcre4j-regex"
+            "pcre4j-native-${NATIVE_PLATFORM}"
+          )
+          deadline=$(( $(date +%s) + 1800 ))
+          attempt=0
+          while true; do
+            attempt=$((attempt + 1))
+            missing=""
+            for artifact in "${artifacts[@]}"; do
+              url="https://repo1.maven.apache.org/maven2/org/pcre4j/${artifact}/${PCRE4J_VERSION}/${artifact}-${PCRE4J_VERSION}.jar"
+              if ! curl -fsSI "$url" -o /dev/null; then
+                missing="$artifact"
+                break
+              fi
+            done
+            if [[ -z "$missing" ]]; then
+              echo "All artifacts visible after attempt $attempt"
+              exit 0
+            fi
+            if (( $(date +%s) >= deadline )); then
+              echo "::error::Artifacts not visible on Maven Central after 30 minutes (last missing: ${missing}-${PCRE4J_VERSION}.jar)"
+              exit 1
+            fi
+            echo "Attempt ${attempt}: ${missing}-${PCRE4J_VERSION}.jar not yet visible, sleeping 30s..."
+            sleep 30
+          done
+
+      - name: Render Maven project from template
+        shell: bash
+        working-directory: .github/post-deploy-smoke
+        run: |
+          set -euo pipefail
+          sed \
+            -e "s/@VERSION@/${PCRE4J_VERSION}/g" \
+            -e "s/@PLATFORM@/${NATIVE_PLATFORM}/g" \
+            pom.xml.template > pom.xml
+          echo "--- rendered pom.xml ---"
+          cat pom.xml
+
+      - name: Resolve dependencies from Maven Central
+        shell: bash
+        working-directory: .github/post-deploy-smoke
+        run: |
+          set -euo pipefail
+          mvn -B -ntp -q dependency:build-classpath -Dmdep.outputFile=cp.txt
+          # Sanity: the resolved classpath must include the native bundle.
+          if ! grep -q "pcre4j-native-${NATIVE_PLATFORM}-${PCRE4J_VERSION}\.jar" cp.txt; then
+            echo "::error::Resolved classpath does not include pcre4j-native-${NATIVE_PLATFORM}-${PCRE4J_VERSION}.jar"
+            cat cp.txt
+            exit 1
+          fi
+          echo "Classpath includes the native bundle"
+
+      - name: Compile smoke test
+        shell: bash
+        working-directory: .github/post-deploy-smoke
+        run: |
+          set -euo pipefail
+          mkdir -p build
+          javac -cp "$(cat cp.txt)" -d build SmokeTest.java
+
+      - name: Run smoke test (no pcre2.library.path; system discovery disabled)
+        shell: bash
+        working-directory: .github/post-deploy-smoke
+        run: |
+          set -euo pipefail
+          # Windows runners with shell:bash still need ';' for Java classpath.
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            sep=";"
+          else
+            sep=":"
+          fi
+          cp_str=$(cat cp.txt)
+          # Explicitly DO NOT pass: -Dpcre2.library.path, -Djna.library.path,
+          # -Djava.library.path. AND disable Pcre2LibraryFinder so a
+          # system-installed pcre2 cannot mask an empty bundle on macOS or Linux.
+          # shellcheck disable=SC2016  # %4$s/%5$s are SimpleFormatter placeholders, not shell vars
+          java \
+            -Dpcre2.library.discovery=false \
+            -Djava.util.logging.SimpleFormatter.format='%4$s: %5$s%n' \
+            -cp "build${sep}${cp_str}" \
+            SmokeTest
+
+  alert-on-failure:
+    # Only auto-open issues when the upstream Release run drove this run.
+    # Manual workflow_dispatch failures stay as a CI failure only — the
+    # operator who dispatched can read the run output.
+    if: |
+      always()
+      && github.event_name == 'workflow_run'
+      && needs.determine-version.result == 'success'
+      && needs.smoke.result == 'failure'
+
+    needs:
+      - determine-version
+      - smoke
+
+    runs-on: ubuntu-24.04
+
+    permissions:
+      issues: write
+
+    timeout-minutes: 5
+
+    steps:
+      - name: Open or update tracking issue
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v7
+        env:
+          PCRE4J_VERSION: ${{ needs.determine-version.outputs.version }}
+        with:
+          script: |
+            const version = process.env.PCRE4J_VERSION;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const titlePrefix = 'Post-deploy smoke test failed';
+            const body = [
+              `Post-deploy smoke test for **${version}** failed on at least one runner.`,
+              ``,
+              `Failing run: ${runUrl}`,
+              ``,
+              `This is the post-publish gate that resolves`,
+              `\`org.pcre4j:pcre4j-native-<platform>:${version}\` from Maven Central and`,
+              `exercises PCRE4J end-to-end with no \`-Dpcre2.library.path\` set`,
+              `(see ADR-0010 Decision 4 and #559).`,
+              ``,
+              `Likely causes:`,
+              `- the native bundle JAR is empty/undersized for one or more platforms`,
+              `- Sonatype Central or the CDN transformed the artifact during publish`,
+              `- the bundled native does not load on the target platform at runtime`,
+            ].join('\n');
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'ci/cd,bug',
+              per_page: 100,
+            });
+            const match = existing.find((i) => i.title.startsWith(titlePrefix));
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Another failure detected for **${version}**.\n\nFailing run: ${runUrl}`,
+              });
+              core.info(`Updated existing issue #${match.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `${titlePrefix} for ${version}`,
+                body: body,
+                labels: ['bug', 'ci/cd'],
+              });
+              core.info(`Opened new issue #${created.data.number}`);
+            }


### PR DESCRIPTION
## Description

Adds a post-deploy smoke test workflow that exercises the PUBLISHED
`pcre4j-native-<platform>` bundles end-to-end from Maven Central on a 3-OS
matrix (`ubuntu-24.04`, `macos-14`, `windows-2022`) with no
`-Dpcre2.library.path` set. Triggered by `workflow_run` after a successful
`Release` run, or manually via `workflow_dispatch`.

This crosses trust boundaries the in-build checks cannot reach — JReleaser
staging, Sonatype Central, and the CDN. It is Decision 4 of ADR-0010's
defense-in-depth release procedure, completing the stack alongside the
already-merged #556 (5-platform matrix natives), #557 (`verifyNativeBundles`),
#558 (fixture-based loader test), #564 (pre-deploy staging inspection), and
#563 (ADR-0010 itself).

### Files

- **`.github/workflows/post-deploy-smoke.yaml`** — workflow with three jobs:
  - `determine-version`: extracts the version from `workflow_run.head_branch`
    (tag) or `inputs.version`, regex-gated to `^[0-9]+\.[0-9]+\.[0-9]+$` so
    non-release refs cannot drive a smoke run. `permissions: {}`.
  - `smoke`: 3-OS matrix, `fail-fast: false`. Each runner polls
    `repo1.maven.apache.org` for `pcre4j-jna`, `pcre4j-regex`, and
    `pcre4j-native-<platform>` under a shared 30-minute deadline to absorb
    Sonatype/CDN propagation delay, renders `pom.xml.template`, resolves the
    classpath with `mvn dependency:build-classpath`, and runs `SmokeTest`.
  - `alert-on-failure`: only on `workflow_run`-driven failure (not manual
    dispatch); `issues: write` job-level permission; opens or comments on
    an open issue labeled `bug` + `ci/cd` with a link to the failing run.

- **`.github/post-deploy-smoke/SmokeTest.java`** — asserts
  `Pcre2NativeLoader.load("pcre2-8")` returns a non-empty path **before**
  constructing the JNA backend, which forecloses the path where a
  system-installed pcre2 could mask an empty bundle via JNA's fallback
  load. Then compiles `"a(b|c)+"` and matches `"abbc"` (the exact scenario
  in the AC).

- **`.github/post-deploy-smoke/pom.xml.template`** — depends on `pcre4j-jna`,
  `pcre4j-regex`, and `pcre4j-native-@PLATFORM@` at `@VERSION@` from Maven
  Central; explicit `<repository>` so the test does not depend on the
  runner's `~/.m2/settings.xml`.

- **`.github/post-deploy-smoke/README.md`** — local-reproduction
  instructions, rationale for choosing JNA over FFM, and rationale for
  `-Dpcre2.library.discovery=false`.

- **`.github/post-deploy-smoke/.gitignore`** — covers `pom.xml`, `cp.txt`,
  `build/` produced by local runs.

### Validation

- `actionlint .github/workflows/post-deploy-smoke.yaml` → exit 0.
- `SmokeTest.java` compiles against locally-built `api`/`lib`/`jna`/`regex`
  jars + JNA 5.17.0 with the exact `javac -cp "$(cat cp.txt)" -d build
  SmokeTest.java` form the workflow uses.
- **Negative path verified locally**: with no native bundle on classpath,
  `Pcre2NativeLoader.load("pcre2-8")` returns empty → bundle-assertion
  fails with the canonical error message and exits 1. Same behavior
  expected when run against an empty `1.0.0`-style native bundle.
- **Positive path verified locally**: with a synthetic
  `META-INF/native/macos-aarch64/libpcre2-8.dylib` on classpath, the
  bundle assertion passes, the JNA backend initializes, and
  `Pcre2NativeLoader` logs the extraction path.
- Two fresh-context validation iterations against the #559 AC: iteration
  1 flagged 1 BLOCKER + 2 SHOULD-FIX + NITs; iteration 2 after fixes
  returned **CLEAN**. Fresh-context polish returned **CLEAN** with two
  small consistency edits to the README.

### First exercise

This workflow does not fire for real until the next tagged release (1.0.1);
until then, the workflow file itself is the deliverable. Maintainers can
exercise the flow early by running `workflow_dispatch` against `1.0.1` once
it ships, or by running the local-reproduction recipe in
`.github/post-deploy-smoke/README.md` against any published version.

Fixes #559

## Checklist

- [x] Tests pass (`./gradlew build`) — N/A: no Gradle-tested code added; this
      PR only adds files under `.github/` which are not in any Gradle source
      set. Local validation via `actionlint` + `javac` against published jars
      is documented above.
- [x] Checkstyle passes (`./gradlew checkstyleMain checkstyleTest`) — N/A:
      no Java code added to any checkstyle-governed source set. The
      `SmokeTest.java` under `.github/post-deploy-smoke/` is compiled ad hoc
      by the workflow, not by Gradle.
- [x] Commits are signed off (DCO: `git commit -s`)
- [x] `PCRE2_API.md` updated (if new PCRE2 API bindings are added) — N/A:
      no new PCRE2 API bindings.