### PR TITLE
(docs) readme: extend native bundles warning to cover main-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,12 @@ can set the `pcre2.regex.jit` system property with the value `false` to the JVM.
 Add a platform-specific bundle to your dependencies and PCRE4J loads the library automatically:
 
 > [!WARNING]
-> **Known issue in 1.0.0:** The `pcre4j-native-*:1.0.0` artifacts on Maven Central are empty
-> and will cause `UnsatisfiedLinkError` at runtime (see
-> [#556](https://github.com/alexey-pelykh/pcre4j/issues/556)).
-> Upgrade to **1.0.1+** once released, or use **Option B** (system-installed PCRE2) below as
-> the workaround for 1.0.0.
+> **Known issue:** The published `pcre4j-native-*` artifacts are empty and will cause
+> `UnsatisfiedLinkError` at runtime. This affects both the **1.0.0** release on Maven Central
+> (see [#556](https://github.com/alexey-pelykh/pcre4j/issues/556)) and the **`main-SNAPSHOT`**
+> builds on Maven Central Snapshots (see
+> [#573](https://github.com/alexey-pelykh/pcre4j/issues/573)). Use **Option B** (system-installed
+> PCRE2) below as the workaround until both issues are fixed.
 
 | Artifact | Platform |
 |----------|----------|


### PR DESCRIPTION
## Summary

Extends the Option A `[!WARNING]` callout in `README.md` so it covers `main-SNAPSHOT` native bundles too, not just the `1.0.0` release. Both Maven Central (release) and Maven Central Snapshots (`main-SNAPSHOT`) currently publish empty `pcre4j-native-*` artifacts that cause `UnsatisfiedLinkError` at runtime.

## What changed

`README.md` lines 111-117 (the `[!WARNING]` callout above the Option A dependency table):

- Lead claim broadened to "published `pcre4j-native-*` artifacts are empty" (no longer scoped to 1.0.0).
- Enumerates **both** affected versions: `1.0.0` release **on Maven Central** (links #556) AND `main-SNAPSHOT` builds **on Maven Central Snapshots** (links #573).
- Locates each version in its respective Sonatype repository so readers don't conflate the two.
- Re-states **Option B** (system-installed PCRE2) as the workaround.
- Drops the speculative "Upgrade to **1.0.1+** once released" wording in favor of an unbounded "until both issues are fixed" — neither fix has shipped yet.

## Acceptance criteria

From #577 Scenario 1 (this PR delivers):

- [x] Covers both `1.0.0 release` AND `main-SNAPSHOT` as affected versions
- [x] Links to both #556 (release fix) and #573 (snapshot fix)
- [x] Recommended workaround (Option B: system-installed PCRE2) is re-stated

Scenario 2 (post-snapshot-fix trim) is **out of scope** for this PR — that belongs in #573's PR after the snapshot fix verifies non-empty.

## Out-of-scope finding (flagged for follow-up)

`ROADMAP.md` lines 11-13 still reference only #556 and the speculative "fixed in 1.0.1" wording. Now that this PR aligns README on both issues, ROADMAP drifts. Recommend a follow-up to mirror this PR's enumeration in ROADMAP. Not fixed here per caller scope (README.md only).

## Test plan

- [ ] CI passes (no code changes — this is docs-only; expected to be quick)
- [ ] Render the diff on GitHub and visually confirm the `[!WARNING]` alert renders correctly
- [ ] Confirm both issue links resolve (#556 and #573)

Refs #577