### PR TITLE
(fix) ci: build natives on matrix before snapshot publish in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -301,6 +301,28 @@ jobs:
         run: |
           LD_LIBRARY_PATH=/opt/pcre2/lib ./build/native-image-test/pcre4j-smoke-test
 
+  # Build platform-specific PCRE2 native libraries on a 5-platform matrix and
+  # upload each built libpcre2-8.{so|dylib|dll} file as a workflow artifact.
+  # The `package` job downloads the 5 artifacts and places each library into
+  # native/<platform>/src/main/resources/META-INF/native/<platform>/ before
+  # running Gradle publish, so every pcre4j-native-<platform>-<version>.jar
+  # staged for Maven Central Snapshots carries its expected
+  # libpcre2-8.{so|dylib|dll}.
+  #
+  # Mirrors the same pattern used in release.yaml. See ADR-0010
+  # (docs/adr/0010-native-bundle-release-procedure.md, Decision 1) and
+  # umbrella issue #556 for the rationale.
+  build-natives:
+    # Keep pcre2-version in lockstep with the `PCRE2_VERSION` env vars in the
+    # `package` and `native-image` jobs. GitHub Actions does not evaluate
+    # workflow- or job-level `env` contexts inside reusable-workflow `with:`
+    # expressions, so the version must be duplicated here as a literal.
+    uses: ./.github/workflows/build-natives.yaml
+    with:
+      pcre2-version: '10.47'
+    permissions:
+      contents: read
+
   package:
     runs-on: ubuntu-24.04
 
@@ -312,6 +334,7 @@ jobs:
     needs:
       - lint
       - compatibility-all
+      - build-natives
 
     env:
       PCRE2_VERSION: '10.47'
@@ -353,8 +376,60 @@ jobs:
         with:
           version: ${{ env.PCRE2_VERSION }}
 
+      # Download the 5 per-platform native libraries produced by the build-natives
+      # matrix. Each artifact name is `native-<platform>` and contains the
+      # platform's libpcre2-8.{so|dylib|dll} at the archive root (per
+      # build-natives.yaml's upload step).
+      - name: Download native library artifacts
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          pattern: native-*
+          path: .tmp/natives
+
+      # Place each downloaded library into the matching Gradle module's resources
+      # so that Gradle's java-library resource processing bundles it into the
+      # corresponding pcre4j-native-<platform>-<version>.jar. The per-platform
+      # native/<platform>/src/main/resources/META-INF/native/<platform>/ directories
+      # already exist (with .gitkeep placeholders); this step populates them.
+      # The platform-to-library mapping mirrors buildSrc/.../pcre4j-native-lib.gradle.kts.
+      - name: Place native libraries into module resources
+        shell: bash
+        run: |
+          set -euo pipefail
+          for platform in linux-x86_64 linux-aarch64 macos-x86_64 macos-aarch64 windows-x86_64; do
+            case "$platform" in
+              linux-*)   lib=libpcre2-8.so ;;
+              macos-*)   lib=libpcre2-8.dylib ;;
+              windows-*) lib=pcre2-8.dll ;;
+              *)
+                echo "::error::Unknown native platform '$platform'"
+                exit 1
+                ;;
+            esac
+            src=".tmp/natives/native-$platform/$lib"
+            dst_dir="native/$platform/src/main/resources/META-INF/native/$platform"
+            if [[ ! -f "$src" ]]; then
+              echo "::error::Expected native library missing for $platform: $src"
+              ls -laR ".tmp/natives/native-$platform" 2>/dev/null || true
+              exit 1
+            fi
+            mkdir -p "$dst_dir"
+            cp "$src" "$dst_dir/$lib"
+            size=$(stat -c '%s' "$dst_dir/$lib")
+            echo "Placed $platform: $dst_dir/$lib ($size bytes)"
+          done
+
       - name: Build artifacts
         run: ./gradlew build jacocoAggregatedTestReport -Dpcre2.library.path=/opt/pcre2/lib
+
+      # Safety net: fail the snapshot publish if any pcre4j-native-* JAR was
+      # staged without the expected PCRE2 shared library (>= 10 KB). Guards
+      # against a recurrence of the main-SNAPSHOT / PR-SNAPSHOT empty-native
+      # regression that reopened #556.
+      - name: Verify native bundles
+        run: >
+          ./gradlew verifyNativeBundles
+          -Ppcre4j.version=${{ github.event_name == 'pull_request' && format('PR-{0}-SNAPSHOT', github.event.pull_request.number) || 'main-SNAPSHOT' }}
 
       - name: Build docs
         run: |


### PR DESCRIPTION
## Summary

Apply the matrix-build pattern PR #571 established in `release.yaml` to `ci.yaml`'s `package` job, closing the **snapshot-path** side of the #556 empty-native regression.

Before this change, `main-SNAPSHOT` and `PR-{N}-SNAPSHOT` native JARs staged to Maven Central Snapshots from `ci.yaml` were **659 B** (MANIFEST.MF + empty `.gitkeep`): `ci.yaml` built PCRE2 once on a single Ubuntu runner and invoked `publishAllPublicationsToStagingDeployRepository` **without** copying the built `libpcre2-8.so` into `native/<platform>/src/main/resources/META-INF/native/<platform>/`.

Direct verification (2026-04-23, from issue body):

```
$ curl -sL https://central.sonatype.com/repository/maven-snapshots/org/pcre4j/pcre4j-native-linux-x86_64/main-SNAPSHOT/pcre4j-native-linux-x86_64-main-20260423.133253-1.jar | wc -c
659
```

## Changes

- Adds a new top-level `build-natives` job that calls the existing reusable workflow `.github/workflows/build-natives.yaml` (already consumed by `release.yaml`), producing per-platform artifacts for `linux-x86_64`, `linux-aarch64`, `macos-x86_64`, `macos-aarch64`, and `windows-x86_64`.
- Makes the `package` job `needs: build-natives` and, after `Build PCRE2`, adds a `Download native library artifacts` step (downloads into `.tmp/natives/`) and a `Place native libraries into module resources` step (identical logic to `release.yaml`).
- Adds a `Verify native bundles` safety net between `Build artifacts` and `Stage snapshot artifacts`. Uses the `verifyNativeBundles` Gradle task from `buildSrc/src/main/kotlin/pcre4j-native-lib.gradle.kts` (registered per platform module), which throws a `GradleException` naming the platform and expected library path if any JAR would ship without its ≥ 10 KB `libpcre2-8` entry. The `-Ppcre4j.version` expression mirrors the existing `Stage snapshot artifacts` expression (`main-SNAPSHOT` on push to main, `PR-{N}-SNAPSHOT` on `pull_request`).

## Scope boundaries

- The **staging inspection** step (`.github/scripts/verify-staged-natives.sh`) is intentionally **not** added here; it is tracked separately as #578 and will land after this PR merges.
- No changes to `native-image` or `compatibility` jobs; their `PCRE2_VERSION` stays at `'10.47'` and must remain in lockstep with the literal passed to `build-natives` (documented in-file).

## Acceptance Criteria — Verification

- **`main-SNAPSHOT` native JARs contain real libraries** — `build-natives` → Download → Place → `./gradlew build` bundles each `libpcre2-8.{so|dylib|dll}` into the corresponding `pcre4j-native-<platform>-main-SNAPSHOT.jar` before `publishAllPublicationsToStagingDeployRepository` runs.
- **`verifyNativeBundles` protects the snapshot path** — Runs before `Stage snapshot artifacts` and `Publish snapshots to Maven Central`; the task's error message (see `pcre4j-native-lib.gradle.kts:108-123`) names the module path, expected entry path (`META-INF/native/<platform>/libpcre2-8.{so|dylib|dll}`), and entry size.
- **PR-SNAPSHOT path also produces real bundles** — `build-natives` runs unconditionally (including for `pull_request` events); the existing `Stage snapshot artifacts` conditional (`head.repo.full_name == github.repository`) continues to gate same-repo PR staging with `format('PR-{0}-SNAPSHOT', github.event.pull_request.number)`.

## Test plan

- [ ] CI `build-natives` job builds PCRE2 on all 5 matrix platforms and uploads `native-<platform>` artifacts.
- [ ] CI `package` job downloads the 5 artifacts, places them into module resources, and `./gradlew build` produces `pcre4j-native-<platform>-*-SNAPSHOT.jar` files each containing the expected `libpcre2-8.{so|dylib|dll}` entry of ≥ 10 KB.
- [ ] CI `package` job's `Verify native bundles` step passes when the Place step succeeded for all 5 platforms.
- [ ] On push to `main`, the `Publish snapshots to Maven Central` step runs only after `Verify native bundles` succeeds. (Post-merge, verifiable via `curl central.sonatype.com/repository/maven-snapshots/org/pcre4j/pcre4j-native-linux-x86_64/main-SNAPSHOT/...`.)

Fixes #573.