### PR TITLE
(fix) ci: refresh build-natives matrix to current-GA runner images

### DIFF
--- a/.github/workflows/build-natives.yaml
+++ b/.github/workflows/build-natives.yaml
@@ -44,13 +44,19 @@ jobs:
           - os: ubuntu-24.04-arm
             platform: linux-aarch64
             lib-name: libpcre2-8.so
-          - os: macos-13
-            platform: macos-x86_64
-            lib-name: libpcre2-8.dylib
-          - os: macos-14
+          - os: macos-15
             platform: macos-aarch64
             lib-name: libpcre2-8.dylib
-          - os: windows-2022
+          # macos-15-intel is the last remaining x86_64 macOS runner.
+          # macos-13 was deprecated 2025-09-22 and fully unsupported
+          # 2025-12-08 (https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/);
+          # macos-14-intel does not exist as a label (actions/runner-images#13164).
+          # macos-15-intel itself retires in Fall 2027 when Apple's x86_64
+          # architecture is removed from GitHub-hosted runners entirely.
+          - os: macos-15-intel
+            platform: macos-x86_64
+            lib-name: libpcre2-8.dylib
+          - os: windows-2025
             platform: windows-x86_64
             lib-name: pcre2-8.dll
 


### PR DESCRIPTION
## Summary

Refreshes `.github/workflows/build-natives.yaml` matrix to current-GA GitHub-hosted runner images. The `macos-13` image is past EOL and causing our CI to queue indefinitely; this PR unblocks all in-flight work (notably #556 remediation batch #573–#579) and proactively bumps the two other older-GA images in one pass to avoid recurrence.

## Matrix changes

| Before | After | Reason |
|---|---|---|
| `macos-13` | `macos-15-intel` | **REQUIRED** — [deprecated 2025-09-22, fully unsupported 2025-12-08](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/). Jobs queue forever during scheduled brownouts. `macos-14-intel` [does not exist as a label](https://github.com/actions/runner-images/issues/13164) — `macos-15-intel` is the only x86_64 macOS runner GitHub still offers, retiring Fall 2027. |
| `macos-14` | `macos-15` | Proactive. `macos-15` is newer GA; `macos-14` will enter deprecation when macOS 16 ships. |
| `windows-2022` | `windows-2025` | Proactive. `windows-2025` is newer GA; `windows-2022` will enter deprecation when the next Windows Server image becomes GA (`windows-2025-vs2026` is already in preview). |

Entries reordered within macOS so base (`macos-15`, aarch64) precedes the `-intel` variant (x86_64) — version-ascending + base-first-then-variants reads cleanly.

`ubuntu-24.04` + `ubuntu-24.04-arm` unchanged — current LTS, newest available labels.

## Context

Three CI retry attempts against #583 today saw the `build-natives (macos-13, ...)` job stuck `queued` for 5+ hours while every other platform dequeued in minutes. The pattern matched GitHub's [documented "scheduled brownout"](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/) behavior for past-EOL runners. Other OSS projects hit the same wall: [LightGBM #7082](https://github.com/microsoft/lightgbm/issues/7082), [Apache Arrow #47923](https://github.com/apache/arrow/issues/47923), [Wazuh #35408](https://github.com/wazuh/wazuh/issues/35408).

## Test plan

- [ ] CI on this PR dequeues and completes the full `build-natives` matrix (all 5 platforms) within standard runner allocation time
- [ ] `libpcre2-8.{dylib,so,dll}` builds succeed on each matrix entry
- [ ] Post-merge: rebase in-flight PRs (#582, #583) onto new main; verify their `build-natives` jobs also succeed

## References

- [GitHub Changelog: macOS 13 runner image is closing down](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)
- [actions/runner-images#13046 — macOS 13 deprecation tracker](https://github.com/actions/runner-images/issues/13046)
- [actions/runner-images#13045 — macOS 15 Intel image announcement](https://github.com/actions/runner-images/issues/13045)
- [actions/runner-images#13164 — macos-14-intel label missing](https://github.com/actions/runner-images/issues/13164)
- [GitHub Changelog: Early February 2026 Actions updates](https://github.blog/changelog/2026-02-05-github-actions-early-february-2026-updates/)

Fixes #584.
