### PR TITLE
(chore) ci: extend pre-deploy staging inspection to ci.yaml package job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -470,6 +470,16 @@ jobs:
           ./gradlew publishAllPublicationsToStagingDeployRepository
           -Ppcre4j.version=${{ github.event_name == 'pull_request' && format('PR-{0}-SNAPSHOT', github.event.pull_request.number) || 'main-SNAPSHOT' }}
 
+      # Pre-deploy staging inspection: walk **/build/staging-deploy/**/*.jar and
+      # fail if any pcre4j-native-* main artifact is empty or missing its
+      # platform library entry. Mirrors release.yaml's `Inspect staged native
+      # bundles` step (added by #564) for the snapshot path. Condition matches
+      # `Stage snapshot artifacts` above so inspection runs whenever staging
+      # produced artifacts to inspect (push/main + same-repo PRs).
+      - name: Inspect staged native bundles
+        if: ${{ (github.event_name == 'push' && github.ref_name == 'main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
+        run: .github/scripts/verify-staged-natives.sh .
+
       - name: Publish snapshots to Maven Central
         if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         env:


### PR DESCRIPTION
## Summary

Adds an `Inspect staged native bundles` step to `ci.yaml`'s `package` job that runs `.github/scripts/verify-staged-natives.sh` between `Stage snapshot artifacts` and `Publish snapshots to Maven Central`. Mirrors the staging inspection added to `release.yaml` by #564 (commit 83a283f) — extends that safety net to the snapshot publish path.

Closes #578.

## Why

#564 introduced staging-time inspection for the release path: catches transforms (and regressions like the 1.0.0 empty-native ship) that happen between `gradle publishAllPublicationsToStagingDeployRepository` and `jreleaserDeploy`. With #573 (build-natives matrix wired into `package`) and #574 (`verifyNativeBundles` wired into the publish task graph) merged, the build-time defense for the snapshot path is in place. This PR closes the symmetry: staging-time inspection now also guards `main-SNAPSHOT` and same-repo `PR-SNAPSHOT` builds.

Two-layer defense after this PR:
- **Build-time** (`Verify native bundles`, ci.yaml:429-432, from #574) — `./gradlew verifyNativeBundles` checks the built artifacts.
- **Staging-time** (this PR) — `.github/scripts/verify-staged-natives.sh` walks `**/build/staging-deploy/**/*.jar` and fails on any empty `pcre4j-native-*` main artifact before `jreleaserDeploy` runs.

## Change

```diff
+ # Pre-deploy staging inspection: walk **/build/staging-deploy/**/*.jar and
+ # fail if any pcre4j-native-* main artifact is empty or missing its
+ # platform library entry. Mirrors release.yaml's `Inspect staged native
+ # bundles` step (added by #564) for the snapshot path. Condition matches
+ # `Stage snapshot artifacts` above so inspection runs whenever staging
+ # produced artifacts to inspect (push/main + same-repo PRs).
+ - name: Inspect staged native bundles
+   if: ${{ (github.event_name == 'push' && github.ref_name == 'main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
+   run: .github/scripts/verify-staged-natives.sh .
```

The `if:` condition mirrors `Stage snapshot artifacts` byte-for-byte so inspection runs exactly when there are staged artifacts to inspect — push to main and same-repo PRs. Forked PRs and other triggers correctly skip both staging and inspection.

## Trigger matrix

| Trigger | `Stage snapshot artifacts` | `Inspect staged native bundles` (new) | `Publish snapshots to Maven Central` |
|---|---|---|---|
| `push` to `main` | runs | runs | runs |
| Same-repo PR | runs | runs | skipped |
| Forked PR | skipped | skipped | skipped |
| Schedule | skipped | skipped | skipped |

## Test plan

- [x] actionlint clean on the new step (no NEW warnings — pre-existing SC2086 on lines 156/255 verified to pre-date origin/main)
- [x] Step name + script invocation byte-identical to `release.yaml:144-145`
- [x] Step positioned AFTER `Stage snapshot artifacts` (line 467) and BEFORE `Publish snapshots to Maven Central` (line 483)
- [x] Conditional matches `Stage snapshot artifacts` byte-for-byte (line 468 vs line 480)
- [x] Script behavior covered by `verify-staged-natives.test.sh` (invoked by `lint` job lines 99-100, runs every PR — already passing on main)
- [ ] CI matrix run on this PR exercises the gate against good staged artifacts and reports PASS

## Related

- #564 — original staging inspection added to `release.yaml` (commit 83a283f)
- #568 — PR that introduced `verify-staged-natives.sh`
- #573 — build-natives matrix wired into `ci.yaml`'s `package` job
- #574 — `verifyNativeBundles` wired into the publish task graph
- #556 — umbrella issue for the empty-native shipping incident