### PR TITLE
(chore) ci: consolidate native artifact placement into shared composite action

### DIFF
--- a/.github/actions/place-native-artifacts/action.yaml
+++ b/.github/actions/place-native-artifacts/action.yaml
@@ -1,0 +1,69 @@
+name: Place native artifacts
+description: >
+  Download the 5 per-platform native library artifacts produced by
+  build-natives.yaml and place each libpcre2-8.{so|dylib|dll} into its
+  matching Gradle module's resources, so that java-library resource
+  processing bundles it into the corresponding
+  pcre4j-native-<platform>-<version>.jar.
+
+  The platform-to-library mapping mirrors
+  buildSrc/src/main/kotlin/pcre4j-native-lib.gradle.kts.
+
+  This action is the single source of truth for the download+place
+  aggregator step shared by release.yaml (tagged release deploy) and
+  ci.yaml's package job (main/PR snapshot stage). See ADR-0010
+  (docs/adr/0010-native-bundle-release-procedure.md) and umbrella
+  issue #556.
+
+inputs:
+  download-path:
+    description: Directory to download per-platform native-* artifacts into
+    required: false
+    default: .tmp/natives
+
+runs:
+  using: composite
+  steps:
+    # Download the 5 per-platform native libraries produced by the build-natives
+    # matrix. Each artifact name is `native-<platform>` and contains the
+    # platform's libpcre2-8.{so|dylib|dll} at the archive root (per
+    # build-natives.yaml's upload step).
+    - name: Download native library artifacts
+      uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      with:
+        pattern: native-*
+        path: ${{ inputs.download-path }}
+
+    # Place each downloaded library into the matching Gradle module's resources
+    # so that Gradle's java-library resource processing bundles it into the
+    # corresponding pcre4j-native-<platform>-<version>.jar. The per-platform
+    # native/<platform>/src/main/resources/META-INF/native/<platform>/ directories
+    # already exist (with .gitkeep placeholders); this step populates them.
+    - name: Place native libraries into module resources
+      shell: bash
+      env:
+        DOWNLOAD_PATH: ${{ inputs.download-path }}
+      run: |
+        set -euo pipefail
+        for platform in linux-x86_64 linux-aarch64 macos-x86_64 macos-aarch64 windows-x86_64; do
+          case "$platform" in
+            linux-*)   lib=libpcre2-8.so ;;
+            macos-*)   lib=libpcre2-8.dylib ;;
+            windows-*) lib=pcre2-8.dll ;;
+            *)
+              echo "::error::Unknown native platform '$platform'"
+              exit 1
+              ;;
+          esac
+          src="$DOWNLOAD_PATH/native-$platform/$lib"
+          dst_dir="native/$platform/src/main/resources/META-INF/native/$platform"
+          if [[ ! -f "$src" ]]; then
+            echo "::error::Expected native library missing for $platform: $src"
+            ls -laR "$DOWNLOAD_PATH/native-$platform" 2>/dev/null || true
+            exit 1
+          fi
+          mkdir -p "$dst_dir"
+          cp "$src" "$dst_dir/$lib"
+          size=$(stat -c '%s' "$dst_dir/$lib")
+          echo "Placed $platform: $dst_dir/$lib ($size bytes)"
+        done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -376,48 +376,12 @@ jobs:
         with:
           version: ${{ env.PCRE2_VERSION }}
 
-      # Download the 5 per-platform native libraries produced by the build-natives
-      # matrix. Each artifact name is `native-<platform>` and contains the
-      # platform's libpcre2-8.{so|dylib|dll} at the archive root (per
-      # build-natives.yaml's upload step).
-      - name: Download native library artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
-        with:
-          pattern: native-*
-          path: .tmp/natives
-
-      # Place each downloaded library into the matching Gradle module's resources
-      # so that Gradle's java-library resource processing bundles it into the
-      # corresponding pcre4j-native-<platform>-<version>.jar. The per-platform
-      # native/<platform>/src/main/resources/META-INF/native/<platform>/ directories
-      # already exist (with .gitkeep placeholders); this step populates them.
-      # The platform-to-library mapping mirrors buildSrc/.../pcre4j-native-lib.gradle.kts.
-      - name: Place native libraries into module resources
-        shell: bash
-        run: |
-          set -euo pipefail
-          for platform in linux-x86_64 linux-aarch64 macos-x86_64 macos-aarch64 windows-x86_64; do
-            case "$platform" in
-              linux-*)   lib=libpcre2-8.so ;;
-              macos-*)   lib=libpcre2-8.dylib ;;
-              windows-*) lib=pcre2-8.dll ;;
-              *)
-                echo "::error::Unknown native platform '$platform'"
-                exit 1
-                ;;
-            esac
-            src=".tmp/natives/native-$platform/$lib"
-            dst_dir="native/$platform/src/main/resources/META-INF/native/$platform"
-            if [[ ! -f "$src" ]]; then
-              echo "::error::Expected native library missing for $platform: $src"
-              ls -laR ".tmp/natives/native-$platform" 2>/dev/null || true
-              exit 1
-            fi
-            mkdir -p "$dst_dir"
-            cp "$src" "$dst_dir/$lib"
-            size=$(stat -c '%s' "$dst_dir/$lib")
-            echo "Placed $platform: $dst_dir/$lib ($size bytes)"
-          done
+      # Download per-platform native library artifacts produced by build-natives
+      # and place each libpcre2-8.{so|dylib|dll} into its matching Gradle
+      # module's resources. See .github/actions/place-native-artifacts for the
+      # single source of truth shared with release.yaml's tagged-release path.
+      - name: Place native artifacts
+        uses: ./.github/actions/place-native-artifacts
 
       - name: Build artifacts
         run: ./gradlew build jacocoAggregatedTestReport -Dpcre2.library.path=/opt/pcre2/lib

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,48 +86,12 @@ jobs:
         with:
           version: ${{ env.PCRE2_VERSION }}
 
-      # Download the 5 per-platform native libraries produced by the build-natives
-      # matrix. Each artifact name is `native-<platform>` and contains the
-      # platform's libpcre2-8.{so|dylib|dll} at the archive root (per
-      # build-natives.yaml's upload step).
-      - name: Download native library artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
-        with:
-          pattern: native-*
-          path: .tmp/natives
-
-      # Place each downloaded library into the matching Gradle module's resources
-      # so that Gradle's java-library resource processing bundles it into the
-      # corresponding pcre4j-native-<platform>-<version>.jar. The per-platform
-      # native/<platform>/src/main/resources/META-INF/native/<platform>/ directories
-      # already exist (with .gitkeep placeholders); this step populates them.
-      # The platform-to-library mapping mirrors buildSrc/.../pcre4j-native-lib.gradle.kts.
-      - name: Place native libraries into module resources
-        shell: bash
-        run: |
-          set -euo pipefail
-          for platform in linux-x86_64 linux-aarch64 macos-x86_64 macos-aarch64 windows-x86_64; do
-            case "$platform" in
-              linux-*)   lib=libpcre2-8.so ;;
-              macos-*)   lib=libpcre2-8.dylib ;;
-              windows-*) lib=pcre2-8.dll ;;
-              *)
-                echo "::error::Unknown native platform '$platform'"
-                exit 1
-                ;;
-            esac
-            src=".tmp/natives/native-$platform/$lib"
-            dst_dir="native/$platform/src/main/resources/META-INF/native/$platform"
-            if [[ ! -f "$src" ]]; then
-              echo "::error::Expected native library missing for $platform: $src"
-              ls -laR ".tmp/natives/native-$platform" 2>/dev/null || true
-              exit 1
-            fi
-            mkdir -p "$dst_dir"
-            cp "$src" "$dst_dir/$lib"
-            size=$(stat -c '%s' "$dst_dir/$lib")
-            echo "Placed $platform: $dst_dir/$lib ($size bytes)"
-          done
+      # Download per-platform native library artifacts produced by build-natives
+      # and place each libpcre2-8.{so|dylib|dll} into its matching Gradle
+      # module's resources. See .github/actions/place-native-artifacts for the
+      # single source of truth shared with ci.yaml's snapshot path.
+      - name: Place native artifacts
+        uses: ./.github/actions/place-native-artifacts
 
       - name: Build artifacts
         run: ./gradlew build jacocoAggregatedTestReport -Dpcre2.library.path=/opt/pcre2/lib


### PR DESCRIPTION
## Summary

- Extract the duplicated "Download native library artifacts" + "Place native libraries into module resources" aggregator step from `release.yaml` and `ci.yaml` into a single composite action at `.github/actions/place-native-artifacts/action.yaml`.
- Both callers reduce to a 2-line `uses: ./.github/actions/place-native-artifacts` reference with a 4-line cross-reference comment. Net: -84 lines across callers, +70 lines in the new action — the logic now lives in ONE place instead of two.
- Matches the in-tree precedent set by `.github/actions/build-pcre2`, which is invoked the same way by both callers.

## Motivation

The #556 regression was caused by *exactly* this anti-pattern: the same step lived in two places and silently drifted when only one was fixed. Even with #571 fixing `release.yaml`, the snapshot path in `ci.yaml` (addressed later by #573) stayed broken because the two copies were maintained independently. A future publish path (nightly, preview, re-release) would have had to carry a third copy — this PR prevents that class of drift architecturally.

## What's inside the new action

- `actions/download-artifact@v6.0.0` (same SHA-pinned version as before) with `pattern: native-*` and a configurable `download-path` input (default `.tmp/natives`)
- The existing 5-platform loop (`linux-x86_64`, `linux-aarch64`, `macos-x86_64`, `macos-aarch64`, `windows-x86_64`) with the same library-name case mapping that mirrors `buildSrc/src/main/kotlin/pcre4j-native-lib.gradle.kts`
- `env:` injection for the `download-path` input (prevents shell injection surface that a parametric input would otherwise expose)
- Internal step names preserved so CI logs retain the same observability of "Download" vs "Place" operations

## What stays unchanged

- Matrix build remains in `.github/workflows/build-natives.yaml` (`workflow_call`), invoked identically by both workflows — not touched
- `verifyNativeBundles` (#574) and `.github/scripts/verify-staged-natives.sh` (#578) remain separate Gradle/shell steps in each caller, not coupled to this action — any future publish path can invoke them explicitly
- Step ordering in both callers: `Checkout → … → Build PCRE2 → Place native artifacts → Build artifacts → Verify native bundles → Stage → Inspect → Deploy` (unchanged)

## Acceptance criteria

- [x] Shared composite action exists at `.github/actions/place-native-artifacts/action.yaml`
- [x] `release.yaml` delegates matrix build (via `build-natives.yaml`) AND resource population (via the new action); no duplicate matrix, no duplicate placement logic
- [x] `ci.yaml` package job delegates both the same way; logic is not duplicated between the two callers
- [x] A hypothetical future publish path can inherit both via two `uses:` blocks and wire `verifyNativeBundles` + staging inspection independently

## Test plan

- [x] YAML parse validation on all 3 files (action.yaml, release.yaml, ci.yaml)
- [x] Semantic-equivalence review: byte-for-byte identical shell logic to the original (only `.tmp/natives` literal replaced by `$DOWNLOAD_PATH` env var)
- [x] Rescan for stale references to removed step names — no hits in docs, ADRs, or other workflows
- [ ] CI pass on this PR (exercises the new action via `ci.yaml`'s `package` job against real artifacts from `build-natives`)

## Related

- Prerequisite (merged): #571, #573, #574, #578
- Umbrella: #556 — this PR is the architectural prevention of the #556 recurrence class
- Reference pattern: `.github/actions/build-pcre2` (existing in-tree composite action)

Closes #579.