### PR TITLE
(chore) ci: add workflow_dispatch dry-run to release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,24 @@
 name: Release
 
+# Two entry points:
+#   1. tag push matching `[0-9]+.[0-9]+.[0-9]+` — full release: builds, stages,
+#      and deploys artifacts to Maven Central via JReleaser.
+#   2. `workflow_dispatch` — dry run: exercises the full matrix build + native
+#      placement + verifyNativeBundles + publishAllPublicationsToStagingDeployRepository
+#      pipeline but SKIPS the Maven Central deploy step. Use this to validate
+#      the release pipeline produces non-empty native JARs before cutting a real
+#      version. See #575.
 on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version for the dry-run build (passed to Gradle as -Ppcre4j.version). Maven Central deploy is skipped regardless of this value.'
+        required: false
+        default: '0.0.0-dryrun'
+        type: string
 
 concurrency:
   group: release-${{ github.ref }}
@@ -19,6 +34,10 @@ env:
   # workflow-level `env` context inside reusable-workflow `with:` expressions,
   # so the two sites must be kept in lockstep by hand on any PCRE2 bump.
   PCRE2_VERSION: '10.47'
+  # Version string passed to Gradle as `-Ppcre4j.version`. On tag push this is
+  # the tag (e.g., `1.0.0`); on workflow_dispatch this is the dispatch input
+  # (default `0.0.0-dryrun`).
+  RELEASE_VERSION: ${{ inputs.version || github.ref_name }}
 
 jobs:
   # Build platform-specific PCRE2 native libraries on a 5-platform matrix and
@@ -100,15 +119,23 @@ jobs:
       # the expected PCRE2 shared library (>= 10 KB). Guards against a recurrence
       # of the 1.0.0 empty-native regression. See #557.
       - name: Verify native bundles
-        run: ./gradlew verifyNativeBundles -Ppcre4j.version=${{ github.ref_name }}
+        run: ./gradlew verifyNativeBundles -Ppcre4j.version=${{ env.RELEASE_VERSION }}
 
       - name: Stage artifacts
-        run: ./gradlew publishAllPublicationsToStagingDeployRepository -Ppcre4j.version=${{ github.ref_name }}
+        run: ./gradlew publishAllPublicationsToStagingDeployRepository -Ppcre4j.version=${{ env.RELEASE_VERSION }}
 
       - name: Inspect staged native bundles
         run: .github/scripts/verify-staged-natives.sh .
 
+      # Deploy to Maven Central ONLY on real tag-push releases. The compound
+      # guard is deliberate belt-and-suspenders: the `push` trigger above is
+      # already restricted to tag refs matching `[0-9]+.[0-9]+.[0-9]+`, but
+      # checking `github.event_name == 'push' && github.ref_type == 'tag'`
+      # structurally excludes any future `workflow_dispatch`, `pull_request`,
+      # or other triggers from ever reaching the irreversible
+      # publish-to-Maven-Central path. See #575 for the dry-run rationale.
       - name: Release to Maven Central
+        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
@@ -116,4 +143,4 @@ jobs:
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-        run: ./gradlew jreleaserDeploy --no-configuration-cache -Ppcre4j.version=${{ github.ref_name }}
+        run: ./gradlew jreleaserDeploy --no-configuration-cache -Ppcre4j.version=${{ env.RELEASE_VERSION }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,8 @@ gh release create <version> --title <version> --generate-notes
 
 **Note**: `skipRelease: true` in jreleaser.yml exists because the GitHub Release is already created by `gh release create` before JReleaser runs.
 
+**Dry run**: `release.yaml` also accepts a `workflow_dispatch` trigger (Actions UI → "Run workflow") that exercises the full matrix build + stage + verify pipeline but skips the Maven Central deploy step. Use this to validate the release pipeline produces non-empty native JARs without committing to a public release. The `Release to Maven Central` step is guarded by `if: github.event_name == 'push' && github.ref_type == 'tag'`, so only real tag pushes deploy.
+
 ## Snapshot Publishing
 
 Snapshots are published to Maven Central Snapshots repository (not GitHub Packages).


### PR DESCRIPTION
## Summary

Adds a manual `workflow_dispatch` trigger to `release.yaml` that exercises the full matrix build + native placement + `verifyNativeBundles` + staging pipeline but **skips** the Maven Central deploy step. Implements Option C from #575 — lowest risk, zero Maven Central side effects, no tag namespace pollution.

This validates the #571 native-matrix release pipeline end-to-end before cutting a real 1.0.1.

## Changes

- **`workflow_dispatch` trigger** with an optional `version` input (default `0.0.0-dryrun`).
- **Job-level `env.RELEASE_VERSION`** = `inputs.version || github.ref_name` as the single source of version truth. Applies to both entry points.
- **Three `-Ppcre4j.version=` sites** (`verifyNativeBundles`, `publishAllPublicationsToStagingDeployRepository`, `jreleaserDeploy`) switched from `github.ref_name` to `env.RELEASE_VERSION`.
- **Deploy-step guard**: `if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}` on the `Release to Maven Central` step. Compound guard is belt-and-suspenders: the `push` trigger is already restricted to tag refs matching `[0-9]+.[0-9]+.[0-9]+`, but checking both clauses structurally excludes any future trigger (workflow_dispatch, pull_request, etc.) from ever reaching the irreversible publish-to-Maven-Central path.
- **CLAUDE.md**: brief "Dry run" note under § Release Process.

## Tag-push semantics preserved

For tag-push events, `inputs.version` is empty, so `RELEASE_VERSION` falls back to `github.ref_name` (the tag). Every Gradle invocation receives the same `-Ppcre4j.version=<tag>` value as before. The guard evaluates true, so the deploy step runs as before. Zero regression.

## How to use

After merge, trigger from the Actions UI:
1. Actions → Release → "Run workflow"
2. Accept default `version: 0.0.0-dryrun` (or supply a custom label).
3. Watch all 5 matrix builds, verify `Verify native bundles` and `Inspect staged native bundles` steps succeed, confirm `Release to Maven Central` appears as **skipped**.

No Maven Central interaction. No git tag. No GitHub Release.

## Test plan

- [ ] `actionlint .github/workflows/release.yaml` → exit 0 (pre-push: confirmed exit 0 locally).
- [ ] CI on this PR passes (only runs `ci.yaml`; `release.yaml` changes are verified statically).
- [ ] Post-merge: manually trigger `Release` workflow via Actions UI and confirm:
  - All 5 matrix native builds complete.
  - `verifyNativeBundles` succeeds across all 5 platform modules.
  - `Inspect staged native bundles` logs JAR sizes >= 10 KB each.
  - `Release to Maven Central` step shows **skipped** (grey dash in UI).
  - No Maven Central version appears; no GitHub Release is created.

## Related

Closes #575. Validates the release-path fixes from #571 / #573 / #574 / #578 / #584 end-to-end before a real 1.0.1.