### PR TITLE
(chore) docs: prepare CHANGELOG for 1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-04-24
+
 ### Fixed
 
-- dist: populate `pcre4j-native-*` JARs with the PCRE2 shared library at release time ([#556](https://github.com/alexey-pelykh/pcre4j/issues/556))
+- dist: populate `pcre4j-native-*` JARs with the PCRE2 shared library on both release and snapshot publish paths ([#556](https://github.com/alexey-pelykh/pcre4j/issues/556), [#573](https://github.com/alexey-pelykh/pcre4j/issues/573))
+- ci: refresh build-natives matrix to current-GA runner images (`macos-13` EOL → `macos-15-intel`, `macos-14` → `macos-15`, `windows-2022` → `windows-2025`) ([#584](https://github.com/alexey-pelykh/pcre4j/issues/584))
 
 ## [1.0.0] - 2026-02-16
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ if (matcher.find()) {
 
 ```xml
 <properties>
-    <pcre4j.version>1.0.0</pcre4j.version>
+    <pcre4j.version>1.0.1</pcre4j.version>
 </properties>
 
 <dependencies>
@@ -86,7 +86,7 @@ if (matcher.find()) {
 **Gradle** (`build.gradle.kts`):
 
 ```kotlin
-val pcre4jVersion = "1.0.0"
+val pcre4jVersion = "1.0.1"
 
 dependencies {
     implementation("org.pcre4j:regex:$pcre4jVersion")
@@ -109,12 +109,10 @@ can set the `pcre2.regex.jit` system property with the value `false` to the JVM.
 Add a platform-specific bundle to your dependencies and PCRE4J loads the library automatically:
 
 > [!WARNING]
-> **Known issue:** The published `pcre4j-native-*` artifacts are empty and will cause
-> `UnsatisfiedLinkError` at runtime. This affects both the **1.0.0** release on Maven Central
-> (see [#556](https://github.com/alexey-pelykh/pcre4j/issues/556)) and the **`main-SNAPSHOT`**
-> builds on Maven Central Snapshots (see
-> [#573](https://github.com/alexey-pelykh/pcre4j/issues/573)). Use **Option B** (system-installed
-> PCRE2) below as the workaround until both issues are fixed.
+> **Known issue in 1.0.0**: The `pcre4j-native-*:1.0.0` artifacts on Maven Central were
+> published empty and cause `UnsatisfiedLinkError` at runtime (see
+> [#556](https://github.com/alexey-pelykh/pcre4j/issues/556)). **Fixed in 1.0.1+** — use
+> `1.0.1` or later, or fall back to Option B (system-installed PCRE2) if you must pin 1.0.0.
 
 | Artifact | Platform |
 |----------|----------|
@@ -125,7 +123,7 @@ Add a platform-specific bundle to your dependencies and PCRE4J loads the library
 | `org.pcre4j:pcre4j-native-windows-x86_64` | Windows x86_64 |
 | `org.pcre4j:pcre4j-native-all` | All supported platforms |
 
-Example (Gradle): `implementation("org.pcre4j:pcre4j-native-linux-x86_64:1.0.0")`
+Example (Gradle): `implementation("org.pcre4j:pcre4j-native-linux-x86_64:1.0.1")`
 
 ### Option B: System-Installed PCRE2
 
@@ -215,14 +213,14 @@ Add `lib` and a backend to your dependencies:
     <dependency>
         <groupId>org.pcre4j</groupId>
         <artifactId>lib</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </dependency>
     <dependency>
         <groupId>org.pcre4j</groupId>
         <!-- TODO: Select one of the following artifacts corresponding to the backend you want to use -->
         <artifactId>jna</artifactId>
         <!-- <artifactId>ffm</artifactId> -->
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </dependency>
 </dependencies>
 ```
@@ -231,10 +229,10 @@ Add `lib` and a backend to your dependencies:
 
 ```kotlin
 dependencies {
-    implementation("org.pcre4j:lib:1.0.0")
+    implementation("org.pcre4j:lib:1.0.1")
     // TODO: Select one of the following artifacts corresponding to the backend you want to use
-    implementation("org.pcre4j:jna:1.0.0")
-    // implementation("org.pcre4j:ffm:1.0.0")
+    implementation("org.pcre4j:jna:1.0.1")
+    // implementation("org.pcre4j:ffm:1.0.1")
 }
 ```
 
@@ -287,7 +285,7 @@ Add a backend artifact directly:
         <!-- TODO: Select one of the following artifacts corresponding to the backend you want to use -->
         <artifactId>jna</artifactId>
         <!-- <artifactId>ffm</artifactId> -->
-        <version>1.0.0</version>
+        <version>1.0.1</version>
     </dependency>
 </dependencies>
 ```
@@ -297,8 +295,8 @@ Add a backend artifact directly:
 ```kotlin
 dependencies {
     // TODO: Select one of the following artifacts corresponding to the backend you want to use
-    implementation("org.pcre4j:jna:1.0.0")
-    // implementation("org.pcre4j:ffm:1.0.0")
+    implementation("org.pcre4j:jna:1.0.1")
+    // implementation("org.pcre4j:ffm:1.0.1")
 }
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,9 +9,8 @@ PCRE4J **v1.0** is the first stable release, with an API stability commitment.
 - **Two backends**: JNA and FFM (Foreign Function & Memory API)
 - **100% PCRE2 API coverage** across both backends
 - **Platform-specific native library bundles** for Linux, macOS, and Windows
-  (**WARNING:** non-functional in 1.0.0 release and main-SNAPSHOT; release fix in 1.0.1,
-  snapshot fix tracked in [#573](https://github.com/alexey-pelykh/pcre4j/issues/573) —
-  see umbrella [#556](https://github.com/alexey-pelykh/pcre4j/issues/556))
+  (non-functional in 1.0.0 — fixed in 1.0.1; see
+  [#556](https://github.com/alexey-pelykh/pcre4j/issues/556))
 - **GraalVM native-image** support
 - **ServiceLoader-based backend discovery** for zero-configuration setup
 - **High-level API coverage**: pattern serialization, DFA matching, callout support, glob/POSIX


### PR DESCRIPTION
## Summary

Release-prep for **1.0.1** tag. Covers three areas:

1. **CHANGELOG**: move `[Unreleased]` entry into `[1.0.1] - 2026-04-24`, extend to cover both release and snapshot publish paths (#573), and add the runner refresh (#584).
2. **README**: rewrite Option A WARNING — the snapshot path is now fixed, so the warning is scoped to 1.0.0 only. Bump all install-snippet version references from `1.0.0` → `1.0.1` (historical "What's New in 1.0.0" section preserved).
3. **ROADMAP**: simplify native-bundles annotation now that both paths are fixed in 1.0.1.

All other merged PRs since 1.0.0 are `(chore)` or `(docs)` and are omitted from CHANGELOG per the CLAUDE.md § Release Notes Style convention.

## Post-merge

After this merges, the 1.0.1 release tag is cut via:

```bash
gh release create 1.0.1 --title 1.0.1 --generate-notes
```

The tag push triggers `.github/workflows/release.yaml` → Maven Central publish via JReleaser.

**Pre-release verification** (2026-04-24 11:53 UTC snapshot, post all fixes on main):
- `pcre4j-native-linux-x86_64:main-SNAPSHOT` = 285 KB (contains `libpcre2-8.so`)
- `pcre4j-native-linux-aarch64:main-SNAPSHOT` = 263 KB
- `pcre4j-native-macos-x86_64:main-SNAPSHOT` = 269 KB
- `pcre4j-native-macos-aarch64:main-SNAPSHOT` = 284 KB
- `pcre4j-native-windows-x86_64:main-SNAPSHOT` = 238 KB

The 1.0.1 release will use the same (now-verified) code path.

## Test plan

- [x] CHANGELOG renders correctly
- [x] README WARNING scoped to 1.0.0 (the immutable broken release), not misleading about current state
- [x] README install-snippet versions bump to 1.0.1
- [x] ROADMAP annotation softened
- [ ] After merge: `gh release create 1.0.1 --title 1.0.1 --generate-notes` cuts tag
- [ ] release.yaml completes successfully on matrix build
- [ ] Maven Central 1.0.1 native JARs contain real libraries (>= 200 KB each)

## References

- #556 umbrella (now ready to re-close once 1.0.1 ships)
- #573 snapshot fix (already verified on main-SNAPSHOT)
- #584 matrix refresh (macos-13 EOL)
