### PR TITLE
(fix) ci: correct Maven Central host + artifact names in post-deploy smoke test

### DIFF
--- a/.github/post-deploy-smoke/pom.xml.template
+++ b/.github/post-deploy-smoke/pom.xml.template
@@ -7,7 +7,7 @@
     @PLATFORM@  - the runner-mapped native platform (linux-x86_64,
                   macos-aarch64, windows-x86_64)
 
-  All three pcre4j-* dependencies are resolved from Maven Central; nothing
+  All three org.pcre4j dependencies are resolved from Maven Central; nothing
   from the local build is consumed. Maven Central is declared explicitly so
   the smoke test does not depend on the runner's ~/.m2/settings.xml content.
 -->
@@ -32,7 +32,7 @@
         <repository>
             <id>central</id>
             <name>Maven Central</name>
-            <url>https://repo1.maven.apache.org/maven2/</url>
+            <url>https://repo1.maven.org/maven2/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -45,12 +45,12 @@
     <dependencies>
         <dependency>
             <groupId>org.pcre4j</groupId>
-            <artifactId>pcre4j-jna</artifactId>
+            <artifactId>jna</artifactId>
             <version>@VERSION@</version>
         </dependency>
         <dependency>
             <groupId>org.pcre4j</groupId>
-            <artifactId>pcre4j-regex</artifactId>
+            <artifactId>regex</artifactId>
             <version>@VERSION@</version>
         </dependency>
         <dependency>

--- a/.github/workflows/post-deploy-smoke.yaml
+++ b/.github/workflows/post-deploy-smoke.yaml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Wait for Maven Central propagation
         # JReleaser deploy succeeds before the artifacts are reachable on
-        # repo1.maven.apache.org (Sonatype/CDN sync delay). Sonatype Central +
+        # repo1.maven.org (Sonatype/CDN sync delay). Sonatype Central +
         # the CDN do not guarantee same-instant visibility across all artifacts
         # in a deploy batch, so poll all three the consumer needs (jna, regex,
         # native bundle) and proceed only when ALL are visible. 30-minute cap.
@@ -119,8 +119,8 @@ jobs:
         run: |
           set -euo pipefail
           artifacts=(
-            "pcre4j-jna"
-            "pcre4j-regex"
+            "jna"
+            "regex"
             "pcre4j-native-${NATIVE_PLATFORM}"
           )
           deadline=$(( $(date +%s) + 1800 ))
@@ -129,7 +129,7 @@ jobs:
             attempt=$((attempt + 1))
             missing=""
             for artifact in "${artifacts[@]}"; do
-              url="https://repo1.maven.apache.org/maven2/org/pcre4j/${artifact}/${PCRE4J_VERSION}/${artifact}-${PCRE4J_VERSION}.jar"
+              url="https://repo1.maven.org/maven2/org/pcre4j/${artifact}/${PCRE4J_VERSION}/${artifact}-${PCRE4J_VERSION}.jar"
               if ! curl -fsSI "$url" -o /dev/null; then
                 missing="$artifact"
                 break


### PR DESCRIPTION
## Summary

Fixes the post-deploy smoke test (`.github/workflows/post-deploy-smoke.yaml` + `.github/post-deploy-smoke/pom.xml.template`) introduced in PR #572. All three matrix jobs failed for release 1.0.1 due to two compounding defects in the same workflow, both introduced together and masking each other:

1. **Hostname typo**: `repo1.maven.apache.org` (combines Sonatype's `1` with Apache's `.apache.org`) — NXDOMAIN, does not exist. Valid hosts are `repo1.maven.org` (Sonatype canonical) or `repo.maven.apache.org` (Apache alias, no digit).
2. **Wrong artifact IDs**: `pcre4j-jna`, `pcre4j-regex` — HTTP 404 on Maven Central. Actual coordinates are `org.pcre4j:jna` and `org.pcre4j:regex` (no `pcre4j-` prefix — that prefix is carried only by the native bundles `pcre4j-native-*`). `settings.gradle.kts` and `README.md` already use the correct forms.

Fixing only (1) would leave the smoke test failing at `missing: pcre4j-jna` instead of DNS timeout — so both fixes ship together.

## Root cause (why PR #572's validation missed this)

The failing run is the first real exercise of the workflow. PR #572's in-PR validation (`actionlint` + local `javac` against locally-built jars) did not exercise DNS resolution or Maven Central artifact resolution. The workflow itself was the test, and the 1.0.1 release was the first production run.

## Verification

Direct curl against real 1.0.1 artifacts using the corrected URLs (all HTTP 200):

| URL | Status |
|---|---|
| `https://repo1.maven.org/maven2/org/pcre4j/jna/1.0.1/jna-1.0.1.jar` | 200 |
| `https://repo1.maven.org/maven2/org/pcre4j/regex/1.0.1/regex-1.0.1.jar` | 200 |
| `https://repo1.maven.org/maven2/org/pcre4j/pcre4j-native-linux-x86_64/1.0.1/pcre4j-native-linux-x86_64-1.0.1.jar` | 200 |

Confirming the diagnosis: `host repo1.maven.apache.org` → NXDOMAIN (old); `host repo1.maven.org` → resolves (new).

`actionlint .github/workflows/post-deploy-smoke.yaml` → exit 0.

## Post-merge verification plan

After merge, trigger Post-Deploy Smoke via `workflow_dispatch` against version `1.0.1` (the manual input form is the existing escape hatch for off-cycle smoke-testing — see `post-deploy-smoke.yaml:14-20`). Expected: all 3 matrix jobs green. That confirms the end-to-end path against Maven Central is now correct.

## Out of scope (deferred)

A related defect in `lib/src/main/java/org/pcre4j/Pcre4j.java:43,217` — the backend-discovery `IllegalStateException` message and Javadoc reference the same non-existent `pcre4j-jna` / `pcre4j-ffm` coordinates, misleading library consumers who follow the guidance. Same defect class but library-user-facing (vs CI-only here), so tracked separately as #591.

Fixes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)
