### PR TITLE
(fix) lib: use resolvable Maven coordinates in backend-discovery error + Javadoc

### DIFF
--- a/lib/src/main/java/org/pcre4j/Pcre4j.java
+++ b/lib/src/main/java/org/pcre4j/Pcre4j.java
@@ -40,7 +40,7 @@ import java.util.ServiceLoader;
  *
  * <ol>
  *   <li><strong>Automatic discovery (recommended)</strong> — simply add a backend artifact
- *       ({@code pcre4j-jna} or {@code pcre4j-ffm}) to your classpath. The first call to
+ *       ({@code org.pcre4j:jna} or {@code org.pcre4j:ffm}) to your classpath. The first call to
  *       {@link #api()} will use {@link ServiceLoader} to discover and initialize a backend
  *       automatically.</li>
  *   <li><strong>Explicit setup</strong> — call {@link #setup(IPcre2)} with a backend instance
@@ -214,7 +214,7 @@ public final class Pcre4j {
                 api = discoverBackend();
                 if (api == null) {
                     throw new IllegalStateException(
-                            "No PCRE2 backend found. Add pcre4j-jna or pcre4j-ffm to your classpath, "
+                            "No PCRE2 backend found. Add org.pcre4j:jna or org.pcre4j:ffm to your classpath, "
                                     + "or call Pcre4j.setup() explicitly."
                     );
                 }


### PR DESCRIPTION
## Summary

Replaces the non-existent Maven coordinates `pcre4j-jna` / `pcre4j-ffm` with the actual published coordinates `org.pcre4j:jna` / `org.pcre4j:ffm` in two consumer-facing surfaces of the `lib` module:

- `Pcre4j.java:43` — Javadoc "Initialization" section (`{@code pcre4j-jna}` → `{@code org.pcre4j:jna}`)
- `Pcre4j.java:217` — `IllegalStateException` message thrown when no backend is auto-discovered

A consumer who followed the error-message guidance verbatim (e.g., `org.pcre4j:pcre4j-jna:1.0.1`) got HTTP 404 from Maven Central. The actual published backends under the `org.pcre4j` group are `jna` and `ffm` (no `pcre4j-` prefix — that prefix only appears on the native bundles `pcre4j-native-*`).

The README.md dependency examples (lines 92/94/95) already use the `org.pcre4j:<module>` form; this change brings `Pcre4j.java` into alignment.

## Test plan

- [x] `./gradlew lib:checkstyleMain -Dpcre2.library.path=/opt/homebrew/lib` — BUILD SUCCESSFUL
- [x] `./gradlew lib:test -Dpcre2.library.path=/opt/homebrew/lib` — BUILD SUCCESSFUL, no regressions
- [x] Maven Central resolution verified:
  - `curl -fsSI https://repo1.maven.org/maven2/org/pcre4j/jna/1.0.1/jna-1.0.1.jar` → HTTP/2 200
  - `curl -fsSI https://repo1.maven.org/maven2/org/pcre4j/ffm/1.0.1/ffm-1.0.1.jar` → HTTP/2 200
- [x] No existing test asserts the old error-message text (grep-verified) — no test update needed
- [x] Rescanned codebase for other `pcre4j-jna` / `pcre4j-ffm` references; out-of-scope findings noted below

## Scope

Pure-text fix with no behavioral change. Pre-existing behavior of `Pcre4j.api()` / `discoverBackend()` is unchanged.

### Out of scope (tracked separately if desired)

The rescan surfaced two additional `pcre4j-jna` / `pcre4j-ffm` sites that are different defect classes and explicitly out of scope per the issue framing:

- `benchmark/src/jmh/java/org/pcre4j/benchmark/BenchmarkBase.java` — JMH `@Param` values and case labels (`pcre4j-jna`, `pcre4j-ffm`, `-jit` variants). These are internal benchmark engine identifiers used as command-line parameters, not Maven coordinates. Changing them would break existing benchmark invocations.
- `docs/adr/0004-multi-release-jar-for-ffm.md:47` — ADR referencing `pcre4j-ffm` as the FFM artifact name. Historical architectural record, different review axis from user-facing error guidance.

Issue #591 explicitly scoped the fix to `Pcre4j.java` ("library user-facing, different review axis, different module"). The workflow/template instances were addressed in PR #592 (#590).

Fixes #591