### PR TITLE
(fix) ci: repair dependabot-automerge action SHA

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444e3745145 # v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- The pinned SHA for `dependabot/fetch-metadata` in `.github/workflows/dependabot-automerge.yaml` was corrupted: `d7267f607e9d3fb96fc2fbe83e0af444e3745145`. The first 32 hex characters match the real v2.3.0 SHA (`d7267f607e9d3fb96fc2fbe83e0af444713e90b7`) but the last 8 characters differ, so GitHub cannot resolve the action.
- Every Dependabot PR has therefore been failing the `automerge` workflow with `Unable to resolve action dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444e3745145, unable to find version`, blocking the auto-merge path for all dependency bumps. Since the `automerge` check is not in the branch-protection required set, CI-green Dependabot PRs have been silently piling up (see #554, #553, #552, #550, #545).
- Repin to `v2.5.0` (`21025c705c08248db411dc16f3619e6b5f9ea21a`), the latest release of `dependabot/fetch-metadata`.

## Test plan

- [ ] PR CI passes (`dco`, `lint`, `analyze`, `compatibility-all`, `package`).
- [ ] After merge, re-run the `automerge` workflow on one of the existing green Dependabot PRs (or let the next Dependabot PR trigger it) and confirm it resolves the action successfully.