### PR TITLE
(fix) ci: auto-detect Visual Studio generator for Windows PCRE2 build

### DIFF
--- a/.github/actions/build-pcre2/action.yaml
+++ b/.github/actions/build-pcre2/action.yaml
@@ -71,7 +71,7 @@ runs:
       run: |
         cd pcre2-${{ inputs.version }}
         mkdir build && cd build
-        cmake .. -G "Visual Studio 17 2022" -A x64 \
+        cmake .. -A x64 \
           -DCMAKE_INSTALL_PREFIX=/opt/pcre2 \
           -DPCRE2_SUPPORT_JIT=ON \
           -DPCRE2_BUILD_PCRE2_16=ON \


### PR DESCRIPTION
## Problem

The `build-natives` Windows job fails whenever the PCRE2 source cache misses:

```
CMake Error at CMakeLists.txt:121 (project):
  Generator  Visual Studio 17 2022  could not find any instance of Visual Studio.
```

The `build-pcre2` composite action hardcodes the `Visual Studio 17 2022` generator, but the `windows-2025` runner image now ships **Visual Studio 2026**. The failure was latent for weeks: the PCRE2 cache had been populated on the old `windows-2022` image and kept being restored across the image change, because the cache key (`pcre2-<version>-<os>-<arch>`) does not capture the runner image / VS version. It surfaced once that cache evicted and the from-source build actually ran on `windows-2025`.

## Fix

Drop the pinned `-G "Visual Studio 17 2022"` and let CMake auto-detect the newest installed Visual Studio generator (keeping `-A x64`). This is robust across future runner-image / VS bumps.

## Validation

Not reproducible locally (non-Windows host); the `build-native (windows-2025, …)` job on this PR is the validation. Note this is **not** a CMake-4 policy issue — PCRE2 10.47's `cmake_minimum_required` is 3.15.

## Optional follow-up

Consider adding the runner image (or VS major version) to the PCRE2 cache key, so a toolchain change can't be masked by a stale cross-image cache again.