### PR TITLE
(chore) ci: Bump actions/download-artifact from 6.0.0 to 8.0.1

### DIFF
--- a/.github/actions/place-native-artifacts/action.yaml
+++ b/.github/actions/place-native-artifacts/action.yaml
@@ -29,7 +29,7 @@ runs:
     # platform's libpcre2-8.{so|dylib|dll} at the archive root (per
     # build-natives.yaml's upload step).
     - name: Download native library artifacts
-      uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         pattern: native-*
         path: ${{ inputs.download-path }}


### PR DESCRIPTION
v6.0.0 (`018cc2cf`) runs on Node.js 20 — GitHub forces Node 24 on hosted runners starting **June 16, 2026**, and the deprecation warning already shows in `package` job runs. No dependabot PR exists for this bump, so pinning manually.

- v7.0.0: Node 24 runtime (requires runner ≥ 2.327.1 — satisfied by GitHub-hosted runners)
- v8.0.0: ESM migration (transparent), `digest-mismatch` defaults to `error` (desirable for our same-run artifacts), content-type-aware unzip (no effect on `pattern:` + `path:` usage in `place-native-artifacts`)
- v8.0.1 (`3e5f45b2`): CJK artifact-name support

Verified against release notes; the `pattern: native-*` per-artifact subdirectory layout the placement script depends on is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)